### PR TITLE
Fix Bug preventing EditPage Dialog to be submitted with enter

### DIFF
--- a/.changeset/famous-seahorses-pay.md
+++ b/.changeset/famous-seahorses-pay.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Fix a bug that prevented Forms inside a dialog to be submitted using Enter

--- a/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
+++ b/packages/admin/cms-admin/src/pages/createEditPageNode.tsx
@@ -476,6 +476,7 @@ export function createEditPageNode({
                                         )}
                                     </Field>
                                 )}
+                                <input type="submit" hidden />
 
                                 {additionalFormFields}
                             </>

--- a/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
+++ b/storybook/src/docs/bestPractices/GridAndFormLayouts.stories.tsx
@@ -170,6 +170,7 @@ export const LargeFormOnAPage = {
                         <TextField name="email" fullWidth variant="horizontal" label="Email" />
                         <TextField name="phone" fullWidth variant="horizontal" label="Phone" />
                     </FieldSet>
+                    <input type="submit" hidden />
                 </FinalForm>
             );
         };
@@ -282,6 +283,7 @@ export const LargeFormInADialog = {
                         <TextField name="email" fullWidth variant="horizontal" label="Email" />
                         <TextField name="phone" fullWidth variant="horizontal" label="Phone" />
                     </FormSection>
+                    <input type="submit" hidden />
                 </FinalForm>
             );
         };


### PR DESCRIPTION
## Description
Fix a bug that prevented the create PageTree Node Form to be submitted using Enter

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1296
Problem: 
- The form is rendered dynamically which results in the submit button being outside of the scope of the form tag
- This was solved adding an additional hidden submit button activated when pressing Enter