### PR TITLE
Renovate: allow lock file maintenance PR to merge

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -114,6 +114,10 @@
         {
             "matchDepTypes": ["peerDependencies"],
             "rangeStrategy": ["widen"]
+        },
+        {
+            "matchUpdateTypes": ["lockFileMaintenance"],
+            "minimumReleaseAgeBehaviour": "timestamp-optional"
         }
     ],
     "lockFileMaintenance": { "enabled": true },


### PR DESCRIPTION
## Description

Currently, Renovate's stability days check for lock file maintenance PRs (e.g. https://github.com/vivid-planet/dev-oidc-provider/pull/36) never finishes. I've reviewed the [job logs](https://developer.mend.io/github/vivid-planet/dev-oidc-provider/-/job/019bc199-c0ce-7ec9-ba55-0787f358a406) and found the following problem:

```
DEBUG: Marking 1 release(s) as pending, as they do not have a releaseTimestamp and we're running with minimumReleaseAgeBehaviour=timestamp-required (branch="renovate/lock-file-maintenance")
{
  "updates": [
    {
      "updateType": "lockFileMaintenance"
    }
  ]
}
```

It seems that doesn't support release timestamps for lock file maintenance PRs, despite it being supported by the [Npm Datasource](https://docs.renovatebot.com/modules/datasource/npm/). I therefore suggest to change the `minimumReleaseAgeBehaviour` to `timestamp-optional` for lock file maintenance PRs only.