### PR TITLE
Fix broken imports in cross-module join entity resolvers

### DIFF
--- a/.changeset/join-entity-cross-module-resolver-imports.md
+++ b/.changeset/join-entity-cross-module-resolver-imports.md
@@ -1,0 +1,9 @@
+---
+"@comet/api-generator": patch
+---
+
+Fix broken imports in generated relation resolver for cross-module join entities
+
+When an entity with `@CrudGenerator` had a `@OneToMany` relation to an explicit join entity located in a different module, the generated relation resolver for the join entity was emitted into the referencing entity's module with import paths that assumed the join entity lived in that same module. The resulting file did not compile.
+
+The join-entity resolver is now written into the module that owns the join entity, where its imports resolve correctly.

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/cross-module-fixtures/articles/entities/article.entity.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/cross-module-fixtures/articles/entities/article.entity.ts
@@ -1,0 +1,16 @@
+import { BaseEntity, Collection, Entity, OneToMany, PrimaryKey, Property } from "@mikro-orm/postgresql";
+import { v4 as uuid } from "uuid";
+
+import { ArticleToPeriodical } from "../../periodicals/entities/article-to-periodical.entity";
+
+@Entity()
+export class Article extends BaseEntity {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @Property()
+    title: string;
+
+    @OneToMany(() => ArticleToPeriodical, (articleToPeriodical) => articleToPeriodical.article, { orphanRemoval: true })
+    periodicalsIncludedIn = new Collection<ArticleToPeriodical>(this);
+}

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/cross-module-fixtures/periodicals/entities/article-to-periodical.entity.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/cross-module-fixtures/periodicals/entities/article-to-periodical.entity.ts
@@ -1,0 +1,17 @@
+import { BaseEntity, Entity, ManyToOne, PrimaryKey, type Ref } from "@mikro-orm/postgresql";
+import { v4 as uuid } from "uuid";
+
+import { Article } from "../../articles/entities/article.entity";
+import { Periodical } from "./periodical.entity";
+
+@Entity()
+export class ArticleToPeriodical extends BaseEntity {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @ManyToOne(() => Article, { ref: true })
+    article: Ref<Article>;
+
+    @ManyToOne(() => Periodical, { ref: true })
+    periodical: Ref<Periodical>;
+}

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/cross-module-fixtures/periodicals/entities/periodical.entity.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/cross-module-fixtures/periodicals/entities/periodical.entity.ts
@@ -1,0 +1,16 @@
+import { BaseEntity, Collection, Entity, OneToMany, PrimaryKey, Property } from "@mikro-orm/postgresql";
+import { v4 as uuid } from "uuid";
+
+import { ArticleToPeriodical } from "./article-to-periodical.entity";
+
+@Entity()
+export class Periodical extends BaseEntity {
+    @PrimaryKey({ type: "uuid" })
+    id: string = uuid();
+
+    @Property()
+    name: string;
+
+    @OneToMany(() => ArticleToPeriodical, (articleToPeriodical) => articleToPeriodical.periodical, { orphanRemoval: true })
+    articlesIncluded = new Collection<ArticleToPeriodical>(this);
+}

