### PR TITLE
Make DamModule dependencies optional for file-only deployments

### DIFF
--- a/.changeset/dam-module-file-only.md
+++ b/.changeset/dam-module-file-only.md
@@ -1,0 +1,39 @@
+---
+"@comet/cms-api": minor
+---
+
+Support using `DamModule` for file upload and download without the full DAM
+
+`DamModule` pulled in a lot of internal dependencies (`ImgproxyModule`, `UserPermissionsModule`, `DependenciesModule`), which made it hard to provide the plain DAM file upload/download endpoints in a standalone service (e.g. a separate public API microservice).
+
+The heavy dependencies are now optional:
+
+- **`fileOnly` mode:** Set `fileOnly: true` to register only the file/folder upload/download HTTP endpoints and their services. The GraphQL resolvers, blocks, image serving and dependents resolver — and their dependencies on `ImgproxyModule`, `UserPermissionsModule` and `DependenciesModule` — are skipped.
+- **Imgproxy is optional:** When no `ImgproxyModule` is registered, the dominant-color calculation is skipped.
+- **Access control is optional:** When an access control service is available (as in a full Comet app), the scope-based checks are applied as before. When it is not available, the endpoints fail closed and respond with `403 Forbidden`. To run the endpoints without an access control service — for example in a standalone service that protects them with its own authentication guard — set `disableScopeAccessControl: true`.
+
+Existing usage of `DamModule` is unchanged.
+
+**Example**
+
+```ts
+BlobStorageModule.register({
+    backend: config.blob.storage,
+    cacheDirectory: `${config.blob.storageDirectoryPrefix}-cache`,
+}),
+DamModule.register({
+    damConfig: {
+        secret: config.dam.secret,
+        filesDirectory: `${config.blob.storageDirectoryPrefix}-files`,
+        maxFileSize: config.dam.uploadsMaxFileSize,
+        maxSrcResolution: config.dam.maxSrcResolution,
+        allowedImageSizes: config.dam.allowedImageSizes,
+        allowedAspectRatios: config.dam.allowedImageAspectRatios,
+    },
+    Scope: DamScope,
+    File: DamFile,
+    Folder: DamFolder,
+    fileOnly: true,
+    disableScopeAccessControl: true,
+}),
+```

--- a/packages/api/cms-api/src/dam/dam.module.ts
+++ b/packages/api/cms-api/src/dam/dam.module.ts
@@ -1,5 +1,5 @@
 import { MikroOrmModule } from "@mikro-orm/nestjs";
-import { DynamicModule, Global, Module, Type, ValueProvider } from "@nestjs/common";
+import { DynamicModule, Global, Logger, Module, Type, ValueProvider } from "@nestjs/common";
 import { TypeMetadataStorage } from "@nestjs/graphql";
 
 import { BlobStorageModule, damDefaultAcceptedMimetypes, DependentsResolverFactory } from "..";
@@ -42,6 +42,16 @@ interface DamModuleOptions {
     Scope?: Type<DamScopeInterface>;
     Folder?: Type<FolderInterface>;
     File?: Type<FileInterface>;
+    // When true, only the file/folder upload/download HTTP endpoints and their services are registered. The GraphQL
+    // resolvers, blocks, image serving and dependents resolver — and their dependencies on ImgproxyModule,
+    // UserPermissionsModule and DependenciesModule — are skipped. Use this to provide the plain DAM file endpoints in a
+    // standalone service (e.g. a separate public API microservice) without pulling in the full admin stack.
+    fileOnly?: boolean;
+    // The DAM file/folder endpoints perform scope-based access control only when an access control service is available
+    // (provided by UserPermissionsModule). Set this to true to acknowledge that authorization is handled outside of the
+    // DAM module (e.g. by an authentication guard in front of a standalone service). Without it, the endpoints fail
+    // closed when no access control service is registered.
+    disableScopeAccessControl?: boolean;
 }
 
 @Global()
