### PR TITLE
Remove deprecated @calm/eslint-plugin-react-intl

### DIFF
--- a/.changeset/remove-eslint-plugin-react-intl.md
+++ b/.changeset/remove-eslint-plugin-react-intl.md
@@ -1,0 +1,7 @@
+---
+"@comet/eslint-config": major
+---
+
+Remove the deprecated `@calm/eslint-plugin-react-intl` plugin
+
+The `@calm/eslint-plugin-react-intl` package is deprecated. Its `missing-formatted-message` rule enforced that user-facing strings are masked with `FormattedMessage`. This is now sufficiently covered by the `react/jsx-no-literals` rule, which is already part of the config.

--- a/.changeset/remove-eslint-plugin-react-intl.md
+++ b/.changeset/remove-eslint-plugin-react-intl.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/eslint-config": major
+---
+
+Remove the deprecated `@calm/eslint-plugin-react-intl` plugin
+
+The `@calm/eslint-plugin-react-intl` package is deprecated. Its `missing-formatted-message` rule enforced that user-facing strings are masked with `FormattedMessage`. This is now sufficiently covered by the `react/jsx-no-literals` rule, which is already part of the config.

--- a/docs/docs/2-core-concepts/6-internationalization/index.mdx
+++ b/docs/docs/2-core-concepts/6-internationalization/index.mdx
@@ -11,7 +11,7 @@ The following page describes core translation concepts. We use [FormatJS](https:
 
 ## Masking strings
 
-All strings that should be translated must be masked using [`<FormattedMessage />`](https://formatjs.io/docs/react-intl/components#formattedmessage) or, if not possible, [`intl.formatMessage()`](https://formatjs.io/docs/react-intl/api#formatmessage). To ensure that all strings are translated we use [`@calm/eslint-plugin-react-intl`](https://www.npmjs.com/package/@calm/eslint-plugin-react-intl).
+All strings that should be translated must be masked using [`<FormattedMessage />`](https://formatjs.io/docs/react-intl/components#formattedmessage) or, if not possible, [`intl.formatMessage()`](https://formatjs.io/docs/react-intl/api#formatmessage). To ensure that all strings are translated we use the [`react/jsx-no-literals`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md) ESLint rule.
 
 A stable and unique ID must be used to identify the string. IDs must be prefixed with a project identifier to prevent clashes with other translations. IDs must be named camelCase with dots representing hierarchy.
 

--- a/docs/docs/2-core-concepts/6-internationalization/index.mdx
+++ b/docs/docs/2-core-concepts/6-internationalization/index.mdx
@@ -11,7 +11,7 @@ The following page describes core translation concepts. We use [FormatJS](https:
 
 ## Masking strings
 
-All strings that should be translated must be masked using [`<FormattedMessage />`](https://formatjs.io/docs/react-intl/components#formattedmessage) or, if not possible, [`intl.formatMessage()`](https://formatjs.io/docs/react-intl/api#formatmessage). To ensure that all strings are translated we use [`@calm/eslint-plugin-react-intl`](https://www.npmjs.com/package/@calm/eslint-plugin-react-intl).
+All strings that should be translated must be masked using [`<FormattedMessage />`](https://formatjs.io/docs/react-intl/components#formattedmessage) or, if not possible, [`intl.formatMessage()`](https://formatjs.io/docs/react-intl/api#formatmessage). To ensure that all strings are translated we use the [`react/jsx-no-literals`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md) ESLint rule.
 
 A stable and unique ID must be used to identify the string. IDs must be named camelCase with dots representing hierarchy. Dextinity's own messages are prefixed with `dextinity.`, so don't use that prefix in your application to prevent clashes.
 

--- a/docs/docs/7-migration-guide/migration-from-v10-to-v11.md
+++ b/docs/docs/7-migration-guide/migration-from-v10-to-v11.md
@@ -1,0 +1,77 @@
+---
+title: Migrating from v10 to v11
+sidebar_position: -11
+---
+
+# Migrating from v10 to v11
+
+:::info AI-Assisted Migration
+
+This migration guide is designed to be executed by an AI coding agent (e.g., Claude Code). Each section contains structured, step-by-step instructions that an agent can follow to perform the migration automatically.
+
+**Sample prompt to get started:**
+
+```
+Migrate this project from Dextinity v10 to v11. Follow the migration guide at https://cms-docs.dextinity.com/docs/migration-guide/migration-from-v10-to-v11 step by step. Work through each section sequentially, making the required changes and running any verification commands. Commit after each major section.
+```
+
+:::
+
+## What changes in v11
+
+This guide is a work in progress and is extended as breaking changes land on the next major.
+
+## Linting
+
+### Remove the `@calm/react-intl/missing-formatted-message` ESLint rule
+
+`@dextinity/eslint-config` no longer bundles the deprecated [`@calm/eslint-plugin-react-intl`](https://www.npmjs.com/package/@calm/eslint-plugin-react-intl) plugin. Enforcing that user-facing strings are masked with `<FormattedMessage />` is now covered by [`react/jsx-no-literals`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md), which the config already enables.
+
+Because the rule no longer exists, any project that still references it fails linting: a rule override throws `Definition for rule '@calm/react-intl/missing-formatted-message' was not found`, and a disable comment becomes an unused-directive report (an error under `--max-warnings 0`).
+
+Remove the rule from your own ESLint config(s). Find the overrides:
+
+```sh
+git grep -n "@calm/react-intl/missing-formatted-message" -- "*eslint.config*" ".eslintrc*"
+```
+
+```diff title="eslint.config.mjs"
+  {
+      files: ["**/*.stories.tsx", "**/*.test.tsx"],
+      rules: {
+-         "@calm/react-intl/missing-formatted-message": "off",
+          "react/jsx-no-literals": "off",
+      },
+  },
+```
+
+Then update the inline disable comments. Find them:
+
+```sh
+git grep -n "@calm/react-intl/missing-formatted-message"
+```
+
+Drop the rule from each `eslint-disable*` comment. If it was combined with `react/jsx-no-literals`, keep that one; if it was the only rule listed, remove the whole comment:
+
+```diff
+- {/* eslint-disable-next-line @calm/react-intl/missing-formatted-message,react/jsx-no-literals */}
++ {/* eslint-disable-next-line react/jsx-no-literals */}
+```
+
+Finally, if your project's `package.json` depends on `@calm/eslint-plugin-react-intl` directly (it was previously pulled in transitively through `@dextinity/eslint-config`), remove it:
+
+```sh
+npm uninstall @calm/eslint-plugin-react-intl
+```
+
+:::note
+
+`react/jsx-no-literals` covers untranslated JSX text, but the removed rule's `enforceLabels` option additionally flagged some string attributes (such as `label`, `title` and `placeholder`). Those are no longer enforced automatically — review any remaining untranslated attribute strings manually.
+
+:::
+
+### Verify
+
+```sh
+npm run lint
+```

--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -6,7 +6,6 @@ export default defineConfig([
     ...eslintConfigReact,
     {
         rules: {
-            "@calm/react-intl/missing-formatted-message": "off",
             "react/jsx-no-literals": "off",
         },
     },

--- a/packages/admin/admin/eslint.config.mjs
+++ b/packages/admin/admin/eslint.config.mjs
@@ -28,7 +28,6 @@ export default defineConfig([
     {
         files: ["**/*.test.ts", "**/*.test.tsx"],
         rules: {
-            "@calm/react-intl/missing-formatted-message": "off",
             "no-restricted-imports": [
                 "error",
                 {
@@ -55,7 +54,6 @@ export default defineConfig([
     {
         files: ["**/*.stories.ts", "**/*.stories.tsx"],
         rules: {
-            "@calm/react-intl/missing-formatted-message": "off",
             "@typescript-eslint/no-empty-function": "off",
             "@typescript-eslint/no-explicit-any": "off",
             "@typescript-eslint/no-non-null-assertion": "off",

--- a/packages/admin/cms-admin/eslint.config.mjs
+++ b/packages/admin/cms-admin/eslint.config.mjs
@@ -45,7 +45,6 @@ export default defineConfig([
     {
         files: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
         rules: {
-            "@calm/react-intl/missing-formatted-message": "off",
             "no-restricted-imports": [
                 "error",
                 {
@@ -64,7 +63,6 @@ export default defineConfig([
     {
         files: ["**/*.stories.ts", "**/*.stories.tsx"],
         rules: {
-            "@calm/react-intl/missing-formatted-message": "off",
             "@typescript-eslint/no-empty-function": "off",
             "@typescript-eslint/no-explicit-any": "off",
             "@typescript-eslint/no-non-null-assertion": "off",

--- a/packages/admin/cms-admin/src/common/header/about/AboutModal.tsx
+++ b/packages/admin/cms-admin/src/common/header/about/AboutModal.tsx
@@ -67,7 +67,7 @@ export function AboutModal({ open, onClose, logo = <CometDigitalExperienceLogo s
                     </Typography>
 
                     <Link href="https://www.vivid-planet.com" target="_blank" underline="hover">
-                        {/* eslint-disable-next-line @calm/react-intl/missing-formatted-message,react/jsx-no-literals */}
+                        {/* eslint-disable-next-line react/jsx-no-literals */}
                         <Typography>www.vivid-planet.com</Typography>
                     </Link>
                 </DialogContent>

--- a/packages/admin/cms-admin/src/common/header/about/AboutModal.tsx
+++ b/packages/admin/cms-admin/src/common/header/about/AboutModal.tsx
@@ -67,7 +67,7 @@ export function AboutModal({ open, onClose, logo = <DextinityLogo sx={{ fontSize
                     </Typography>
 
                     <Link href="https://www.vivid-planet.com" target="_blank" underline="hover">
-                        {/* eslint-disable-next-line @calm/react-intl/missing-formatted-message,react/jsx-no-literals */}
+                        {/* eslint-disable-next-line react/jsx-no-literals */}
                         <Typography>www.vivid-planet.com</Typography>
                     </Link>
                 </DialogContent>

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -42,7 +42,6 @@
         "lint:prettier": "pnpm exec prettier --check '*.{ts,js,json,md,yml,yaml}'"
     },
     "dependencies": {
-        "@calm/eslint-plugin-react-intl": "^1.4.1",
         "@comet/eslint-plugin": "workspace:*",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^9.39.4",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -42,7 +42,6 @@
         "lint:prettier": "pnpm exec prettier --check '*.{ts,js,json,md,yml,yaml}'"
     },
     "dependencies": {
-        "@calm/eslint-plugin-react-intl": "^1.4.1",
         "@dextinity/eslint-plugin": "workspace:*",
         "@eslint/eslintrc": "^3.3.6",
         "@eslint/js": "^9.39.5",

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -1,5 +1,4 @@
 import coreConfig, { restrictedImportPatterns } from "./core.js";
-import reactIntlFormatPlugin from "@calm/eslint-plugin-react-intl";
 import globals from "globals";
 import formatJs from "eslint-plugin-formatjs";
 import graphqlPlugin from "@graphql-eslint/eslint-plugin";
@@ -69,22 +68,11 @@ const config = [
     ...coreConfig,
     {
         plugins: {
-            "@calm/react-intl": reactIntlFormatPlugin,
-        },
-    },
-    {
-        plugins: {
             formatjs: formatJs,
         },
         rules: {
             "formatjs/enforce-default-message": ["error", "literal"],
             "formatjs/enforce-placeholders": "error",
-        },
-    },
-    {
-        files: ["**/*.ts", "**/*.tsx"],
-        rules: {
-            "@calm/react-intl/missing-formatted-message": ["error", { enforceLabels: true }],
         },
     },
     {

--- a/packages/mail-react/eslint.config.mjs
+++ b/packages/mail-react/eslint.config.mjs
@@ -12,7 +12,6 @@ export default defineConfig([
     {
         files: ["src/**/*.stories.tsx", "src/**/*.test.ts", "src/**/*.test.tsx", "src/storybook/**"],
         rules: {
-            "@calm/react-intl/missing-formatted-message": "off",
             "react/jsx-no-literals": "off",
         },
     },

--- a/packages/mail-react/src/blocks/factories/BlocksBlock.tsx
+++ b/packages/mail-react/src/blocks/factories/BlocksBlock.tsx
@@ -20,7 +20,7 @@ export const BlocksBlock = ({ supportedBlocks, data: { blocks } }: Props) => {
                     if (process.env.NODE_ENV === "development") {
                         return (
                             <MjmlText key={block.key}>
-                                {/* eslint-disable-next-line @calm/react-intl/missing-formatted-message,react/jsx-no-literals */}
+                                {/* eslint-disable-next-line react/jsx-no-literals */}
                                 {/* eslint-disable-next-line react/jsx-no-literals */}
                                 Unknown type ({block.type}): {JSON.stringify(block.props)}
                             </MjmlText>

--- a/packages/mail-react/src/blocks/factories/BlocksBlock.tsx
+++ b/packages/mail-react/src/blocks/factories/BlocksBlock.tsx
@@ -18,13 +18,7 @@ export const BlocksBlock = ({ supportedBlocks, data: { blocks } }: Props) => {
 
                 if (!blockFunction) {
                     if (process.env.NODE_ENV === "development") {
-                        return (
-                            <MjmlText key={block.key}>
-                                {/* eslint-disable-next-line react/jsx-no-literals */}
-                                {/* eslint-disable-next-line react/jsx-no-literals */}
-                                Unknown type ({block.type}): {JSON.stringify(block.props)}
-                            </MjmlText>
-                        );
+                        return <MjmlText key={block.key}>{`Unknown type (${block.type}): ${JSON.stringify(block.props)}`}</MjmlText>;
                     }
 
                     return null;

--- a/packages/mail-react/src/blocks/factories/OneOfBlock.tsx
+++ b/packages/mail-react/src/blocks/factories/OneOfBlock.tsx
@@ -24,13 +24,7 @@ export const OneOfBlock = ({ data: { block, ...additionalProps }, supportedBlock
 
     if (!blockFunction) {
         if (process.env.NODE_ENV === "development") {
-            return (
-                <MjmlText>
-                    {/* eslint-disable-next-line react/jsx-no-literals */}
-                    {/* eslint-disable-next-line react/jsx-no-literals */}
-                    Unknown type ({block.type}): {JSON.stringify(block.props)}
-                </MjmlText>
-            );
+            return <MjmlText>{`Unknown type (${block.type}): ${JSON.stringify(block.props)}`}</MjmlText>;
         }
 
         return null;

--- a/packages/mail-react/src/blocks/factories/OneOfBlock.tsx
+++ b/packages/mail-react/src/blocks/factories/OneOfBlock.tsx
@@ -26,7 +26,7 @@ export const OneOfBlock = ({ data: { block, ...additionalProps }, supportedBlock
         if (process.env.NODE_ENV === "development") {
             return (
                 <MjmlText>
-                    {/* eslint-disable-next-line @calm/react-intl/missing-formatted-message,react/jsx-no-literals */}
+                    {/* eslint-disable-next-line react/jsx-no-literals */}
                     {/* eslint-disable-next-line react/jsx-no-literals */}
                     Unknown type ({block.type}): {JSON.stringify(block.props)}
                 </MjmlText>

--- a/packages/site/site-react/src/blocks/factories/BlocksBlock.tsx
+++ b/packages/site/site-react/src/blocks/factories/BlocksBlock.tsx
@@ -23,13 +23,7 @@ export const BlocksBlock = ({ supportedBlocks, data: { blocks } }: Props) => {
 
                 if (!blockFunction) {
                     if (process.env.NODE_ENV === "development") {
-                        return (
-                            <pre key={block.key}>
-                                {/* eslint-disable-next-line react/jsx-no-literals */}
-                                {/* eslint-disable-next-line react/jsx-no-literals */}
-                                Unknown type ({block.type}): {JSON.stringify(block.props)}
-                            </pre>
-                        );
+                        return <pre key={block.key}>{`Unknown type (${block.type}): ${JSON.stringify(block.props)}`}</pre>;
                     }
 
                     return null;

--- a/packages/site/site-react/src/blocks/factories/BlocksBlock.tsx
+++ b/packages/site/site-react/src/blocks/factories/BlocksBlock.tsx
@@ -25,7 +25,7 @@ export const BlocksBlock = ({ supportedBlocks, data: { blocks } }: Props) => {
                     if (process.env.NODE_ENV === "development") {
                         return (
                             <pre key={block.key}>
-                                {/* eslint-disable-next-line @calm/react-intl/missing-formatted-message,react/jsx-no-literals */}
+                                {/* eslint-disable-next-line react/jsx-no-literals */}
                                 {/* eslint-disable-next-line react/jsx-no-literals */}
                                 Unknown type ({block.type}): {JSON.stringify(block.props)}
                             </pre>

--- a/packages/site/site-react/src/blocks/factories/OneOfBlock.tsx
+++ b/packages/site/site-react/src/blocks/factories/OneOfBlock.tsx
@@ -24,13 +24,7 @@ export const OneOfBlock = ({ data: { block, ...additionalProps }, supportedBlock
 
     if (!blockFunction) {
         if (process.env.NODE_ENV === "development") {
-            return (
-                <pre>
-                    {/* eslint-disable-next-line react/jsx-no-literals */}
-                    {/* eslint-disable-next-line react/jsx-no-literals */}
-                    Unknown type ({block.type}): {JSON.stringify(block.props)}
-                </pre>
-            );
+            return <pre>{`Unknown type (${block.type}): ${JSON.stringify(block.props)}`}</pre>;
         }
 
         return null;

--- a/packages/site/site-react/src/blocks/factories/OneOfBlock.tsx
+++ b/packages/site/site-react/src/blocks/factories/OneOfBlock.tsx
@@ -26,7 +26,7 @@ export const OneOfBlock = ({ data: { block, ...additionalProps }, supportedBlock
         if (process.env.NODE_ENV === "development") {
             return (
                 <pre>
-                    {/* eslint-disable-next-line @calm/react-intl/missing-formatted-message,react/jsx-no-literals */}
+                    {/* eslint-disable-next-line react/jsx-no-literals */}
                     {/* eslint-disable-next-line react/jsx-no-literals */}
                     Unknown type ({block.type}): {JSON.stringify(block.props)}
                 </pre>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,7 +505,7 @@ importers:
         version: 5.9.3
       vite-tsconfig-paths:
         specifier: ^6.0.4
-        version: 6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
+        version: 6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
@@ -967,7 +967,7 @@ importers:
         version: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: ^6.0.4
-        version: 6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
+        version: 6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
@@ -1823,7 +1823,7 @@ importers:
         version: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: ^6.0.3
-        version: 6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))
+        version: 6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
@@ -2349,9 +2349,6 @@ importers:
 
   packages/eslint-config:
     dependencies:
-      '@calm/eslint-plugin-react-intl':
-        specifier: ^1.4.1
-        version: 1.4.1
       '@comet/eslint-plugin':
         specifier: workspace:*
         version: link:../eslint-plugin
@@ -4096,10 +4093,6 @@ packages:
 
   '@cacheable/utils@2.3.3':
     resolution: {integrity: sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==}
-
-  '@calm/eslint-plugin-react-intl@1.4.1':
-    resolution: {integrity: sha512-J3Tj03JwlV6CPENBqEt64M+Z+k49cNcHUBRYY67Wx9l960NOKhqlRCPUrE85zRqOXqO0cYUrcgrvb0wHAWMpKA==}
-    engines: {node: '>=0.10.0'}
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -15760,10 +15753,6 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
-  requireindex@1.1.0:
-    resolution: {integrity: sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==}
-    engines: {node: '>=0.10.5'}
-
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -17344,11 +17333,6 @@ packages:
 
   vite-tsconfig-paths@6.0.4:
     resolution: {integrity: sha512-iIsEJ+ek5KqRTK17pmxtgIxXtqr3qDdE6OxrP9mVeGhVDNXRJTKN/l9oMbujTQNzMLe6XZ8qmpztfbkPu2TiFQ==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -19537,10 +19521,6 @@ snapshots:
     dependencies:
       hashery: 1.4.0
       keyv: 5.6.0
-
-  '@calm/eslint-plugin-react-intl@1.4.1':
-    dependencies:
-      requireindex: 1.1.0
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -34023,8 +34003,6 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
-  requireindex@1.1.0: {}
-
   requires-port@1.0.0: {}
 
   reselect@5.1.1: {}
@@ -35882,16 +35860,26 @@ snapshots:
       pathe: 0.2.0
       vite: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
 
-  vite-tsconfig-paths@6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)):
+  vite-tsconfig-paths@6.0.4(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-    optionalDependencies:
       vite: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
     transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
       - supports-color
+      - terser
+      - tsx
       - typescript
+      - yaml
 
   vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2343,9 +2343,6 @@ importers:
 
   packages/eslint-config:
     dependencies:
-      '@calm/eslint-plugin-react-intl':
-        specifier: ^1.4.1
-        version: 1.4.1
       '@dextinity/eslint-plugin':
         specifier: workspace:*
         version: link:../eslint-plugin
@@ -4046,11 +4043,6 @@ packages:
 
   '@cacheable/utils@2.3.3':
     resolution: {integrity: sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==}
-
-  '@calm/eslint-plugin-react-intl@1.4.1':
-    resolution: {integrity: sha512-J3Tj03JwlV6CPENBqEt64M+Z+k49cNcHUBRYY67Wx9l960NOKhqlRCPUrE85zRqOXqO0cYUrcgrvb0wHAWMpKA==}
-    engines: {node: '>=0.10.0'}
-    deprecated: This package is no longer actively maintained by Calm. It remains available for compatibility with existing consumers, but new projects should avoid depending on it.
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -15734,10 +15726,6 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
-  requireindex@1.1.0:
-    resolution: {integrity: sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==}
-    engines: {node: '>=0.10.5'}
-
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -19432,10 +19420,6 @@ snapshots:
     dependencies:
       hashery: 1.4.0
       keyv: 5.6.0
-
-  '@calm/eslint-plugin-react-intl@1.4.1':
-    dependencies:
-      requireindex: 1.1.0
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -33947,8 +33931,6 @@ snapshots:
   require-like@0.1.2: {}
 
   require-main-filename@2.0.0: {}
-
-  requireindex@1.1.0: {}
 
   requires-port@1.0.0: {}
 

--- a/storybook/eslint.config.mjs
+++ b/storybook/eslint.config.mjs
@@ -8,7 +8,6 @@ export default defineConfig([
     ...storybook.configs["flat/recommended"],
     {
         rules: {
-            "@calm/react-intl/missing-formatted-message": "off",
             "@typescript-eslint/no-empty-function": "off",
             "@typescript-eslint/no-explicit-any": "off",
             "@typescript-eslint/no-non-null-assertion": "off",


### PR DESCRIPTION
Removes the deprecated `@calm/eslint-plugin-react-intl` package and its `missing-formatted-message` ESLint rule from the codebase. The functionality is now covered by the existing `react/jsx-no-literals` rule which is already part of the ESLint configuration.

https://claude.ai/code/session_01TZ9za5i8HJq129iTgHi36M