### PR TITLE
Save page state in session storage when Error occures

### DIFF
--- a/.changeset/famous-items-fly.md
+++ b/.changeset/famous-items-fly.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": minor
+---
+
+Save PageState in SessionStorage when User Session expires to prevent data los
+
+-   Saved state is retrieved once back on the edited Page

--- a/packages/admin/cms-admin/src/pages/createUsePage.tsx
+++ b/packages/admin/cms-admin/src/pages/createUsePage.tsx
@@ -277,6 +277,7 @@ export const createUsePage: CreateUsePage =
                         if (sessionStoragePageState) {
                             const state = await generateStateFromSession(sessionStoragePageState);
                             setPageState(state ? state : page);
+                            // set reference output to the loaded page to enable the user to save the page
                             setReferenceOutput(generateOutput(page));
                             window.sessionStorage.removeItem(`pageState_${pageId}`);
                         } else if (!pageState) {
@@ -355,6 +356,9 @@ export const createUsePage: CreateUsePage =
                     } catch (error) {
                         if (hasChanges) {
                             const output = generateOutput(pageState);
+                            for (const [key] of Object.entries(rootBlocks)) {
+                                delete pageState.document[key];
+                            }
                             window.sessionStorage.setItem(`pageState_${pageId}`, JSON.stringify({ output, pageState }));
                         }
                         console.error(error);


### PR DESCRIPTION
## Description
To prevent data los when user is unable to save editing Progress because of an expired Session, the Page State is stored and retrieved using the Sessionstorage
## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-1035