--- a/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-cross-module.spec.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/__tests__/generate-crud-relations-cross-module.spec.ts
@@ -1,0 +1,55 @@
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+
+import { defineConfig, MikroORM } from "@mikro-orm/postgresql";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
+import { describe, expect, it } from "vitest";
+
+import { formatGeneratedFiles, parseSource, testPermission } from "../../utils/test-helper";
+import { buildOptions } from "../build-options";
+import { generateCrud } from "../generate-crud";
+import { Article } from "./cross-module-fixtures/articles/entities/article.entity";
+import { ArticleToPeriodical } from "./cross-module-fixtures/periodicals/entities/article-to-periodical.entity";
+import { Periodical } from "./cross-module-fixtures/periodicals/entities/periodical.entity";
+
+describe("generate-crud relations cross module", () => {
+    it("should emit the join-entity resolver into the join entity's module with correct imports", async () => {
+        LazyMetadataStorage.load();
+        const orm = await MikroORM.init(
+            defineConfig({
+                dbName: "test-db",
+                connect: false,
+                entities: [Article, Periodical, ArticleToPeriodical],
+            }),
+        );
+
+        const articleMetadata = orm.em.getMetadata().get("Article");
+        const joinMetadata = orm.em.getMetadata().get("ArticleToPeriodical");
+
+        const out = await generateCrud({ requiredPermission: testPermission }, articleMetadata);
+        const formattedOut = await formatGeneratedFiles(out);
+
+        const file = formattedOut.find((file) => file.name === "article-to-periodical.resolver.ts");
+        if (!file) {
+            throw new Error("File not found");
+        }
+
+        // The join entity lives in a different module than the referencing Article entity. The resolver must be written
+        // into the join entity's own module, not the referencing module – otherwise its `../entities/…` imports break.
+        const { targetDirectory: joinTargetDirectory } = buildOptions(joinMetadata, { requiredPermission: testPermission });
+        expect(file.targetDirectory).toBe(joinTargetDirectory);
+
+        // Every relative import must resolve to an existing file when resolved against the resolver's target directory.
+        const source = parseSource(file.content);
+        for (const tsImport of source.getImportDeclarations()) {
+            const moduleSpecifier = tsImport.getModuleSpecifierValue();
+            if (!moduleSpecifier.startsWith(".")) {
+                continue;
+            }
+            const resolved = path.resolve(joinTargetDirectory, `${moduleSpecifier}.ts`);
+            expect(existsSync(resolved), `import "${moduleSpecifier}" should resolve to an existing file`).toBe(true);
+        }
+
+        await orm.close();
+    });
+});

--- a/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
+++ b/packages/api/api-generator/src/commands/generate/generateCrud/generate-crud.ts
@@ -1291,9 +1291,15 @@ export async function generateCrud(generatorOptionsParam: CrudGeneratorOptions, 
 
                 //can be null if no relations exist
                 if (content) {
+                    // The nested resolver's imports are resolved relative to the join entity's own module (see
+                    // generateNestedEntityResolver). When the join entity lives in a different module than the entity
+                    // referencing it, write the resolver into the join entity's module so the imports resolve correctly
+                    // and it isn't emitted as a broken duplicate into the referencing module.
+                    const { targetDirectory: nestedTargetDirectory } = buildOptions(prop.targetMeta, generatorOptions);
                     generatedFiles.push({
                         name: `${fileNameSingular}.resolver.ts`,
                         content,
+                        targetDirectory: nestedTargetDirectory,
                         type: "resolver",
                     });
                 }


### PR DESCRIPTION
## Summary
Fixed an issue where generated relation resolvers for explicit join entities located in different modules were being emitted into the referencing entity's module with incorrect import paths, causing compilation failures.

## Key Changes
- Modified `generate-crud.ts` to write join-entity resolvers into the join entity's own module instead of the referencing entity's module
- Added `targetDirectory` property to the generated resolver file, pointing to the join entity's module directory
- Added comprehensive test suite (`generate-crud-relations-cross-module.spec.ts`) with cross-module entity fixtures to verify correct resolver generation and import resolution
- Created test fixtures demonstrating a multi-module setup with `Article`, `Periodical`, and `ArticleToPeriodical` entities across different modules

## Implementation Details
The fix ensures that when a `@CrudGenerator` decorated entity has a `@OneToMany` relation to an explicit join entity in a different module, the generated nested resolver is placed in the join entity's module where its relative imports (e.g., `../entities/…`) resolve correctly. This prevents broken imports and duplicate resolver files in the wrong module location.

https://claude.ai/code/session_01Bw7NTNTTPv3vPi1ttmJUr6