### PR TITLE
Draft: Add support for different scopes to `createDependencyMethods()`, `createDocumentDependencyMethods()` and `DependencyList`

### DIFF
--- a/.changeset/chatty-planets-exercise.md
+++ b/.changeset/chatty-planets-exercise.md
@@ -1,0 +1,13 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add support for different scopes to `createDependencyMethods()`, `createDocumentDependencyMethods()` and `DependencyList`
+
+You can now pass a `scopeFragment` to `createDependencyMethods()` and `createDocumentDependencyMethods()` to load the dependency's scope.
+The loaded scope is then passed to `basePath` where you must attach it to the URL.
+
+The `DependencyList` now checks if the scope is already in the URL and only prepends the current scope if needed.
+
+This is helpful when the DAM is not or only partially scoped.
+Otherwise, users might encounter 404 errors when dependencies are in a different scope than currently selected.

--- a/demo/admin/src/links/Link.tsx
+++ b/demo/admin/src/links/Link.tsx
@@ -4,6 +4,7 @@ import { createDocumentDependencyMethods, createDocumentRootBlocksMethods, Depen
 import { PageTreePage } from "@comet/cms-admin/lib/pages/pageTree/usePageTree";
 import { Chip } from "@mui/material";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
+import { ContentScope } from "@src/common/ContentScopeProvider";
 import { GQLPageTreeNodeAdditionalFieldsFragment } from "@src/common/EditPageNode";
 import { GQLLink, GQLLinkInput } from "@src/graphql.generated";
 import { EditLink } from "@src/links/EditLink";
@@ -59,6 +60,17 @@ export const Link: DocumentInterface<Pick<GQLLink, "content">, GQLLinkInput> & D
     ...createDocumentDependencyMethods({
         rootQueryName: "link",
         rootBlocks,
-        basePath: ({ pageTreeNode }) => `/pages/pagetree/${categoryToUrlParam(pageTreeNode.category)}/${pageTreeNode.id}/edit`,
+        scopeFragment: gql`
+            fragment PageDependencyScope on PageTreeNodeScope {
+                domain
+                language
+            }
+        `,
+        basePath: ({ pageTreeNode, scope }) => {
+            const contentScope = scope as ContentScope;
+            return `/${contentScope.domain}/${contentScope.language}/pages/pagetree/${categoryToUrlParam(pageTreeNode.category)}/${
+                pageTreeNode.id
+            }/edit`;
+        },
     }),
 };

--- a/demo/admin/src/news/dependencies/NewsDependency.tsx
+++ b/demo/admin/src/news/dependencies/NewsDependency.tsx
@@ -1,4 +1,6 @@
+import { gql } from "@apollo/client";
 import { createDependencyMethods, DamImageBlock, DependencyInterface } from "@comet/cms-admin";
+import { GQLNewsContentScope } from "@src/graphql.generated";
 import { NewsContentBlock } from "@src/news/blocks/NewsContentBlock";
 import { FormattedMessage } from "react-intl";
 
@@ -7,6 +9,18 @@ export const NewsDependency: DependencyInterface = {
     ...createDependencyMethods({
         rootQueryName: "news",
         rootBlocks: { content: { block: NewsContentBlock, path: "/form" }, image: DamImageBlock },
-        basePath: ({ id }) => `/structured-content/news/${id}/edit`,
+        scopeFragment: {
+            fragment: gql`
+                fragment NewsDependencyScope on NewsContentScope {
+                    domain
+                    language
+                }
+            `,
+            name: "NewsDependencyScope",
+        },
+        basePath: ({ id, scope }) => {
+            const newsScope = scope as GQLNewsContentScope;
+            return `/${newsScope.domain}/${newsScope.language}/structured-content/news/${id}/edit`;
+        },
     }),
 };

