### PR TITLE
cms-api: Batch ActionLog.user lookups via DataLoader

### DIFF
--- a/.changeset/batch-action-log-user-lookups.md
+++ b/.changeset/batch-action-log-user-lookups.md
@@ -1,0 +1,9 @@
+---
+"@comet/cms-api": patch
+---
+
+Batch user lookups in `ActionLog.user` resolver via DataLoader
+
+When loading a list of action log entries, the `user` resolve-field previously
+issued one `findUser` call per row sequentially. The lookups are now batched
+through a request-scoped DataLoader and run concurrently.

--- a/.changeset/batch-action-log-user-lookups.md
+++ b/.changeset/batch-action-log-user-lookups.md
@@ -1,9 +1,0 @@
----
-"@comet/cms-api": patch
----
-
-Batch user lookups in `ActionLog.user` resolver via DataLoader
-
-When loading a list of action log entries, the `user` resolve-field previously
-issued one `findUser` call per row sequentially. The lookups are now batched
-through a request-scoped DataLoader and run concurrently.

--- a/demo/api/src/auth/user.service.ts
+++ b/demo/api/src/auth/user.service.ts
@@ -22,6 +22,9 @@ export class UserService implements UserPermissionsUserServiceInterface, JwtToUs
         }
         return user;
     }
+    findUsersByIds(ids: string[]): Array<User | null> {
+        return ids.map((id) => this.findUser(id));
+    }
     findUsers(args: FindUsersArgs): Users {
         const search = args.search?.toLowerCase();
         const users = staticUsers.filter((user) => !search || user.name.toLowerCase().includes(search) || user.email.toLowerCase().includes(search));

--- a/packages/api/cms-api/src/action-logs/action-logs-user-loader.service.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs-user-loader.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Scope } from "@nestjs/common";
 import DataLoader from "dataloader";
 
+import { User } from "../user-permissions/interfaces/user";
 import { UserPermissionsService } from "../user-permissions/user-permissions.service";
 import { ActionLogsUser } from "./dto/action-logs-user";
 
@@ -10,15 +11,22 @@ export class ActionLogsUserLoaderService {
 
     constructor(private readonly userPermissionsService: UserPermissionsService) {
         this.dataLoader = new DataLoader<string, ActionLogsUser>(async (userIds) => {
-            return Promise.all(
-                userIds.map(async (userId) => {
-                    if (this.userPermissionsService.isSystemUser(userId)) {
-                        return { id: userId, name: userId };
-                    }
-                    const user = await this.userPermissionsService.findUser(userId);
-                    return user ? { id: user.id, name: user.name } : { id: userId };
-                }),
-            );
+            const idsToLookUp = userIds.filter((userId) => !this.userPermissionsService.isSystemUser(userId));
+            const users = await this.userPermissionsService.findUsersByIds(idsToLookUp);
+            const usersById = new Map<string, User>();
+            for (const [index, userId] of idsToLookUp.entries()) {
+                const user = users[index];
+                if (user) {
+                    usersById.set(userId, user);
+                }
+            }
+            return userIds.map((userId) => {
+                if (this.userPermissionsService.isSystemUser(userId)) {
+                    return { id: userId, name: userId };
+                }
+                const user = usersById.get(userId);
+                return user ? { id: user.id, name: user.name } : { id: userId };
+            });
         });
     }
 

--- a/packages/api/cms-api/src/action-logs/action-logs-user-loader.service.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs-user-loader.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, Scope } from "@nestjs/common";
+import DataLoader from "dataloader";
+
+import { UserPermissionsService } from "../user-permissions/user-permissions.service";
+import { ActionLogsUser } from "./dto/action-logs-user";
+
+@Injectable({ scope: Scope.REQUEST })
+export class ActionLogsUserLoaderService {
+    private dataLoader: DataLoader<string, ActionLogsUser>;
+
+    constructor(private readonly userPermissionsService: UserPermissionsService) {
+        this.dataLoader = new DataLoader<string, ActionLogsUser>(async (userIds) => {
+            return Promise.all(
+                userIds.map(async (userId) => {
+                    if (this.userPermissionsService.isSystemUser(userId)) {
+                        return { id: userId, name: userId };
+                    }
+                    const user = await this.userPermissionsService.findUser(userId);
+                    return user ? { id: user.id, name: user.name } : { id: userId };
+                }),
+            );
+        });
+    }
+
+    load(userId: string): Promise<ActionLogsUser> {
+        return this.dataLoader.load(userId);
+    }
+}

--- a/packages/api/cms-api/src/action-logs/action-logs.module.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.module.ts
@@ -7,6 +7,7 @@ import { ActionLogsResolverFactory } from "./action-logs.resolver.factory";
 import { ActionLogsService } from "./action-logs.service";
 import { ActionLogsSubscriber } from "./action-logs.subscriber";
 import { ActionLogsFeatureModule } from "./action-logs-feature.module";
+import { ActionLogsUserLoaderService } from "./action-logs-user-loader.service";
 import { ActionLog } from "./entities/action-log.entity";
 import { PreviousActionLogLoaderService } from "./previous-action-log-loader.service";
 
@@ -15,7 +16,7 @@ export class ActionLogsModule {
         return {
             module: ActionLogsModule,
             imports: [MikroOrmModule.forFeature([ActionLog])],
-            providers: [ActionLogsSubscriber, ActionLogsService, ActionLogsResolver, PreviousActionLogLoaderService],
+            providers: [ActionLogsSubscriber, ActionLogsService, ActionLogsResolver, PreviousActionLogLoaderService, ActionLogsUserLoaderService],
         };
     }
 

