### PR TITLE
Remove system user filter from demo AccessLogModule

### DIFF
--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -220,15 +220,7 @@ export class AppModule {
                 MailTemplatesModule,
                 ProductsModule,
                 ...(config.azureAiTranslator ? [AzureAiTranslatorModule.register(config.azureAiTranslator)] : []),
-                AccessLogModule.forRoot({
-                    shouldLogRequest: ({ user }) => {
-                        // Ignore system user
-                        if (user === "system-user") {
-                            return false;
-                        }
-                        return true;
-                    },
-                }),
+                AccessLogModule.forRoot({}),
                 OpenTelemetryModule,
                 ...(config.sentry ? [SentryModule.forRootAsync(config.sentry)] : []),
                 WarningsModule,

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -220,7 +220,13 @@ export class AppModule {
                 MailTemplatesModule,
                 ProductsModule,
                 ...(config.azureAiTranslator ? [AzureAiTranslatorModule.register(config.azureAiTranslator)] : []),
-                AccessLogModule.forRoot({}),
+                ...(!config.debug
+                    ? [
+                          AccessLogModule.forRoot({
+                              shouldLogRequest: ({ req }) => !req.route.path.startsWith("/api/healthcheck/"),
+                          }),
+                      ]
+                    : []),
                 OpenTelemetryModule,
                 ...(config.sentry ? [SentryModule.forRootAsync(config.sentry)] : []),
                 WarningsModule,


### PR DESCRIPTION
## Summary

The demo's `AccessLogModule` filtered out requests from the `system-user`. That filter was originally added to avoid access log spam during site build. Since the site now uses SSR, the filter no longer serves this purpose, so it is removed.

While touching the configuration, the setup is aligned with [comet-starter](https://github.com/vivid-planet/comet-starter/blob/main/api/src/app.module.ts).

## Changes

- **Remove the system user filter** — it is obsolete now that the site uses SSR.
- **Add a healthcheck filter** — `/api/healthcheck/` requests are excluded from the access log to avoid noise from automated health monitoring, matching [comet-starter](https://github.com/vivid-planet/comet-starter/blob/main/api/src/app.module.ts#L141).
- **Register `AccessLogModule` conditionally** — the module is only added when not in debug mode (`!config.debug`), keeping local development logs clean, matching [comet-starter](https://github.com/vivid-planet/comet-starter/blob/main/api/src/app.module.ts#L138).

```ts
...(!config.debug
    ? [
          AccessLogModule.forRoot({
              shouldLogRequest: ({ req }) => !req.route.path.startsWith("/api/healthcheck/"),
          }),
      ]
    : []),
```

The system user check present in comet-starter is intentionally omitted here.