### PR TITLE
Add scope filter and sort to Global Action Log [COM-3006]

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -29,8 +29,16 @@ input ActionLogFilter {
   entityId: IdFilter
   entityName: StringFilter
   or: [ActionLogFilter!]
+  scope: ActionLogScopeFilter
   userId: StringFilter
   version: NumberFilter
+}
+
+input ActionLogScopeFilter {
+  equal: JSONObject
+  isAnyOf: [JSONObject!]
+  isGlobal: Boolean
+  notEqual: JSONObject
 }
 
 input ActionLogSort {
@@ -40,6 +48,8 @@ input ActionLogSort {
 
 enum ActionLogSortField {
   createdAt
+  entityName
+  scope
   version
 }
 

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.gql.ts
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.gql.ts
@@ -17,8 +17,8 @@ const globalActionLogGridFragment = gql`
 `;
 
 export const globalActionLogGridQuery = gql`
-    query GlobalActionLogGrid($offset: Int!, $limit: Int!, $sort: [ActionLogSort!], $scopes: [JSONObject!]!) {
-        actionLogs(offset: $offset, limit: $limit, sort: $sort, scopes: $scopes) {
+    query GlobalActionLogGrid($offset: Int!, $limit: Int!, $sort: [ActionLogSort!], $filter: ActionLogFilter, $scopes: [JSONObject!]!) {
+        actionLogs(offset: $offset, limit: $limit, sort: $sort, filter: $filter, scopes: $scopes) {
             nodes {
                 ...GlobalActionLogGrid
             }

--- a/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
+++ b/packages/admin/cms-admin/src/actionLog/globalActionLog/globalActionLogGrid/GlobalActionLogGrid.tsx
@@ -3,16 +3,24 @@ import {
     dataGridDateTimeColumn,
     DataGridToolbar,
     type GridColDef,
+    GridFilterButton,
     MainContent,
+    messages,
+    muiGridFilterToGql,
     muiGridSortToGql,
+    ToolbarItem,
     useBufferedRowCount,
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { useMemo, useState } from "react";
+import { Autocomplete } from "@mui/material";
+import { type GridFilterInputValueProps, type GridFilterItem, type GridFilterOperator, useGridRootProps } from "@mui/x-data-grid";
+import { capitalCase } from "change-case";
+import isEqual from "lodash.isequal";
+import { createContext, useContext, useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 
-import { useContentScope } from "../../../contentScope/Provider";
+import { type ContentScope, useContentScope } from "../../../contentScope/Provider";
 import { DataGrid } from "../../../dataGrid/DataGrid";
 import { ActionLogTypeChip } from "../../components/actionLogTypeChip/ActionLogTypeChip";
 import { ScopeCell } from "../../components/scopeCell/ScopeCell";
@@ -26,6 +34,108 @@ import type {
 } from "./GlobalActionLogGrid.gql.generated";
 import { EntityTypeChip } from "./GlobalActionLogGrid.sc";
 
+function scopeColumnToGqlFilter(filterItem: GridFilterItem) {
+    if (filterItem.operator === "isAnyOf") {
+        const scopes = ((filterItem.value as string[] | undefined) ?? []).map((value) => JSON.parse(value) as ContentScope | null);
+        const includesGlobal = scopes.some((scope) => scope === null);
+        const contentScopes = scopes.filter((scope): scope is ContentScope => scope !== null);
+        if (includesGlobal && contentScopes.length > 0) {
+            return { or: [{ scope: { isGlobal: true } }, { scope: { isAnyOf: contentScopes } }] };
+        }
+        if (includesGlobal) {
+            return { scope: { isGlobal: true } };
+        }
+        return { scope: { isAnyOf: contentScopes } };
+    }
+    if (typeof filterItem.value !== "string") {
+        return { scope: {} };
+    }
+    const scope = JSON.parse(filterItem.value) as ContentScope | null;
+    if (scope === null) {
+        return { scope: { isGlobal: filterItem.operator !== "not" } };
+    }
+    const gqlOperator = filterItem.operator === "not" ? "notEqual" : "equal";
+    return { scope: { [gqlOperator]: scope } };
+}
+
+type ScopeOption = { value: string; label: string };
+
+const ScopeFilterOptionsContext = createContext<ScopeOption[]>([]);
+
+function ScopeFilterSingleInput({ item, applyValue, focusElementRef, apiRef }: GridFilterInputValueProps) {
+    const options = useContext(ScopeFilterOptionsContext);
+    const rootProps = useGridRootProps();
+    const selectedValue = typeof item.value === "string" ? (options.find((option) => option.value === item.value) ?? null) : null;
+    return (
+        <Autocomplete<ScopeOption, false, false, false>
+            options={options}
+            value={selectedValue}
+            getOptionLabel={(option) => option.label}
+            isOptionEqualToValue={(option, candidate) => option.value === candidate.value}
+            onChange={(_, newValue) => applyValue({ ...item, value: newValue?.value ?? null })}
+            renderInput={(params) => (
+                <rootProps.slots.baseTextField
+                    {...params}
+                    label={apiRef.current.getLocaleText("filterPanelInputLabel")}
+                    inputRef={focusElementRef}
+                    slotProps={{
+                        inputLabel: { shrink: true },
+                        input: params.InputProps,
+                    }}
+                />
+            )}
+        />
+    );
+}
+
+function ScopeFilterMultiInput({ item, applyValue, focusElementRef, apiRef }: GridFilterInputValueProps) {
+    const options = useContext(ScopeFilterOptionsContext);
+    const rootProps = useGridRootProps();
+    const selectedValues = Array.isArray(item.value) ? (item.value as string[]) : [];
+    const selectedOptions = options.filter((option) => selectedValues.includes(option.value));
+    return (
+        <Autocomplete<ScopeOption, true, false, false>
+            multiple
+            options={options}
+            value={selectedOptions}
+            getOptionLabel={(option) => option.label}
+            isOptionEqualToValue={(option, candidate) => option.value === candidate.value}
+            onChange={(_, newValue) => applyValue({ ...item, value: newValue.map((option) => option.value) })}
+            renderInput={(params) => (
+                <rootProps.slots.baseTextField
+                    {...params}
+                    label={apiRef.current.getLocaleText("filterPanelInputLabel")}
+                    inputRef={focusElementRef}
+                    slotProps={{
+                        inputLabel: { shrink: true },
+                        input: params.InputProps,
+                    }}
+                />
+            )}
+        />
+    );
+}
+
+const throwOnLocalScopeFilter = () => {
+    throw new Error("Server-side filter; not applied on the client.");
+};
+
+const scopeFilterOperators: GridFilterOperator[] = [
+    { value: "is", getApplyFilterFn: throwOnLocalScopeFilter, InputComponent: ScopeFilterSingleInput },
+    { value: "not", getApplyFilterFn: throwOnLocalScopeFilter, InputComponent: ScopeFilterSingleInput },
+    { value: "isAnyOf", getApplyFilterFn: throwOnLocalScopeFilter, InputComponent: ScopeFilterMultiInput },
+];
+
+function GlobalActionLogGridToolbar() {
+    return (
+        <DataGridToolbar>
+            <ToolbarItem>
+                <GridFilterButton />
+            </ToolbarItem>
+        </DataGridToolbar>
+    );
+}
+
 export function GlobalActionLogGrid() {
     const intl = useIntl();
     const { values: scopeValues } = useContentScope();
@@ -35,6 +145,29 @@ export function GlobalActionLogGrid() {
         ...useDataGridRemote({ initialSort: [{ field: "createdAt", sort: "desc" }] }),
         ...usePersistentColumnState("GlobalActionLogGrid"),
     };
+
+    const formatScopeLabel = useMemo(
+        () =>
+            (scope: ContentScope): string => {
+                const matched = scopeValues.find((item) => isEqual(item.scope, scope));
+                const source = matched ?? { scope, label: undefined as Record<string, string> | undefined };
+                return Object.keys(source.scope)
+                    .map((key) => source.label?.[key] ?? capitalCase(String(source.scope[key])))
+                    .join(" / ");
+            },
+        [scopeValues],
+    );
+
+    const scopeValueOptions = useMemo(
+        () => [
+            { value: JSON.stringify(null), label: intl.formatMessage(messages.globalContentScope) },
+            ...scopeValues.map((item) => ({
+                value: JSON.stringify(item.scope),
+                label: formatScopeLabel(item.scope),
+            })),
+        ],
+        [intl, scopeValues, formatScopeLabel],
+    );
 
     const columns = useMemo<GridColDef<GQLGlobalActionLogGridFragment>[]>(
         () => [
@@ -47,8 +180,8 @@ export function GlobalActionLogGrid() {
             {
                 field: "scope",
                 headerName: intl.formatMessage({ id: "comet.globalActionLog.columns.scope", defaultMessage: "Scope" }),
-                sortable: false,
-                filterable: false,
+                filterOperators: scopeFilterOperators,
+                toGqlFilter: scopeColumnToGqlFilter,
                 width: 150,
                 renderCell: ({ row }) => <ScopeCell scopes={row.scope} />,
             },
@@ -87,12 +220,15 @@ export function GlobalActionLogGrid() {
         [intl],
     );
 
+    const { filter: gqlFilter } = muiGridFilterToGql(columns, dataGridProps.filterModel);
+
     const scopes = useMemo(() => scopeValues.map((item) => item.scope), [scopeValues]);
 
     const { data, loading, error } = useQuery<GQLGlobalActionLogGridQuery, GQLGlobalActionLogGridQueryVariables>(globalActionLogGridQuery, {
         variables: {
             offset: dataGridProps.paginationModel.page * dataGridProps.paginationModel.pageSize,
             limit: dataGridProps.paginationModel.pageSize,
+            filter: gqlFilter,
             scopes,
             sort: muiGridSortToGql(dataGridProps.sortModel),
         },
@@ -105,19 +241,21 @@ export function GlobalActionLogGrid() {
     }
 
     return (
-        <MainContent fullHeight>
-            <DataGrid
-                {...dataGridProps}
-                columns={columns}
-                rows={data?.actionLogs.nodes ?? []}
-                rowCount={rowCount}
-                loading={loading}
-                disableRowSelectionOnClick
-                onRowClick={({ row }) => setOpenVersionId(row.id)}
-                slots={{ toolbar: DataGridToolbar }}
-                showToolbar
-            />
-            <GlobalActionLogShowVersionDialog actionLogId={openVersionId} open={openVersionId !== null} onClose={() => setOpenVersionId(null)} />
-        </MainContent>
+        <ScopeFilterOptionsContext.Provider value={scopeValueOptions}>
+            <MainContent fullHeight>
+                <DataGrid
+                    {...dataGridProps}
+                    columns={columns}
+                    rows={data?.actionLogs.nodes ?? []}
+                    rowCount={rowCount}
+                    loading={loading}
+                    disableRowSelectionOnClick
+                    onRowClick={({ row }) => setOpenVersionId(row.id)}
+                    slots={{ toolbar: GlobalActionLogGridToolbar }}
+                    showToolbar
+                />
+                <GlobalActionLogShowVersionDialog actionLogId={openVersionId} open={openVersionId !== null} onClose={() => setOpenVersionId(null)} />
+            </MainContent>
+        </ScopeFilterOptionsContext.Provider>
     );
 }

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -621,6 +621,7 @@ input ActionLogFilter {
   entityName: StringFilter
   version: NumberFilter
   createdAt: DateTimeFilter
+  scope: ActionLogScopeFilter
   and: [ActionLogFilter!]
   or: [ActionLogFilter!]
 }
@@ -654,6 +655,13 @@ input DateTimeFilter {
   isNotEmpty: Boolean
 }
 
+input ActionLogScopeFilter {
+  isAnyOf: [JSONObject!]
+  equal: JSONObject
+  notEqual: JSONObject
+  isGlobal: Boolean
+}
+
 input ActionLogSort {
   field: ActionLogSortField!
   direction: SortDirection! = ASC
@@ -662,6 +670,8 @@ input ActionLogSort {
 enum ActionLogSortField {
   version
   createdAt
+  entityName
+  scope
 }
 
 input RedirectScopeInput {

--- a/packages/api/cms-api/src/action-logs/action-logs-filter.utils.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs-filter.utils.ts
@@ -1,0 +1,44 @@
+import type { ObjectQuery } from "@mikro-orm/postgresql";
+
+import { filtersToMikroOrmQuery } from "../common/filter/mikro-orm";
+import type { ActionLogFilter } from "./dto/action-log.filter";
+import type { ActionLog } from "./entities/action-log.entity";
+
+export function actionLogFilterToWhere(filter: ActionLogFilter): ObjectQuery<ActionLog> {
+    const andConditions: ObjectQuery<ActionLog>[] = [];
+
+    if (filter.scope) {
+        if (filter.scope.isGlobal === true) {
+            andConditions.push({ scope: null });
+        }
+        if (filter.scope.equal !== undefined) {
+            andConditions.push({ scope: { $contains: [filter.scope.equal] } });
+        }
+        if (filter.scope.isAnyOf !== undefined && filter.scope.isAnyOf.length > 0) {
+            andConditions.push({ $or: filter.scope.isAnyOf.map((scope) => ({ scope: { $contains: [scope] } })) });
+        }
+        if (filter.scope.notEqual !== undefined) {
+            andConditions.push({ $not: { scope: { $contains: [filter.scope.notEqual] } } });
+        }
+    }
+
+    const { scope: _scope, and, or, ...rest } = filter;
+    if (Object.keys(rest).length > 0) {
+        andConditions.push(filtersToMikroOrmQuery(rest));
+    }
+
+    if (and && and.length > 0) {
+        andConditions.push({ $and: and.map(actionLogFilterToWhere) });
+    }
+    if (or && or.length > 0) {
+        andConditions.push({ $or: or.map(actionLogFilterToWhere) });
+    }
+
+    if (andConditions.length === 0) {
+        return {};
+    }
+    if (andConditions.length === 1) {
+        return andConditions[0];
+    }
+    return { $and: andConditions };
+}

--- a/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
@@ -4,10 +4,11 @@ import { Args, ID, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql
 import isEqual from "lodash.isequal";
 
 import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
-import { filtersToMikroOrmQuery, gqlSortToMikroOrmOrderBy, searchToMikroOrmQuery } from "../common/filter/mikro-orm";
+import { gqlSortToMikroOrmOrderBy, searchToMikroOrmQuery } from "../common/filter/mikro-orm";
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
 import { CurrentUser } from "../user-permissions/dto/current-user";
 import { UserPermissionsService } from "../user-permissions/user-permissions.service";
+import { actionLogFilterToWhere } from "./action-logs-filter.utils";
 import { ActionLogType } from "./dto/action-log-type.enum";
 import { ActionLogsUser } from "./dto/action-logs-user";
 import { GlobalActionLogsArgs } from "./dto/global-action-logs.args";
@@ -45,7 +46,7 @@ export class ActionLogsResolver {
         }
 
         if (filter) {
-            andFilters.push(filtersToMikroOrmQuery(filter));
+            andFilters.push(actionLogFilterToWhere(filter));
         }
 
         // Use $contained (<@) so a row's scope must be a subset of one of the user's allowed scopes.

--- a/packages/api/cms-api/src/action-logs/dto/action-log.filter.ts
+++ b/packages/api/cms-api/src/action-logs/dto/action-log.filter.ts
@@ -1,12 +1,33 @@
 import { Field, InputType } from "@nestjs/graphql";
 import { Type } from "class-transformer";
-import { ValidateNested } from "class-validator";
+import { IsOptional, ValidateNested } from "class-validator";
+import { GraphQLJSONObject } from "graphql-scalars";
 
 import { DateTimeFilter } from "../../common/filter/date-time.filter";
 import { IdFilter } from "../../common/filter/id.filter";
 import { NumberFilter } from "../../common/filter/number.filter";
 import { StringFilter } from "../../common/filter/string.filter";
 import { IsUndefinable } from "../../common/validators/is-undefinable";
+import { ContentScope } from "../../user-permissions/interfaces/content-scope.interface";
+
+@InputType({ isAbstract: true })
+class ActionLogScopeFilter {
+    @Field(() => [GraphQLJSONObject], { nullable: true })
+    @IsOptional()
+    isAnyOf?: ContentScope[];
+
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    @IsOptional()
+    equal?: ContentScope;
+
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    @IsOptional()
+    notEqual?: ContentScope;
+
+    @Field(() => Boolean, { nullable: true })
+    @IsOptional()
+    isGlobal?: boolean;
+}
 
 @InputType()
 export class ActionLogFilter {
@@ -39,6 +60,10 @@ export class ActionLogFilter {
     @Type(() => DateTimeFilter)
     @IsUndefinable()
     createdAt?: DateTimeFilter;
+
+    @Field(() => ActionLogScopeFilter, { nullable: true })
+    @IsOptional()
+    scope?: ActionLogScopeFilter;
 
     @Field(() => [ActionLogFilter], { nullable: true })
     @ValidateNested({ each: true })

--- a/packages/api/cms-api/src/action-logs/dto/action-log.sort.ts
+++ b/packages/api/cms-api/src/action-logs/dto/action-log.sort.ts
@@ -6,6 +6,8 @@ import { SortDirection } from "../../common/sorting/sort-direction.enum";
 enum ActionLogSortField {
     version = "version",
     createdAt = "createdAt",
+    entityName = "entityName",
+    scope = "scope",
 }
 registerEnumType(ActionLogSortField, {
     name: "ActionLogSortField",


### PR DESCRIPTION
Jira: [COM-3006](https://vivid-planet.atlassian.net/browse/COM-3006)

## Summary

Extends the Global Action Log view with the ability to filter and sort by content scope. The Scope column gets an autocomplete-style filter that lists every scope the user has access to plus a "Global" entry for unscoped entities.

## Screencast

<img width="2784" height="3044" alt="Screen Recording 2026-07-15 at 09 37 41" src="https://github.com/user-attachments/assets/2de9b491-43dc-4eac-8ffc-d2d7b3d93bd8"/>

## Depends on

- #5861 — the base Global Action Log view (the grid and resolver this PR extends).

---
_Generated by [Claude Code](https://claude.ai/code/session_012YKxucGjjtFStey4ZggbDi)_

[COM-3006]: ``https://vivid-planet.atlassian.net/browse/COM-3006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ``