### PR TITLE
Improve performance when requesting availableContentScopes

### DIFF
--- a/.changeset/user-permissions-content-scope-dedupe-perf.md
+++ b/.changeset/user-permissions-content-scope-dedupe-perf.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-api": patch
+---
+
+Improve performance when requesting `availableContentScopes`

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -69,7 +69,6 @@
         "jszip": "^3.10.1",
         "jwks-rsa": "^3.2.2",
         "lodash.isequal": "^4.5.0",
-        "lodash.uniqwith": "^4.5.0",
         "mime": "^3.0.0",
         "mime-db": "^1.54.0",
         "multer": "^2.1.1",

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -5,7 +5,6 @@ import { Inject, Injectable, Optional } from "@nestjs/common";
 import { isFuture, isPast } from "date-fns";
 import { Request } from "express";
 import isEqual from "lodash.isequal";
-import uniqWith from "lodash.uniqwith";
 import getUuid from "uuid-by-string";
 
 import { AbstractAccessControlService } from "./access-control.service";
@@ -27,6 +26,19 @@ import {
     UserPermissionsUserServiceInterface,
 } from "./user-permissions.types";
 
+// Dedupes by scope content without lodash's deep-equal uniqWith, which is O(n^2) and too slow for large scope lists.
+// Scopes are flat objects of primitive values, so a sorted-entries string key is a safe stand-in for deep equality.
+function dedupeByContentScope<T>(items: T[], getScope: (item: T) => ContentScope): T[] {
+    const seen = new Map<string, T>();
+    for (const item of items) {
+        const key = JSON.stringify(Object.entries(getScope(item)).sort(([a], [b]) => a.localeCompare(b)));
+        if (!seen.has(key)) {
+            seen.set(key, item);
+        }
+    }
+    return [...seen.values()];
+}
+
 @Injectable()
 export class UserPermissionsService {
     constructor(
@@ -40,8 +52,26 @@ export class UserPermissionsService {
 
     private manualPermissions: { userId: string; permission: Permission }[] | undefined;
     private availablePermissions: Permission[] | undefined;
+    private availableContentScopesCache: ContentScopeWithLabel[] | undefined;
+
+    // Populates the cache used by getAvailableContentScopes() for the duration of one operation (e.g. resolving a list of users).
+    // Must be paired with clearAvailableContentScopesCache() so later, unrelated requests don't see a stale snapshot.
+    async warmupAvailableContentScopesCache(): Promise<void> {
+        this.availableContentScopesCache = await this.computeAvailableContentScopes();
+    }
+
+    clearAvailableContentScopesCache(): void {
+        this.availableContentScopesCache = undefined;
+    }
 
     async getAvailableContentScopes(): Promise<ContentScopeWithLabel[]> {
+        if (this.availableContentScopesCache !== undefined) {
+            return this.availableContentScopesCache;
+        }
+        return this.computeAvailableContentScopes();
+    }
+
+    private async computeAvailableContentScopes(): Promise<ContentScopeWithLabel[]> {
         let contentScopes: AvailableContentScope[] = [];
         if (this.options.availableContentScopes) {
             if (typeof this.options.availableContentScopes === "function") {
@@ -75,7 +105,7 @@ export class UserPermissionsService {
                     ]),
                 ),
             }));
-        return uniqWith(contentScopesWithLabel, (value: ContentScopeWithLabel, other: ContentScopeWithLabel) => isEqual(value.scope, other.scope));
+        return dedupeByContentScope(contentScopesWithLabel, (cs) => cs.scope);
     }
 
     async getAvailablePermissions(): Promise<Permission[]> {
@@ -225,7 +255,7 @@ export class UserPermissionsService {
             }
         }
 
