### PR TITLE
Make handmade DataGrid rows clickable with shared primary action

### DIFF
--- a/.changeset/heavy-apes-add.md
+++ b/.changeset/heavy-apes-add.md
@@ -1,0 +1,5 @@
+---
+"@comet/admin": minor
+---
+
+Set cursor of DataGrid rows to "pointer" if `onRowClick` is set

--- a/demo/admin/src/products/ManufacturersGrid.tsx
+++ b/demo/admin/src/products/ManufacturersGrid.tsx
@@ -14,6 +14,7 @@ import {
     useBufferedRowCount,
     useDataGridRemote,
     usePersistentColumnState,
+    useStackSwitchApi,
 } from "@comet/admin";
 import { Add as AddIcon, Edit, Info } from "@comet/admin-icons";
 import { IconButton } from "@mui/material";
@@ -24,7 +25,7 @@ import {
     type GQLManufacturersListQuery,
     type GQLManufacturersListQueryVariables,
 } from "@src/products/ManufacturersGrid.generated";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 function ManufacturersGridToolbar() {
@@ -47,6 +48,14 @@ export function ManufacturersGrid() {
     const sortModel = dataGridProps.sortModel;
     const client = useApolloClient();
     const intl = useIntl();
+    const stackSwitchApi = useStackSwitchApi();
+
+    const handleRowPrimaryAction = useCallback(
+        (row: GridValues) => {
+            stackSwitchApi.activatePage("edit", row.id);
+        },
+        [stackSwitchApi],
+    );
 
     const columns: GridColDef<GridValues>[] = useMemo(() => {
         return [
@@ -119,7 +128,7 @@ export function ManufacturersGrid() {
                 renderCell: (params) => {
                     return (
                         <>
-                            <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id}>
+                            <IconButton color="primary" onClick={() => handleRowPrimaryAction(params.row)}>
                                 <Edit />
                             </IconButton>
                             <CrudContextMenu
@@ -136,7 +145,7 @@ export function ManufacturersGrid() {
                 },
             },
         ];
-    }, [client, intl]);
+    }, [client, intl, handleRowPrimaryAction]);
 
     const { data, loading, error } = useQuery<GQLManufacturersListQuery, GQLManufacturersListQueryVariables>(manufacturersQuery, {
         variables: {
@@ -158,6 +167,7 @@ export function ManufacturersGrid() {
             rowCount={rowCount}
             columns={columns}
             loading={loading}
+            onRowClick={(params) => handleRowPrimaryAction(params.row)}
             slots={{
                 toolbar: ManufacturersGridToolbar,
             }}

--- a/demo/admin/src/products/ProductVariantsGrid.tsx
+++ b/demo/admin/src/products/ProductVariantsGrid.tsx
@@ -11,10 +11,12 @@ import {
     useBufferedRowCount,
     useDataGridRemote,
     usePersistentColumnState,
+    useStackSwitchApi,
 } from "@comet/admin";
 import { Add as AddIcon, Edit } from "@comet/admin-icons";
 import { IconButton } from "@mui/material";
 import { DataGridPro, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
+import { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 
 import {
@@ -45,7 +47,15 @@ function ProductVariantsGridToolbar() {
 export function ProductVariantsGrid({ productId }: { productId: string }) {
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductVariantsGrid") };
     const sortModel = dataGridProps.sortModel;
+    const stackSwitchApi = useStackSwitchApi();
     //const client = useApolloClient();
+
+    const handleRowPrimaryAction = useCallback(
+        (row: GQLProductVariantsListFragment) => {
+            stackSwitchApi.activatePage("edit", row.id);
+        },
+        [stackSwitchApi],
+    );
 
     const columns: GridColDef<GQLProductVariantsListFragment>[] = [
         { field: "name", headerName: "Name", flex: 1 },
@@ -85,7 +95,7 @@ export function ProductVariantsGrid({ productId }: { productId: string }) {
             renderCell: (params) => {
                 return (
                     <>
-                        <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id}>
+                        <IconButton color="primary" onClick={() => handleRowPrimaryAction(params.row)}>
                             <Edit />
                         </IconButton>
                         {/*
@@ -121,6 +131,7 @@ export function ProductVariantsGrid({ productId }: { productId: string }) {
             rowCount={rowCount}
             columns={columns}
             loading={loading}
+            onRowClick={(params) => handleRowPrimaryAction(params.row)}
             slots={{
                 toolbar: ProductVariantsGridToolbar,
             }}

--- a/demo/admin/src/products/ProductsGrid.tsx
+++ b/demo/admin/src/products/ProductsGrid.tsx
@@ -23,6 +23,7 @@ import {
     useDataGridExcelExport,
     useDataGridRemote,
     usePersistentColumnState,
+    useStackSwitchApi,
 } from "@comet/admin";
 import { Add as AddIcon, Disabled, Edit, Education as EducationIcon, Excel, Online } from "@comet/admin-icons";
 import { CircularProgress, IconButton, useTheme } from "@mui/material";
@@ -35,7 +36,7 @@ import {
     GridToolbarQuickFilter,
 } from "@mui/x-data-grid-pro";
 import { ProductCategoryFilterOperators } from "@src/products/ProductCategoryFilter";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
 
 import { PublishAllProducts } from "./helpers/PublishAllProducts";
@@ -125,7 +126,15 @@ export function ProductsGrid() {
     const client = useApolloClient();
     const intl = useIntl();
     const theme = useTheme();
+    const stackSwitchApi = useStackSwitchApi();
     const [selectionModel, setSelectionModel] = useState<GridRowSelectionModel>([]);
+
+    const handleRowPrimaryAction = useCallback(
+        (row: GQLProductsListManualFragment) => {
+            stackSwitchApi.activatePage("edit", row.id);
+        },
+        [stackSwitchApi],
+    );
 
     const columns = useMemo((): GridColDef<GQLProductsListManualFragment>[] => {
         return [
@@ -319,7 +328,7 @@ export function ProductsGrid() {
                     return (
                         <>
                             <ProductsGridPreviewAction {...params} />
-                            <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id}>
+                            <IconButton color="primary" onClick={() => handleRowPrimaryAction(params.row)}>
                                 <Edit />
                             </IconButton>
                             <CrudContextMenu
@@ -337,7 +346,7 @@ export function ProductsGrid() {
                 disableExport: true,
             },
         ];
-    }, [client, intl, theme]);
+    }, [client, intl, theme, handleRowPrimaryAction]);
 
     const { data, loading, error } = useQuery<GQLProductsListQuery, GQLProductsListQueryVariables>(productsQuery, {
         variables: {
@@ -377,6 +386,7 @@ export function ProductsGrid() {
             rowCount={rowCount}
             columns={columns}
             loading={loading}
+            onRowClick={(params) => handleRowPrimaryAction(params.row)}
             slots={{
                 toolbar: ProductsGridToolbar as GridSlotsComponent["toolbar"],
             }}

--- a/demo/admin/src/products/highlights/ProductHighlightsGrid.tsx
+++ b/demo/admin/src/products/highlights/ProductHighlightsGrid.tsx
@@ -12,10 +12,12 @@ import {
     useBufferedRowCount,
     useDataGridRemote,
     usePersistentColumnState,
+    useStackSwitchApi,
 } from "@comet/admin";
 import { Add as AddIcon, Edit as EditIcon } from "@comet/admin-icons";
 import { IconButton } from "@mui/material";
 import { DataGridPro, type GridSlotsComponent, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
+import { useCallback } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import {
@@ -64,6 +66,15 @@ export function ProductHighlightsGrid() {
     const client = useApolloClient();
     const intl = useIntl();
     const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("ProductHighlightsGrid") };
+    const stackSwitchApi = useStackSwitchApi();
+
+    const handleRowPrimaryAction = useCallback(
+        (row: GQLProductHighlightsFormFragment) => {
+            stackSwitchApi.activatePage("edit", row.id);
+        },
+        [stackSwitchApi],
+    );
+
     const columns: GridColDef<GQLProductHighlightsFormFragment>[] = [
         {
             field: "description",
@@ -83,7 +94,7 @@ export function ProductHighlightsGrid() {
             renderCell: (params) => {
                 return (
                     <>
-                        <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id}>
+                        <IconButton color="primary" onClick={() => handleRowPrimaryAction(params.row)}>
                             <EditIcon />
                         </IconButton>
                         <CrudContextMenu
@@ -120,6 +131,7 @@ export function ProductHighlightsGrid() {
             rowCount={rowCount}
             columns={columns}
             loading={loading}
+            onRowClick={(params) => handleRowPrimaryAction(params.row)}
             slots={{
                 toolbar: ProductHighlightsGridToolbar as GridSlotsComponent["toolbar"],
             }}

--- a/demo/admin/src/products/tags/ProductTagsGrid.tsx
+++ b/demo/admin/src/products/tags/ProductTagsGrid.tsx
@@ -12,10 +12,12 @@ import {
     useBufferedRowCount,
     useDataGridRemote,
     usePersistentColumnState,
+    useStackSwitchApi,
 } from "@comet/admin";
 import { Add as AddIcon, Edit as EditIcon } from "@comet/admin-icons";
 import { IconButton } from "@mui/material";
 import { DataGridPro, type GridSlotsComponent, GridToolbarQuickFilter } from "@mui/x-data-grid-pro";
+import { useCallback } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import {
@@ -70,6 +72,15 @@ export function ProductTagsGrid() {
         }),
         ...usePersistentColumnState("ProductTagsGrid"),
     };
+    const stackSwitchApi = useStackSwitchApi();
+
+    const handleRowPrimaryAction = useCallback(
+        (row: GQLProductTagsGridFragment) => {
+            stackSwitchApi.activatePage("edit", row.id);
+        },
+        [stackSwitchApi],
+    );
+
     const columns: GridColDef<GQLProductTagsGridFragment>[] = [
         { field: "title", headerName: intl.formatMessage({ id: "productTag.title", defaultMessage: "Title" }), flex: 1, minWidth: 150 },
         {
@@ -84,7 +95,7 @@ export function ProductTagsGrid() {
             renderCell: (params) => {
                 return (
                     <>
-                        <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id}>
+                        <IconButton color="primary" onClick={() => handleRowPrimaryAction(params.row)}>
                             <EditIcon />
                         </IconButton>
                         <CrudContextMenu
@@ -121,6 +132,7 @@ export function ProductTagsGrid() {
             rowCount={rowCount}
             columns={columns}
             loading={loading}
+            onRowClick={(params) => handleRowPrimaryAction(params.row)}
             slots={{
                 toolbar: ProductTagsGridToolbar as GridSlotsComponent["toolbar"],
             }}

--- a/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiDataGrid.tsx
@@ -170,7 +170,9 @@ export const getMuiDataGrid: GetMuiComponentTheme<"MuiDataGrid"> = (component, {
                 minHeight: getDensityHeightValue(ownerState?.density),
             },
         }),
-
+        row: ({ ownerState }) => ({
+            cursor: ownerState?.onRowClick ? "pointer" : undefined,
+        }),
         iconSeparator: {
             backgroundColor: palette.grey[100],
             width: "2px",


### PR DESCRIPTION
## Description

DataGrids should generally have a "primary action", in most cases this will be "edit". 
This action should be called, not only trough a button in the `actions` column, but also when clicking the row directly. 

This is the simplest way of implementing this, however it might make sense to find a more generic solution. 
E.g. a `handleRowPrimaryAction` option in `useDataGridRemote` which adds the `onRowClick` prop to the DataGrid and automatically renders an IconButton in the `actions` column. 

There is one negative side-effect: The IconButton is no longer a `a` tag with `href` so a11y functions like "open in new tab" no longer work. The same applies to the row itself, which also is not an `a` tag. 

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [x] Add changeset
-   [ ] Can we find a generic solution for the `a` tag a11y issue?

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2618