--- a/demo/admin/src/news/dependencies/NewsDependency.tsx
+++ b/demo/admin/src/news/dependencies/NewsDependency.tsx
@@ -9,15 +9,12 @@ export const NewsDependency: DependencyInterface = {
     ...createDependencyMethods({
         rootQueryName: "news",
         rootBlocks: { content: { block: NewsContentBlock, path: "/form" }, image: DamImageBlock },
-        scopeFragment: {
-            fragment: gql`
-                fragment NewsDependencyScope on NewsContentScope {
-                    domain
-                    language
-                }
-            `,
-            name: "NewsDependencyScope",
-        },
+        scopeFragment: gql`
+            fragment NewsDependencyScope on NewsContentScope {
+                domain
+                language
+            }
+        `,
         basePath: ({ id, scope }) => {
             const newsScope = scope as GQLNewsContentScope;
             return `/${newsScope.domain}/${newsScope.language}/structured-content/news/${id}/edit`;

--- a/demo/admin/src/pages/Page.tsx
+++ b/demo/admin/src/pages/Page.tsx
@@ -67,15 +67,12 @@ export const Page: DocumentInterface<Pick<GQLPage, "content" | "seo">, GQLPageIn
             content: PageContentBlock,
             seo: { block: SeoBlock, path: "/config" },
         },
-        scopeFragment: {
-            fragment: gql`
-                fragment PageDependencyScope on PageTreeNodeScope {
-                    domain
-                    language
-                }
-            `,
-            name: "PageDependencyScope",
-        },
+        scopeFragment: gql`
+            fragment PageDependencyScope on PageTreeNodeScope {
+                domain
+                language
+            }
+        `,
         basePath: ({ pageTreeNode, scope }) => {
             const contentScope = scope as ContentScope;
             return `/${contentScope.domain}/${contentScope.language}/pages/pagetree/${categoryToUrlParam(pageTreeNode.category)}/${

--- a/demo/admin/src/pages/Page.tsx
+++ b/demo/admin/src/pages/Page.tsx
@@ -4,6 +4,7 @@ import { createDocumentDependencyMethods, createDocumentRootBlocksMethods, Depen
 import { PageTreePage } from "@comet/cms-admin/lib/pages/pageTree/usePageTree";
 import { Chip } from "@mui/material";
 import { SeoBlock } from "@src/common/blocks/SeoBlock";
+import { ContentScope } from "@src/common/ContentScopeProvider";
 import { GQLPageTreeNodeAdditionalFieldsFragment } from "@src/common/EditPageNode";
 import { GQLPage, GQLPageInput } from "@src/graphql.generated";
 import { categoryToUrlParam } from "@src/pageTree/pageTreeCategories";
@@ -66,6 +67,20 @@ export const Page: DocumentInterface<Pick<GQLPage, "content" | "seo">, GQLPageIn
             content: PageContentBlock,
             seo: { block: SeoBlock, path: "/config" },
         },
-        basePath: ({ pageTreeNode }) => `/pages/pagetree/${categoryToUrlParam(pageTreeNode.category)}/${pageTreeNode.id}/edit`,
+        scopeFragment: {
+            fragment: gql`
+                fragment PageDependencyScope on PageTreeNodeScope {
+                    domain
+                    language
+                }
+            `,
+            name: "PageDependencyScope",
+        },
+        basePath: ({ pageTreeNode, scope }) => {
+            const contentScope = scope as ContentScope;
+            return `/${contentScope.domain}/${contentScope.language}/pages/pagetree/${categoryToUrlParam(pageTreeNode.category)}/${
+                pageTreeNode.id
+            }/edit`;
+        },
     }),
 };

--- a/docs/docs/dependencies/index.md
+++ b/docs/docs/dependencies/index.md
@@ -207,10 +207,37 @@ export const NewsDependency: DependencyInterface = {
 };
 ```
 
+**If your DAM is global or only uses a part of the scope, you must further pass a `scopeFragment`.**
+The loaded scope is then passed to the `basePath` method where you must attach it to the URL.
+
+```tsx
+// NewsDependency.tsx
+export const NewsDependency: DependencyInterface = {
+    // ...
+    ...createDependencyMethods({
+        // ...
+        scopeFragment: gql`
+            fragment NewsDependencyScope on NewsContentScope {
+                domain
+                language
+            }
+        `,
+        basePath: ({ id, scope }) => {
+            const newsScope = scope as GQLNewsContentScope;
+            return `/${newsScope.domain}/${newsScope.language}/structured-content/news/${id}/edit`;
+        },
+    }),
+};
+```
+
+If you don't provide a `scopeFragment`, the link to a dependency will always stay in the current scope.
+This can cause 404 errors if the dependency is in a different scope.
+
 ##### `createDocumentDependencyMethods`
 
 For document types you can use the `createDocumentDependencyMethods` helper.
 It loads the document and also the `PageTreeNode` the document is attached to.
+The API is identical to `createDependencyMethods()`.
 
 ```tsx
 // Page.tsx

--- a/packages/admin/cms-admin/src/dependencies/DependencyList.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependencyList.tsx
@@ -6,7 +6,7 @@ import { LabelDisplayedRowsArgs } from "@mui/material/TablePagination/TablePagin
 import { DataGrid } from "@mui/x-data-grid";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { useHistory } from "react-router";
+import { matchPath, useHistory } from "react-router";
 
 import { useContentScope } from "../contentScope/Provider";
 import { GQLDependency } from "../graphql.generated";
@@ -104,7 +104,8 @@ export const DependencyList = ({ query, variables }: DependencyListProps) => {
                         apolloClient,
                         id: row.id,
                     });
-                    return contentScope.match.url + path;
+                    const hasScopeInBasePath = !!matchPath(path, contentScope.match);
+                    return hasScopeInBasePath ? path : contentScope.match.url + path;
                 };
 
                 return (

--- a/packages/admin/cms-admin/src/dependencies/createDependencyMethods.ts
+++ b/packages/admin/cms-admin/src/dependencies/createDependencyMethods.ts
@@ -33,10 +33,11 @@ export function createDependencyMethods<RootBlocks extends Record<string, BlockI
                             id
                             ${Object.keys(rootBlocks).join("\n")}
                             ${
-                                scopeFragment &&
-                                `scope {
-                                    ...${scopeFragment.name}
-                                }`
+                                scopeFragment
+                                    ? `scope {
+                                        ...${scopeFragment.name}
+                                    }`
+                                    : ""
                             }
                         }    
                     }    


### PR DESCRIPTION
You can now pass a `scopeFragment` to `createDependencyMethods()` and `createDocumentDependencyMethods()` to load the dependency's scope.
The loaded scope is then passed to `basePath` where you must attach it to the URL.

The `DependencyList` now checks if the scope is already in the URL and only prepends the current scope if needed.

This is helpful when the DAM is not or only partially scoped.
Otherwise, users might encounter 404 errors when dependencies are in a different scope than currently selected.

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Verify if the change requires a changeset. See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md)
-   [x] Link to the respective task if one exists: COM-910
-   [x] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->

Previously:

https://github.com/user-attachments/assets/03bbd9b6-38d7-4291-87d5-b1424ce560dc

Now:

https://github.com/user-attachments/assets/b73bcce0-63ea-43b1-86d4-afabbde4b058


</details>