-        return uniqWith(contentScopes, isEqual);
+        return dedupeByContentScope(contentScopes, (scope) => scope);
     }
 
     async getImpersonatedUser(authenticatedUser: User, request: Request): Promise<User | undefined> {
@@ -270,7 +300,10 @@ export class UserPermissionsService {
                 const contentScopes = userPermission.overrideContentScopes ? userPermission.contentScopes : userContentScopes;
                 const existingPermission = acc.find((p) => p.permission === userPermission.permission);
                 if (existingPermission) {
-                    existingPermission.contentScopes = uniqWith([...existingPermission.contentScopes, ...contentScopes], isEqual);
+                    existingPermission.contentScopes = dedupeByContentScope(
+                        [...existingPermission.contentScopes, ...contentScopes],
+                        (scope) => scope,
+                    );
                 } else {
                     acc.push({
                         permission: userPermission.permission,

--- a/packages/api/cms-api/src/user-permissions/user.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user.resolver.ts
@@ -33,52 +33,60 @@ export class UserResolver {
         if (permissionAndFilters && permissionOrFilters) {
             throw new Error("You cannot use both 'and' and 'or' permission filters at the same time.");
         }
-        if (permissionAndFilters && permissionAndFilters.length > 0) {
-            await this.userService.warmupHasPermissionCache();
-            // If a permission filter is provided, we need to get all users and filter them
-            const filteredUsers: User[] = [];
-            let offset = 0;
-            let users: User[] = [];
-            do {
-                [users] = await this.userService.findUsers({ filter: args.filter, sort: args.sort, offset, limit: 100 });
-                for (let i = 0; i < users.length; i++) {
-                    if (await this.permissionAndFiltersApplies(users[i], permissionAndFilters)) {
-                        filteredUsers.push(users[i]);
-                    }
-                }
-                offset += users.length;
-            } while (users.length > 0);
-            return new UserPermissionPaginatedUserList(filteredUsers.slice(args.offset, args.offset + args.limit), filteredUsers.length);
-        } else if (permissionOrFilters && permissionOrFilters.length > 0) {
-            await this.userService.warmupHasPermissionCache();
-            const matchedUsers = new Set<User>();
-            let users: User[] = [];
-            // Add all users that match other than permission filters
-            if (args.filter?.or?.some((f) => !f.permission)) {
+
+        // Warms up the available-content-scopes cache for the lifetime of this query, so the contentScopesCount
+        // field resolver doesn't recompute (and dedupe) the full scope list once per returned user.
+        await this.userService.warmupAvailableContentScopesCache();
+        try {
+            if (permissionAndFilters && permissionAndFilters.length > 0) {
+                await this.userService.warmupHasPermissionCache();
+                // If a permission filter is provided, we need to get all users and filter them
+                const filteredUsers: User[] = [];
                 let offset = 0;
+                let users: User[] = [];
                 do {
                     [users] = await this.userService.findUsers({ filter: args.filter, sort: args.sort, offset, limit: 100 });
                     for (let i = 0; i < users.length; i++) {
-                        matchedUsers.add(users[i]);
+                        if (await this.permissionAndFiltersApplies(users[i], permissionAndFilters)) {
+                            filteredUsers.push(users[i]);
+                        }
                     }
                     offset += users.length;
                 } while (users.length > 0);
-            }
-            // Add users that match permission filters
-            let offset = 0;
-            do {
-                [users] = await this.userService.findUsers({ sort: args.sort, offset, limit: 100 });
-                for (let i = 0; i < users.length; i++) {
-                    if (await this.permissionOrFiltersApplies(users[i], permissionOrFilters)) {
-                        matchedUsers.add(users[i]);
-                    }
+                return new UserPermissionPaginatedUserList(filteredUsers.slice(args.offset, args.offset + args.limit), filteredUsers.length);
+            } else if (permissionOrFilters && permissionOrFilters.length > 0) {
+                await this.userService.warmupHasPermissionCache();
+                const matchedUsers = new Set<User>();
+                let users: User[] = [];
+                // Add all users that match other than permission filters
+                if (args.filter?.or?.some((f) => !f.permission)) {
+                    let offset = 0;
+                    do {
+                        [users] = await this.userService.findUsers({ filter: args.filter, sort: args.sort, offset, limit: 100 });
+                        for (let i = 0; i < users.length; i++) {
+                            matchedUsers.add(users[i]);
+                        }
+                        offset += users.length;
+                    } while (users.length > 0);
                 }
-                offset += users.length;
-            } while (users.length > 0);
-            return new UserPermissionPaginatedUserList(Array.from(matchedUsers).slice(args.offset, args.offset + args.limit), matchedUsers.size);
-        } else {
-            const [users, totalCount] = await this.userService.findUsers(args);
-            return new UserPermissionPaginatedUserList(users, totalCount);
+                // Add users that match permission filters
+                let offset = 0;
+                do {
+                    [users] = await this.userService.findUsers({ sort: args.sort, offset, limit: 100 });
+                    for (let i = 0; i < users.length; i++) {
+                        if (await this.permissionOrFiltersApplies(users[i], permissionOrFilters)) {
+                            matchedUsers.add(users[i]);
+                        }
+                    }
+                    offset += users.length;
+                } while (users.length > 0);
+                return new UserPermissionPaginatedUserList(Array.from(matchedUsers).slice(args.offset, args.offset + args.limit), matchedUsers.size);
+            } else {
+                const [users, totalCount] = await this.userService.findUsers(args);
+                return new UserPermissionPaginatedUserList(users, totalCount);
+            }
+        } finally {
+            this.userService.clearAvailableContentScopesCache();
         }
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2124,7 +2124,7 @@ importers:
         version: 5.10.0
       jsdom:
         specifier: ^28.1.0
-        version: 28.1.0(@noble/hashes@1.8.0)
+        version: 28.1.0
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -2132,9 +2132,6 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2
       lodash.isequal:
-        specifier: ^4.5.0
-        version: 4.5.0
-      lodash.uniqwith:
         specifier: ^4.5.0
         version: 4.5.0
       mime:
@@ -2151,7 +2148,7 @@ importers:
         version: 8.0.5
       openai:
         specifier: ^6.32.0
-        version: 6.32.0(ws@8.20.0)(zod@4.4.3)
+        version: 6.32.0(ws@8.20.0)
       probe-image-size:
         specifier: ^7.2.3
         version: 7.2.3
@@ -2203,7 +2200,7 @@ importers:
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/graphql':
         specifier: ^13.4.0
-        version: 13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@25.0.1)
+        version: 13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)
       '@nestjs/jwt':
         specifier: ^11.0.2
         version: 11.0.2(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))
@@ -2275,7 +2272,7 @@ importers:
         version: 0.14.3
       eslint:
         specifier: ^9.39.4
-        version: 9.39.4(jiti@2.7.0)
+        version: 9.39.4
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -2308,7 +2305,7 @@ importers:
         version: 1.5.9(@swc/core@1.15.41)(rollup@4.59.0)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0)
 
   packages/cli:
     dependencies:
@@ -13338,9 +13335,6 @@ packages:
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
-  lodash.uniqwith@4.5.0:
-    resolution: {integrity: sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q==}
-
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -20945,6 +20939,11 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.21.2':
@@ -20985,6 +20984,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.14.1': {}
 
   '@exodus/bytes@1.14.1(@noble/hashes@1.8.0)':
     optionalDependencies:
@@ -22814,6 +22815,34 @@ snapshots:
       uid: 2.0.2
     optionalDependencies:
       '@nestjs/platform-express': 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)
+
+  '@nestjs/graphql@13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@graphql-tools/merge': 9.1.9(graphql@16.14.2)
+      '@graphql-tools/schema': 10.0.33(graphql@16.14.2)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.2)
+      '@nestjs/common': 11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
+      chokidar: 4.0.3
+      fast-glob: 3.3.3
+      graphql: 16.14.2
+      graphql-tag: 2.12.6(graphql@16.14.2)
+      graphql-ws: 6.0.8(graphql@16.14.2)(ws@8.20.0)
+      lodash: 4.18.1
+      normalize-path: 3.0.0
+      reflect-metadata: 0.2.2
+      subscriptions-transport-ws: 0.11.0(graphql@16.14.2)
+      tslib: 2.8.1
+      ws: 8.20.0
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.3
+    transitivePeerDependencies:
+      - '@fastify/websocket'
+      - bufferutil
+      - crossws
+      - utf-8-validate
 
   '@nestjs/graphql@13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@25.0.1)':
     dependencies:
@@ -25813,6 +25842,14 @@ snapshots:
       msw: 2.14.6(@types/node@24.12.4)(typescript@5.9.3)
       vite: 7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
 
+  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@24.12.4))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.12.4)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -27658,6 +27695,13 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -28462,6 +28506,45 @@ snapshots:
   eslint-visitor-keys@4.2.1: {}
 
   eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
 
   eslint@9.39.4(jiti@2.7.0):
     dependencies:
