### PR TITLE
Remove unused env files from lint:api-can-start command

### DIFF
--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -24,7 +24,7 @@
         "intl:compile:comet-demo": "formatjs compile-folder --format simple --ast lang/comet-demo-lang/api lang-compiled/comet-demo-api",
         "intl:extract": "formatjs extract \"src/**/*.ts*\" --ignore '**/*.{test,spec}.{ts,tsx}' --ignore ./**.d.ts --out-file lang-extracted/en.json --format simple --throws",
         "lint": "pnpm run api-generator && pnpm run intl:compile && pnpm run generate-block-types && run-p lint:prettier lint:eslint lint:tsc lint:api-can-start",
-        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true dotenv -e ../../.env.secrets -e ../../.env.local -e ../../.env -e ../.env.site-configs -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
+        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true dotenv -e ../../.env -e ../.env.site-configs -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
         "lint:ci": "pnpm run api-generator && pnpm run intl:compile && pnpm run generate-block-types && run-p lint:prettier lint:eslint lint:tsc lint:api-can-start && pnpm run lint:generated-files-not-modified",
         "lint:eslint": "eslint --max-warnings 0 src/ '**/*.json' --no-warn-ignored",
         "lint:fix": "run-p lint:fix:eslint lint:fix:prettier",


### PR DESCRIPTION
`lint:api-can-start` is primarily meant to be run in the pipeline, so using `.env.local` and `.env.secrets` doesn't make sense.

https://claude.ai/code/session_017pwmnn4MDZPD2um7HNKP2S