### PR TITLE
Fix auto assigning

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -3,7 +3,7 @@ addAssignees: author
 addReviewers: true
 
 reviewers:
-    - johnnyomair
+    - VPS-Obi
 
 skipKeywords:
     - Merge main into next

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,10 @@
+name: "Auto Assign"
+on:
+    pull_request:
+        types: [opened, ready_for_review]
+
+jobs:
+    auto-assign:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: kentaro-m/auto-assign-action@v2.0.2


### PR DESCRIPTION
Auto assigning via the GitHub app is broken (see https://github.com/kentaro-m/auto-assign/issues/295). Using the GitHub action should work.