@@ -29609,6 +29692,12 @@ snapshots:
 
   hpagent@1.2.0: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.14.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
       '@exodus/bytes': 1.14.1(@noble/hashes@1.8.0)
@@ -30318,6 +30407,33 @@ snapshots:
 
   jsbn@1.1.0: {}
 
+  jsdom@28.1.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@bramus/specificity': 2.4.2
+      '@exodus/bytes': 1.14.1
+      cssstyle: 6.0.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.22.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - supports-color
+
   jsdom@28.1.0(@noble/hashes@1.8.0):
     dependencies:
       '@acemir/cssom': 0.9.31
@@ -30762,8 +30878,6 @@ snapshots:
   lodash.union@4.6.0: {}
 
   lodash.uniq@4.5.0: {}
-
-  lodash.uniqwith@4.5.0: {}
 
   lodash@4.17.21: {}
 
@@ -32172,10 +32286,9 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.32.0(ws@8.20.0)(zod@4.4.3):
+  openai@6.32.0(ws@8.20.0):
     optionalDependencies:
       ws: 8.20.0
-      zod: 4.4.3
 
   opener@1.5.2: {}
 
@@ -35724,6 +35837,18 @@ snapshots:
       - typescript
       - yaml
 
+  vite@7.3.1(@types/node@24.12.4):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.12.4
+      fsevents: 2.3.3
+
   vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
@@ -35767,6 +35892,45 @@ snapshots:
       '@types/node': 24.12.4
       '@vitest/browser-playwright': 4.1.8(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@24.12.4)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.8)
       jsdom: 28.1.0(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@24.12.4))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@24.12.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.12.4
+      jsdom: 28.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -36132,6 +36296,14 @@ snapshots:
   whatwg-mimetype@4.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.0:
+    dependencies:
+      '@exodus/bytes': 1.14.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@16.0.0(@noble/hashes@1.8.0):
     dependencies:


### PR DESCRIPTION
The `availableContentScopes` were repeatedly recomputed for every row when querying users; this is fixed by the cache (per resolver request). Additionally, filtering out duplicate content scopes was very slow when using `lodash.uniqWith` with many content scopes, and was significantly sped up by implementing a custom algorithm (on my machine, with 2000 content scopes, from about 15 seconds down to 0.15 seconds)."