--- a/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
+++ b/packages/api/cms-api/src/action-logs/action-logs.resolver.ts
@@ -1,6 +1,6 @@
 import { Parent, ResolveField, Resolver } from "@nestjs/graphql";
 
-import { UserPermissionsService } from "../user-permissions/user-permissions.service";
+import { ActionLogsUserLoaderService } from "./action-logs-user-loader.service";
 import { ActionLogType } from "./dto/action-log-type.enum";
 import { ActionLogsUser } from "./dto/action-logs-user";
 import { ActionLog } from "./entities/action-log.entity";
@@ -9,8 +9,8 @@ import { PreviousActionLogLoaderService } from "./previous-action-log-loader.ser
 @Resolver(() => ActionLog)
 export class ActionLogsResolver {
     constructor(
-        private readonly userPermissionsService: UserPermissionsService,
         private readonly previousActionLogLoader: PreviousActionLogLoaderService,
+        private readonly actionLogsUserLoader: ActionLogsUserLoaderService,
     ) {}
 
     @ResolveField(() => ActionLog, {
@@ -39,10 +39,6 @@ export class ActionLogsResolver {
 
     @ResolveField(() => ActionLogsUser)
     async user(@Parent() actionLog: ActionLog): Promise<ActionLogsUser> {
-        if (this.userPermissionsService.isSystemUser(actionLog.userId)) {
-            return { id: actionLog.userId, name: actionLog.userId };
-        }
-        const user = await this.userPermissionsService.findUser(actionLog.userId);
-        return user ? { id: user.id, name: user.name } : { id: actionLog.userId };
+        return this.actionLogsUserLoader.load(actionLog.userId);
     }
 }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.spec.ts
@@ -85,4 +85,27 @@ describe("UserPermissionsService", () => {
             await expect(service.findUser("abc")).rejects.toThrow(/userService/);
         });
     });
+
+    describe("findUsersByIds", () => {
+        const userA: User = { id: "a", name: "User A", email: "a@example.com" };
+        const userB: User = { id: "b", name: "User B", email: "b@example.com" };
+
+        it("uses findUsersByIds of the userService and returns users in the order of the passed ids", async () => {
+            const userService = { findUsersByIds: vi.fn().mockResolvedValue([userB, userA]), findUsers: vi.fn() };
+            const service = createService({ userService });
+
+            await expect(service.findUsersByIds(["a", "missing", "b"])).resolves.toEqual([userA, null, userB]);
+            expect(userService.findUsersByIds).toHaveBeenCalledTimes(1);
+            expect(userService.findUsersByIds).toHaveBeenCalledWith(["a", "missing", "b"]);
+        });
+
+        it("falls back to findUser per id when the userService doesn't implement findUsersByIds", async () => {
+            const findUser = vi.fn().mockImplementation((id: string) => (id === "a" ? userA : null));
+            const userService = { findUser, findUsers: vi.fn() };
+            const service = createService({ userService });
+
+            await expect(service.findUsersByIds(["a", "missing"])).resolves.toEqual([userA, null]);
+            expect(findUser).toHaveBeenCalledTimes(2);
+        });
+    });
 });

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -139,6 +139,19 @@ export class UserPermissionsService {
         throw new Error("For this functionality you need to define `findUser` (or the deprecated `getUser`) in the userService.");
     }
 
+    async findUsersByIds(ids: string[]): Promise<Array<User | null>> {
+        if (this.userService?.findUsersByIds) {
+            const usersById = new Map<string, User>();
+            for (const user of await this.userService.findUsersByIds(ids)) {
+                if (user) {
+                    usersById.set(user.id, user);
+                }
+            }
+            return ids.map((id) => usersById.get(id) ?? null);
+        }
+        return Promise.all(ids.map((id) => this.findUser(id)));
+    }
+
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {
         if (!this.userService) {
             throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -44,6 +44,11 @@ export interface UserPermissionsUserServiceInterface {
      */
     findUserForLoginOrThrow?: (id: string) => Promise<User> | User;
     findUserOrThrow?: (id: string) => Promise<User> | User;
+    /**
+     * Optional method to look up multiple users at once, allowing user lookups to be batched (e.g. in a single request to an identity provider).
+     * The result does not need to match the order of the passed ids; missing users may be omitted or returned as null.
+     */
+    findUsersByIds?: (ids: string[]) => Promise<Array<User | null>> | Array<User | null>;
     findUsers: (args: FindUsersArgs) => Promise<Users> | Users;
     /**
      * @deprecated Implement `findUser` and `findUserOrThrow` instead.


### PR DESCRIPTION
## Summary

Resolves the N+1 issue when a GraphQL query returns a list of `ActionLog` entries: the `user` resolve-field previously issued one `findUser` call per row.

The fix follows the same pattern as the existing request-scoped DataLoader services in cms-api (`AttachedDocumentLoaderService`, `PreviousActionLogLoaderService`): collect the keys of a request, resolve them with a single backend call, map the results back per key.

Two parts:

- The `user` resolve-field now goes through a request-scoped `DataLoader`, which deduplicates and caches user ids within a request.
- New optional `findUsersByIds(ids)` method on `UserPermissionsUserServiceInterface` — needed because, unlike the other loaders, this one can't batch via MikroORM: the user store is project-defined. When a project's user service implements it, all distinct user ids of a request are resolved in a **single** lookup (e.g. one request to an identity provider). When not implemented, `UserPermissionsService.findUsersByIds` falls back to per-id `findUser` calls, preserving today's behavior — fully backwards compatible.

The demo `UserService` implements `findUsersByIds` as a reference. Unit tests cover both the delegation and the fallback path.