@@ -51,6 +61,8 @@ export class DamModule {
         Scope,
         Folder = createFolderEntity({ Scope }),
         File = createFileEntity({ Scope, Folder }),
+        fileOnly = false,
+        disableScopeAccessControl = false,
         ...options
     }: DamModuleOptions): DynamicModule {
         const damConfig = {
@@ -60,6 +72,12 @@ export class DamModule {
 
         if (File.name !== FILE_ENTITY) {
             throw new Error(`DamModule: Your File entity must be named ${FILE_ENTITY}`);
+        }
+
+        if (disableScopeAccessControl) {
+            new Logger(DamModule.name).warn(
+                "Scope-based access control is disabled. The DAM file and folder endpoints perform no authorization on their own — make sure they are protected by other means (e.g. an authentication guard).",
+            );
         }
 
         const damConfigProvider: ValueProvider<DamConfig> = {
@@ -74,6 +92,21 @@ export class DamModule {
                 acceptedMimeTypes: damConfig.acceptedMimeTypes ?? damDefaultAcceptedMimetypes,
             }),
         };
+
+        const entitiesModule = MikroOrmModule.forFeature([File, Folder, DamFileImage, ImageCropArea, DamMediaAlternative]);
+
+        if (fileOnly) {
+            return {
+                module: DamModule,
+                imports: [entitiesModule, BlobStorageModule],
+                providers: [damConfigProvider, fileValidationServiceProvider, FilesService, FoldersService],
+                controllers: [
+                    createFilesController({ Scope, damBasePath: damConfig.basePath, disableScopeAccessControl }),
+                    createFoldersController({ damBasePath: damConfig.basePath, disableScopeAccessControl }),
+                ],
+                exports: [entitiesModule, damConfigProvider, FilesService, FoldersService],
+            };
+        }
 
         const DamItemsResolver = createDamItemsResolver({ File, Folder, Scope });
         const FilesResolver = createFilesResolver({ File, Folder, Scope });
@@ -102,7 +135,7 @@ export class DamModule {
 
         return {
             module: DamModule,
-            imports: [MikroOrmModule.forFeature([File, Folder, DamFileImage, ImageCropArea, DamMediaAlternative]), BlobStorageModule, ImgproxyModule],
+            imports: [entitiesModule, BlobStorageModule, ImgproxyModule],
             providers: [
                 damConfigProvider,
                 DamItemsResolver,
@@ -129,8 +162,8 @@ export class DamModule {
                 DamMediaAlternativeResolver,
             ],
             controllers: [
-                createFilesController({ Scope, damBasePath: damConfig.basePath }),
-                createFoldersController({ damBasePath: damConfig.basePath }),
+                createFilesController({ Scope, damBasePath: damConfig.basePath, disableScopeAccessControl }),
+                createFoldersController({ damBasePath: damConfig.basePath, disableScopeAccessControl }),
                 createImagesController({ damBasePath: damConfig.basePath }),
             ],
             exports: [

--- a/packages/api/cms-api/src/dam/files/files.controller.ts
+++ b/packages/api/cms-api/src/dam/files/files.controller.ts
@@ -7,8 +7,10 @@ import {
     Get,
     Headers,
     Inject,
+    InternalServerErrorException,
     Logger,
     NotFoundException,
+    Optional,
     Param,
     Post,
     Res,
@@ -30,7 +32,6 @@ import { createHashedPath } from "../../blob-storage/utils/create-hashed-path.ut
 import { CometValidationException } from "../../common/errors/validation.exception";
 import { FileUploadInput } from "../../file-utils/file-upload.input";
 import { calculatePartialRanges, slugifyFilename } from "../../file-utils/files.utils";
-import { ContentScopeService } from "../../user-permissions/content-scope.service";
 import { RequiredPermission } from "../../user-permissions/decorators/required-permission.decorator";
 import { CurrentUser } from "../../user-permissions/dto/current-user";
 import { ACCESS_CONTROL_SERVICE } from "../../user-permissions/user-permissions.constants";
@@ -45,10 +46,19 @@ import { FileParams, HashFileParams } from "./dto/file.params";
 import { FileInterface } from "./entities/file.entity";
 import { FilesService } from "./files.service";
 import { FoldersService } from "./folders.service";
+import { scopesAreEqual } from "./scopes-are-equal.util";
 
 const fileUrl = `:fileId/:filename`;
 
-export function createFilesController({ Scope: PassedScope, damBasePath }: { Scope?: Type<DamScopeInterface>; damBasePath: string }): Type<unknown> {
+export function createFilesController({
+    Scope: PassedScope,
+    damBasePath,
+    disableScopeAccessControl = false,
+}: {
+    Scope?: Type<DamScopeInterface>;
+    damBasePath: string;
+    disableScopeAccessControl?: boolean;
+}): Type<unknown> {
     const Scope = PassedScope ?? EmptyDamScope;
     const hasNonEmptyScope = PassedScope != null;
 
@@ -66,10 +76,19 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             @Inject(DAM_CONFIG) private readonly damConfig: DamConfig,
             private readonly filesService: FilesService,
             private readonly blobStorageBackendService: BlobStorageBackendService,
-            @Inject(ACCESS_CONTROL_SERVICE) private accessControlService: AccessControlServiceInterface,
-            private readonly contentScopeService: ContentScopeService,
             private readonly foldersService: FoldersService,
+            @Optional() @Inject(ACCESS_CONTROL_SERVICE) private accessControlService?: AccessControlServiceInterface,
         ) {}
+
+        // Fail closed: without an access control service the scope checks below would be silently skipped, leaving the
+        // endpoints unauthorized. Require the consuming application to opt out explicitly when it handles authorization itself.
+        private assertScopeAccessControlAvailable(): void {
+            if (!this.accessControlService && !disableScopeAccessControl) {
+                throw new ForbiddenException(
+                    "DAM scope access control is not available. Register an access control service or set `disableScopeAccessControl: true` on the DAM module to handle authorization outside of the DAM module.",
+                );
+            }
+        }
 
         @Post("upload")
         @UseInterceptors(DamUploadFileInterceptor())
@@ -79,6 +98,8 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             @GetCurrentUser() user: CurrentUser,
             @Headers("x-preview-dam-urls") previewDamUrls: string | undefined,
         ): Promise<Omit<FileInterface, keyof BaseEntity> & { fileUrl: string }> {
+            this.assertScopeAccessControlAvailable();
+
             const transformedBody = plainToInstance(UploadFileBody, body);
             const errors = await validate(transformedBody, { whitelist: true, forbidNonWhitelisted: true });
 
@@ -87,7 +108,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             }
             const scope = nonEmptyScopeOrNothing(transformedBody.scope);
 
-            if (scope && !this.accessControlService.isAllowed(user, "dam", scope)) {
+            if (scope && this.accessControlService && !this.accessControlService.isAllowed(user, "dam", scope)) {
                 throw new ForbiddenException();
             }
 
@@ -97,7 +118,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
                 if (!folder) {
                     throw new BadRequestException(`Folder ${folderId} not found`);
                 }
-                if (!this.contentScopeService.scopesAreEqual(folder.scope, scope)) {
+                if (!scopesAreEqual(folder.scope, scope)) {
                     throw new BadRequestException("Folder scope doesn't match passed scope");
                 }
             }
@@ -118,6 +139,8 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             @GetCurrentUser() user: CurrentUser,
             @Headers("x-preview-dam-urls") previewDamUrls: string | undefined,
         ): Promise<Omit<FileInterface, keyof BaseEntity> & { fileUrl: string }> {
+            this.assertScopeAccessControlAvailable();
+
             const transformedBody = plainToInstance(UploadFileBody, body);
             const errors = await validate(transformedBody, { whitelist: true, forbidNonWhitelisted: true });
 
@@ -126,7 +149,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             }
             const scope = nonEmptyScopeOrNothing(transformedBody.scope);
 
-            if (scope && !this.accessControlService.isAllowed(user, "dam", scope)) {
+            if (scope && this.accessControlService && !this.accessControlService.isAllowed(user, "dam", scope)) {
                 throw new ForbiddenException();
             }
 
@@ -136,7 +159,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
                 if (!folder) {
                     throw new BadRequestException(`Folder ${folderId} not found`);
                 }
-                if (!this.contentScopeService.scopesAreEqual(folder.scope, scope)) {
+                if (!scopesAreEqual(folder.scope, scope)) {
                     throw new BadRequestException("Folder scope doesn't match passed scope");
                 }
             }
@@ -149,7 +172,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             if (!fileToReplace) {
                 throw new NotFoundException(`File not found`);
             }
-            if (!this.accessControlService.isAllowed(user, "dam", fileToReplace.scope)) {
+            if (this.accessControlService && !this.accessControlService.isAllowed(user, "dam", fileToReplace.scope)) {
                 throw new ForbiddenException();
             }
 
@@ -170,6 +193,8 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             @GetCurrentUser() user: CurrentUser,
             @Headers("x-preview-dam-urls") previewDamUrls: string | undefined,
         ): Promise<Omit<FileInterface, keyof BaseEntity> & { fileUrl: string }> {
+            this.assertScopeAccessControlAvailable();
+
             const transformedBody = plainToInstance(ReplaceFileByIdBody, body);
             const errors = await validate(transformedBody, { whitelist: true, forbidNonWhitelisted: true });
 
@@ -183,7 +208,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             if (!fileToReplace) {
                 throw new NotFoundException(`File ${fileId} not found`);
             }
-            if (!this.accessControlService.isAllowed(user, "dam", fileToReplace.scope)) {
+            if (this.accessControlService && !this.accessControlService.isAllowed(user, "dam", fileToReplace.scope)) {
                 throw new ForbiddenException();
             }
 
@@ -203,6 +228,8 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             @GetCurrentUser() user: CurrentUser,
             @Headers("range") range?: string,
         ): Promise<void> {
+            this.assertScopeAccessControlAvailable();
+
             const file = await this.filesService.findOneById(fileId);
 
             if (file === null) {
@@ -213,7 +240,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
                 throw new BadRequestException("Content Hash mismatch!");
             }
 
-            if (file.scope !== undefined && !this.accessControlService.isAllowed(user, "dam", file.scope)) {
+            if (file.scope !== undefined && this.accessControlService && !this.accessControlService.isAllowed(user, "dam", file.scope)) {
                 throw new ForbiddenException();
             }
 
@@ -227,6 +254,8 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             @GetCurrentUser() user: CurrentUser,
             @Headers("range") range?: string,
         ): Promise<void> {
+            this.assertScopeAccessControlAvailable();
+
             const file = await this.filesService.findOneById(fileId);
 
             if (file === null) {
@@ -237,7 +266,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
                 throw new BadRequestException("Content Hash mismatch!");
             }
 
-            if (file.scope !== undefined && !this.accessControlService.isAllowed(user, "dam", file.scope)) {
+            if (file.scope !== undefined && this.accessControlService && !this.accessControlService.isAllowed(user, "dam", file.scope)) {
                 throw new ForbiddenException();
             }
 
@@ -338,7 +367,8 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
                         contentLength,
                     );
                 } catch (err) {
-                    throw new Error(`File-Stream error: (storage.getPartialFile) - ${(err as Error).message}`);
+                    this.logger.error("Failed to stream file from storage (getPartialFile)", err);
+                    throw new InternalServerErrorException("File could not be streamed");
                 }
 
                 stream.on("error", (error) => {
@@ -361,7 +391,8 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
                 try {
                     stream = await this.blobStorageBackendService.getFile(this.damConfig.filesDirectory, createHashedPath(file.contentHash));
                 } catch (err) {
-                    throw new Error(`File-Stream error: (storage.getFile) - ${(err as Error).message}`);
+                    this.logger.error("Failed to stream file from storage (getFile)", err);
+                    throw new InternalServerErrorException("File could not be streamed");
                 }
 
                 stream.on("error", (error) => {

--- a/packages/api/cms-api/src/dam/files/files.service.spec.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.spec.ts
@@ -38,10 +38,9 @@ function createServiceWithMockQueryBuilder() {
         null as never, // blobStorageBackendService
         null as never, // foldersService
         null as never, // DAM_CONFIG
-        null as never, // imgproxyService
         null as never, // orm
-        null as never, // contentScopeService
         null as never, // entityManager
+        undefined, // imgproxyService
     );
 
     const hasFolderConstraint = () =>

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository, MikroORM, QueryBuilder, raw, Utils } from "@mikro-orm/postgresql";
-import { forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
+import { forwardRef, Inject, Injectable, Logger, Optional } from "@nestjs/common";
 import { createHmac } from "crypto";
 import exifr from "exifr";
 import { createReadStream } from "fs";
@@ -22,7 +22,6 @@ import { slugifyFilename } from "../../file-utils/files.utils";
 import { FocalPoint } from "../../file-utils/focal-point.enum";
 import { Extension, ResizingType } from "../../imgproxy/imgproxy.enum";
 import { ImgproxyService } from "../../imgproxy/imgproxy.service";
-import { ContentScopeService } from "../../user-permissions/content-scope.service";
 import { CometImageResolutionException } from "../common/errors/image-resolution.exception";
 import { DamConfig } from "../dam.config";
 import { DAM_CONFIG } from "../dam.constants";
@@ -37,6 +36,7 @@ import { FILE_TABLE_NAME, FileInterface } from "./entities/file.entity";
 import { DamFileImage } from "./entities/file-image.entity";
 import { FolderInterface } from "./entities/folder.entity";
 import { FoldersService } from "./folders.service";
+import { scopesAreEqual } from "./scopes-are-equal.util";
 
 const exifrSupportedMimetypes = ["image/jpeg", "image/tiff", "image/x-iiq", "image/heif", "image/heic", "image/avif", "image/png"];
 
@@ -127,10 +127,9 @@ export class FilesService {
         @Inject(forwardRef(() => BlobStorageBackendService)) private readonly blobStorageBackendService: BlobStorageBackendService,
         private readonly foldersService: FoldersService,
         @Inject(DAM_CONFIG) private readonly config: DamConfig,
-        private readonly imgproxyService: ImgproxyService,
         private readonly orm: MikroORM,
-        private readonly contentScopeService: ContentScopeService,
         private readonly entityManager: EntityManager,
+        @Optional() private readonly imgproxyService?: ImgproxyService,
     ) {}
 
     private selectQueryBuilder(): QueryBuilder<FileInterface> {
@@ -346,8 +345,7 @@ export class FilesService {
         const updatedFiles = [];
 
         for (const file of files) {
-            // Convert to JS object because deep-comparing classes and objects doesn't work
-            if (targetFolder?.scope !== undefined && !this.contentScopeService.scopesAreEqual(file.scope, targetFolder.scope)) {
+            if (targetFolder?.scope !== undefined && !scopesAreEqual(file.scope, targetFolder.scope)) {
                 throw new Error("Target folder scope doesn't match file scope");
             }
 
@@ -413,7 +411,7 @@ export class FilesService {
                 ...assignData,
             });
 
-            if (result.image) {
+            if (result.image && this.imgproxyService) {
                 // We do not want for our users to await the dominant color calculation. To prevent concurrency issues we must use a separate Unit of
                 // Work. This can be achieved by forking the EntityManager instance.
                 // See https://mikro-orm.io/docs/faq#you-cannot-call-emflush-from-inside-lifecycle-hook-handlers and
@@ -573,6 +571,10 @@ export class FilesService {
     }
 
     async calculateDominantColor(contentHash: string): Promise<string | undefined> {
+        if (!this.imgproxyService) {
+            return undefined;
+        }
+
         const path = this.imgproxyService
             .builder()
             .resize(ResizingType.AUTO, 1)
@@ -582,11 +584,12 @@ export class FilesService {
             );
 
         const imgUrl = this.imgproxyService.getSignedUrl(path);
-        let imageResponse: Response;
-        try {
-            imageResponse = await fetch(imgUrl);
-        } catch (error) {
+        const imageResponse = await fetch(imgUrl).catch((error: unknown) => {
             this.logger.error("Failed to calculate dominant color: imgproxy is not available", error);
+            return undefined;
+        });
+
+        if (!imageResponse) {
             return undefined;
         }
 

--- a/packages/api/cms-api/src/dam/files/folders.controller.ts
+++ b/packages/api/cms-api/src/dam/files/folders.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, ForbiddenException, Get, Inject, NotFoundException, Param, Res, Type } from "@nestjs/common";
+import { Controller, ForbiddenException, Get, Inject, NotFoundException, Optional, Param, Res, Type } from "@nestjs/common";
 import { Response } from "express";
 
 import { GetCurrentUser } from "../../auth/decorators/get-current-user.decorator";
@@ -8,23 +8,41 @@ import { ACCESS_CONTROL_SERVICE } from "../../user-permissions/user-permissions.
 import { AccessControlServiceInterface } from "../../user-permissions/user-permissions.types";
 import { FoldersService } from "./folders.service";
 
-export const createFoldersController = ({ damBasePath }: { damBasePath: string }): Type<unknown> => {
+export const createFoldersController = ({
+    damBasePath,
+    disableScopeAccessControl = false,
+}: {
+    damBasePath: string;
+    disableScopeAccessControl?: boolean;
+}): Type<unknown> => {
     @Controller(`${damBasePath}/folders`)
     class FoldersController {
         constructor(
             private readonly foldersService: FoldersService,
-            @Inject(ACCESS_CONTROL_SERVICE) private accessControlService: AccessControlServiceInterface,
+            @Optional() @Inject(ACCESS_CONTROL_SERVICE) private accessControlService?: AccessControlServiceInterface,
         ) {}
+
+        // Fail closed: without an access control service the scope check below would be silently skipped, leaving the
+        // endpoint unauthorized. Require the consuming application to opt out explicitly when it handles authorization itself.
+        private assertScopeAccessControlAvailable(): void {
+            if (!this.accessControlService && !disableScopeAccessControl) {
+                throw new ForbiddenException(
+                    "DAM scope access control is not available. Register an access control service or set `disableScopeAccessControl: true` on the DAM module to handle authorization outside of the DAM module.",
+                );
+            }
+        }
 
         @RequiredPermission(["dam"], { skipScopeCheck: true }) // Scope is checked in method
         @Get("/:folderId/zip")
         async createZip(@Param("folderId") folderId: string, @Res() res: Response, @GetCurrentUser() user: CurrentUser): Promise<void> {
+            this.assertScopeAccessControlAvailable();
+
             const folder = await this.foldersService.findOneById(folderId);
             if (!folder) {
                 throw new NotFoundException("Folder not found");
             }
 
-            if (folder.scope && !this.accessControlService.isAllowed(user, "dam", folder.scope)) {
+            if (folder.scope && this.accessControlService && !this.accessControlService.isAllowed(user, "dam", folder.scope)) {
                 throw new ForbiddenException("The current user is not allowed to access this scope and download this folder.");
             }
 

--- a/packages/api/cms-api/src/dam/files/folders.service.ts
+++ b/packages/api/cms-api/src/dam/files/folders.service.ts
@@ -2,7 +2,6 @@ import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository, MikroORM, QueryBuilder, raw } from "@mikro-orm/postgresql";
 import { forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
 import JSZip from "jszip";
-import isEqual from "lodash.isequal";
 
 import { BlobStorageBackendService } from "../../blob-storage/backends/blob-storage-backend.service";
 import { createHashedPath } from "../../blob-storage/utils/create-hashed-path.util";
@@ -15,6 +14,7 @@ import { DamFolderListPositionArgs, FolderArgsInterface } from "./dto/folder.arg
 import { UpdateFolderInput } from "./dto/folder.input";
 import { FOLDER_TABLE_NAME, FolderInterface } from "./entities/folder.entity";
 import { FilesService } from "./files.service";
+import { scopesAreEqual } from "./scopes-are-equal.util";
 
 const withFoldersSelect = (
     qb: QueryBuilder<FolderInterface>,
@@ -262,8 +262,7 @@ export class FoldersService {
                 throw new Error("Target folder doesn't exist");
             }
 
-            // Convert to JS object because deep-comparing classes and objects doesn't work
-            if (scope && targetFolder.scope && !isEqual({ ...targetFolder.scope }, scope)) {
+            if (scope && targetFolder.scope && !scopesAreEqual(targetFolder.scope, scope)) {
                 throw new Error("Scope arg doesn't match folder scope");
             }
         }
@@ -275,8 +274,7 @@ export class FoldersService {
                 throw new Error("Folder doesn't exist");
             }
 
-            // Convert to JS object because deep-comparing classes and objects doesn't work
-            if (scope && folder.scope && !isEqual({ ...folder.scope }, scope)) {
+            if (scope && folder.scope && !scopesAreEqual(folder.scope, scope)) {
                 throw new Error("Scope arg doesn't match folder scope");
             }
 

--- a/packages/api/cms-api/src/dam/files/scopes-are-equal.util.spec.ts
+++ b/packages/api/cms-api/src/dam/files/scopes-are-equal.util.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { scopesAreEqual } from "./scopes-are-equal.util";
+
+class DamScope {
+    constructor(public domain: string) {}
+}
+
+describe("scopesAreEqual", () => {
+    it("returns true for scopes with equal properties", () => {
+        expect(scopesAreEqual({ domain: "main" }, { domain: "main" })).toBe(true);
+    });
+
+    it("returns false for scopes with different values", () => {
+        expect(scopesAreEqual({ domain: "main" }, { domain: "secondary" })).toBe(false);
+    });
+
+    it("returns false for scopes with different keys", () => {
+        expect(scopesAreEqual({ domain: "main" }, { domain: "main", language: "en" })).toBe(false);
+    });
+
+    it("compares a class instance and a plain object by their properties", () => {
+        expect(scopesAreEqual(new DamScope("main"), { domain: "main" })).toBe(true);
+    });
+
+    it("treats two undefined scopes as equal", () => {
+        expect(scopesAreEqual(undefined, undefined)).toBe(true);
+    });
+
+    it("treats an undefined scope and an empty scope as equal", () => {
+        // Both reduce to {} after cloning. Callers that need to distinguish "no scope" from "empty scope" must guard
+        // for undefined themselves before calling.
+        expect(scopesAreEqual(undefined, {})).toBe(true);
+    });
+
+    it("treats an undefined scope and a non-empty scope as different", () => {
+        expect(scopesAreEqual(undefined, { domain: "main" })).toBe(false);
+    });
+});

--- a/packages/api/cms-api/src/dam/files/scopes-are-equal.util.ts
+++ b/packages/api/cms-api/src/dam/files/scopes-are-equal.util.ts
@@ -1,0 +1,9 @@
+import isEqual from "lodash.isequal";
+
+import type { DamScopeInterface } from "../types";
+
+// The scopes are cloned because they could be an instance of a class (e.g. DamScope) or a plain object (from an HTTP/GraphQL input).
+// Without cloning they wouldn't be deeply equal although they represent the same scope.
+export function scopesAreEqual(scope1?: DamScopeInterface, scope2?: DamScopeInterface): boolean {
+    return isEqual({ ...scope1 }, { ...scope2 });
+}


### PR DESCRIPTION
## Summary

This change makes several dependencies of `DamModule` optional to support standalone file upload/download services without pulling in the full DAM stack (GraphQL resolvers, image processing, etc.).

## Key Changes

- **Added `fileOnly` mode**: When `fileOnly: true` is set on `DamModule.register()`, only file/folder HTTP endpoints and their services are registered. GraphQL resolvers, image serving, blocks, and the dependents resolver are skipped, eliminating dependencies on `ImgproxyModule`, `UserPermissionsModule`, and `DependenciesModule`.

- **Made access control optional**: 
  - The `ACCESS_CONTROL_SERVICE` is now injected as `@Optional()` in file and folder controllers
  - Added `disableScopeAccessControl` option to acknowledge when authorization is handled outside the DAM module
  - Controllers fail closed with `403 Forbidden` when no access control service is available and `disableScopeAccessControl` is not set
  - Scope checks are conditionally applied only when the access control service is available

- **Made ImgproxyService optional**: 
  - Injected as `@Optional()` in `FilesService`
  - Dominant color calculation is skipped when ImgproxyService is unavailable
  - Error handling improved to gracefully handle missing imgproxy

- **Extracted scope comparison logic**: 
  - Created `scopesAreEqual()` utility function to replace `ContentScopeService.scopesAreEqual()`
  - Handles comparison of class instances and plain objects by converting to plain objects
  - Includes comprehensive unit tests

- **Improved error handling**: 
  - File streaming errors now log details and return proper `InternalServerErrorException` instead of generic `Error`
  - Added validation warnings when `disableScopeAccessControl` is enabled

## Implementation Details

- The `fileOnly` mode creates a minimal module with only `BlobStorageModule` as a dependency, suitable for standalone microservices
- Scope access control uses a "fail closed" pattern: endpoints require explicit opt-out via `disableScopeAccessControl: true` to run without access control
- The `scopesAreEqual()` utility uses object spread to normalize class instances and plain objects before comparison, ensuring compatibility with both entity instances and HTTP/GraphQL inputs

https://claude.ai/code/session_01UtrmtcFruc58rm3DLTfjMs