### PR TITLE
TipTap: Allow customizing the default text block style label

### DIFF
--- a/.changeset/tiptap-block-type-paragraph-label.md
+++ b/.changeset/tiptap-block-type-paragraph-label.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Rename the TipTap block type dropdown's non-heading entry from `Default` to `Paragraph`
+
+This makes it clearer that the dropdown selects the block's HTML tag.

--- a/.changeset/tiptap-default-text-block-style-label.md
+++ b/.changeset/tiptap-default-text-block-style-label.md
@@ -1,0 +1,18 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `defaultTextBlockStyleLabel` option to `createTipTapRichTextBlock`
+
+The text block style dropdown always showed `Default` for the entry that applies no style. When a block configures named styles such as `Paragraph Default` and `Paragraph Small`, that fixed `Default` is inconsistent with the styles it sits next to.
+
+`defaultTextBlockStyleLabel` lets the block relabel that entry so it matches the block's naming. It only changes the label — selecting the entry still stores no text block style — and when the option is omitted the entry stays labeled `Default`.
+
+**Example**
+
+```tsx
+createTipTapRichTextBlock({
+    defaultTextBlockStyleLabel: "Paragraph Default",
+    textBlockStyles: [{ name: "small", label: "Paragraph Small", appliesTo: ["paragraph"], element: (props) => <p {...props} /> }],
+});
+```

--- a/.changeset/tiptap-default-text-block-style-label.md
+++ b/.changeset/tiptap-default-text-block-style-label.md
@@ -4,15 +4,19 @@
 
 Add `defaultTextBlockStyleLabel` option to `createTipTapRichTextBlock`
 
-The text block style dropdown always showed `Default` for the entry that applies no style. When a block configures named styles such as `Paragraph Default` and `Paragraph Small`, that fixed `Default` is inconsistent with the styles it sits next to.
+The first entry of the text block style dropdown applies no style and was always labeled `Default`. `defaultTextBlockStyleLabel` sets that label, so a block can name the entry after the base style its site renders when no style is stored.
 
-`defaultTextBlockStyleLabel` lets the block relabel that entry so it matches the block's naming. It only changes the label — selecting the entry still stores no text block style — and when the option is omitted the entry stays labeled `Default`.
+Only the label changes: selecting the entry still stores no text block style. Omitting the option keeps `Default`.
 
 **Example**
 
 ```tsx
 createTipTapRichTextBlock({
-    defaultTextBlockStyleLabel: "Paragraph Default",
-    textBlockStyles: [{ name: "small", label: "Paragraph Small", appliesTo: ["paragraph"], element: (props) => <p {...props} /> }],
+    defaultTextBlockStyleLabel: "Copy 100",
+    textBlockStyles: [
+        { name: "copy-200", label: "Copy 200", appliesTo: ["paragraph"], element: (props) => <p {...props} /> },
+        { name: "label-100", label: "Label 100", appliesTo: ["paragraph"], element: (props) => <p {...props} /> },
+        { name: "label-200", label: "Label 200", appliesTo: ["paragraph"], element: (props) => <p {...props} /> },
+    ],
 });
 ```

--- a/demo/admin/src/common/blocks/TipTapRichTextBlock.tsx
+++ b/demo/admin/src/common/blocks/TipTapRichTextBlock.tsx
@@ -14,14 +14,8 @@ export const TipTapRichTextBlock = createTipTapRichTextBlock({
     },
     textBlockStyles: [
         {
-            name: "paragraph300",
-            label: <FormattedMessage id="tipTapRichTextBlock.paragraph300" defaultMessage="Paragraph" />,
-            appliesTo: ["paragraph"],
-            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 18, lineHeight: "26px" }} {...props} />,
-        },
-        {
             name: "paragraph200",
-            label: <FormattedMessage id="tipTapRichTextBlock.paragraph200" defaultMessage="Paragraph Small" />,
+            label: <FormattedMessage id="tipTapRichTextBlock.small" defaultMessage="Small" />,
             appliesTo: ["paragraph"],
             element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 15, lineHeight: "22px" }} {...props} />,
         },

--- a/demo/api/src/common/blocks/tip-tap-rich-text.block.ts
+++ b/demo/api/src/common/blocks/tip-tap-rich-text.block.ts
@@ -4,6 +4,7 @@ import { ProductTeaserBlock } from "@src/products/blocks/product-teaser.block";
 
 import { LinkBlock } from "./link.block";
 import { Heading1ToHeading2Migration } from "./tip-tap-rich-text/migrations/2-heading-1-to-heading-2.migration";
+import { RemoveParagraph300Migration } from "./tip-tap-rich-text/migrations/3-remove-paragraph-300.migration";
 
 export const TipTapRichTextBlock = createTipTapRichTextBlock(
     {
@@ -13,7 +14,6 @@ export const TipTapRichTextBlock = createTipTapRichTextBlock(
             productTeaser: { block: ProductTeaserBlock, display: "block" },
         },
         textBlockStyles: [
-            { name: "paragraph300", appliesTo: ["paragraph"] },
             { name: "paragraph200", appliesTo: ["paragraph"] },
             { name: "eyebrow600", appliesTo: ["paragraph"] },
             { name: "eyebrow550", appliesTo: ["paragraph"] },
@@ -32,8 +32,8 @@ export const TipTapRichTextBlock = createTipTapRichTextBlock(
     {
         name: "TipTapRichText",
         migrate: {
-            migrations: typeSafeBlockMigrationPipe([Heading1ToHeading2Migration]),
-            version: 2,
+            migrations: typeSafeBlockMigrationPipe([Heading1ToHeading2Migration, RemoveParagraph300Migration]),
+            version: 3,
         },
     },
 );

--- a/demo/api/src/common/blocks/tip-tap-rich-text/migrations/3-remove-paragraph-300.migration.ts
+++ b/demo/api/src/common/blocks/tip-tap-rich-text/migrations/3-remove-paragraph-300.migration.ts
@@ -1,0 +1,26 @@
+import { BlockMigration, type BlockMigrationInterface, type TipTapRichTextBlockContent } from "@comet/cms-api";
+
+interface From {
+    tipTapContent: TipTapRichTextBlockContent;
+}
+
+type To = From;
+
+function unsetParagraph300TextBlockStyle(node: TipTapRichTextBlockContent): TipTapRichTextBlockContent {
+    let result = node;
+    if (node.attrs?.textBlockStyle === "paragraph300") {
+        result = { ...node, attrs: { ...node.attrs, textBlockStyle: null } };
+    }
+    if (Array.isArray(result.content)) {
+        result = { ...result, content: result.content.map(unsetParagraph300TextBlockStyle) };
+    }
+    return result;
+}
+
+export class RemoveParagraph300Migration extends BlockMigration<(from: From) => To> implements BlockMigrationInterface {
+    public readonly toVersion = 3;
+
+    protected migrate(from: From): To {
+        return { tipTapContent: unsetParagraph300TextBlockStyle(from.tipTapContent) };
+    }
+}

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -366,7 +366,7 @@ export const TipTapToolbar = ({
                             sx={selectSx}
                         >
                             <MenuItem value="paragraph" dense>
-                                <FormattedMessage id="comet.blocks.tipTapRichText.textBlockType.default" defaultMessage="Default" />
+                                <FormattedMessage id="comet.blocks.tipTapRichText.textBlockType.paragraph" defaultMessage="Paragraph" />
                             </MenuItem>
                             {([1, 2, 3, 4, 5, 6] as const).map((level) => (
                                 <MenuItem key={level} value={String(level)} dense>

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -159,6 +159,7 @@ export const TipTapToolbar = ({
     editor,
     supports,
     textBlockStyles,
+    defaultTextBlockStyleLabel = <FormattedMessage id="comet.blocks.tipTapRichText.textBlockStyle.default" defaultMessage="Default" />,
     inlineStyles,
     placeholders,
     linkBlock,
@@ -168,6 +169,7 @@ export const TipTapToolbar = ({
     editor: Editor;
     supports: TipTapSupports[];
     textBlockStyles: TipTapTextBlockStyle[];
+    defaultTextBlockStyleLabel?: ReactNode;
     inlineStyles: TipTapInlineStyle[];
     placeholders: TipTapPlaceholder[];
     linkBlock?: BlockInterface & LinkBlockInterface;
@@ -391,7 +393,7 @@ export const TipTapToolbar = ({
                             sx={selectSx}
                         >
                             <MenuItem value="" dense>
-                                <FormattedMessage id="comet.blocks.tipTapRichText.textBlockStyle.default" defaultMessage="Default" />
+                                {defaultTextBlockStyleLabel}
                             </MenuItem>
                             {applicableTextBlockStyles.map((style) => (
                                 <MenuItem key={style.name} value={style.name} dense>

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -191,6 +191,109 @@ export const TextBlockStyles: StoryObj<typeof TextBlockStylesStory> = {
     },
 };
 
+const CustomDefaultLabelBlock = createTipTapRichTextBlock({
+    defaultTextBlockStyleLabel: "Paragraph Default",
+    textBlockStyles: [
+        {
+            name: "small",
+            label: "Paragraph Small",
+            appliesTo: ["paragraph"],
+            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 11 }} {...props} />,
+        },
+    ],
+});
+
+function CustomDefaultLabelStory() {
+    const [state, setState] = useState<TipTapRichTextBlockState>(CustomDefaultLabelBlock.defaultValues());
+
+    return (
+        <StoryWrapper state={state}>
+            <CustomDefaultLabelBlock.AdminComponent state={state} updateState={setState} />
+        </StoryWrapper>
+    );
+}
+
+/**
+ * `defaultTextBlockStyleLabel` renames the no-style entry so it reads consistently next to named styles like
+ * `Paragraph Small`, instead of a fixed `Default`. The stored value is unchanged.
+ */
+export const CustomDefaultTextBlockStyleLabel: StoryObj<typeof CustomDefaultLabelStory> = {
+    render: () => <CustomDefaultLabelStory />,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Text block style dropdown shows the custom default label instead of 'Default'", async () => {
+            await waitFor(
+                () => {
+                    const comboboxes = canvas.getAllByRole("combobox");
+                    expect(comboboxes).toHaveLength(2);
+                },
+                { timeout: 5000 },
+            );
+
+            // The text block style dropdown (second combobox) shows the custom label instead of "Default"
+            const textBlockStyleSelect = canvas.getAllByRole("combobox")[1];
+            expect(textBlockStyleSelect).toHaveTextContent("Paragraph Default");
+        });
+
+        await step("Opening the dropdown lists the custom default label alongside the configured style", async () => {
+            const textBlockStyleSelect = canvas.getAllByRole("combobox")[1];
+            await userEvent.click(textBlockStyleSelect);
+
+            await waitFor(
+                () => {
+                    const body = within(document.body);
+                    expect(body.getByRole("option", { name: "Paragraph Default" })).toBeInTheDocument();
+                    expect(body.getByRole("option", { name: "Paragraph Small" })).toBeInTheDocument();
+                },
+                { timeout: 3000 },
+            );
+        });
+    },
+};
+
+const SingleDropdownStylesBlock = createTipTapRichTextBlock({
+    supports: ["history", "bold", "italic", "strike", "sub", "sup", "ordered-list", "unordered-list", "non-breaking-space", "soft-hyphen"],
+    defaultTextBlockStyleLabel: "Copy Default",
+    textBlockStyles: [
+        {
+            name: "copy-small",
+            label: "Copy Small",
+            appliesTo: ["paragraph"],
+            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 11 }} {...props} />,
+        },
+        {
+            name: "headline-one",
+            label: "Headline One",
+            appliesTo: ["paragraph"],
+            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 32, fontWeight: 700 }} {...props} />,
+        },
+        {
+            name: "headline-two",
+            label: "Headline Two",
+            appliesTo: ["paragraph"],
+            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 24, fontWeight: 600 }} {...props} />,
+        },
+    ],
+});
+
+function SingleDropdownStylesStory() {
+    const [state, setState] = useState<TipTapRichTextBlockState>(SingleDropdownStylesBlock.defaultValues());
+
+    return (
+        <StoryWrapper state={state}>
+            <SingleDropdownStylesBlock.AdminComponent state={state} updateState={setState} />
+        </StoryWrapper>
+    );
+}
+
+/**
+ * When only the visual appearance of text matters and not its semantic element, the block type is irrelevant. Disabling
+ * heading support hides the block type dropdown (paragraph / headings), leaving the text block style dropdown as the only
+ * selector, with `defaultTextBlockStyleLabel` renaming its no-style entry. This fits output such as emails or PDFs.
+ */
+export const SingleDropdownTextBlockStyles: StoryObj<typeof SingleDropdownStylesStory> = {
+    render: () => <SingleDropdownStylesStory />,
+};
+
 const PlaceholdersBlock = createTipTapRichTextBlock({
     placeholders: [
         { name: "firstName", label: "First Name" },

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -192,65 +192,6 @@ export const TextBlockStyles: StoryObj<typeof TextBlockStylesStory> = {
     },
 };
 
-const CustomDefaultLabelBlock = createTipTapRichTextBlock({
-    defaultTextBlockStyleLabel: "Paragraph Default",
-    textBlockStyles: [
-        {
-            name: "small",
-            label: "Paragraph Small",
-            appliesTo: ["paragraph"],
-            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 11 }} {...props} />,
-        },
-    ],
-});
-
-function CustomDefaultLabelStory() {
-    const [state, setState] = useState<TipTapRichTextBlockState>(CustomDefaultLabelBlock.defaultValues());
-
-    return (
-        <StoryWrapper state={state}>
-            <CustomDefaultLabelBlock.AdminComponent state={state} updateState={setState} />
-        </StoryWrapper>
-    );
-}
-
-/**
- * `defaultTextBlockStyleLabel` renames the no-style entry so it reads consistently next to named styles like
- * `Paragraph Small`, instead of a fixed `Default`. The stored value is unchanged.
- */
-export const CustomDefaultTextBlockStyleLabel: StoryObj<typeof CustomDefaultLabelStory> = {
-    render: () => <CustomDefaultLabelStory />,
-    play: async ({ canvas, userEvent, step }) => {
-        await step("Text block style dropdown shows the custom default label instead of 'Default'", async () => {
-            await waitFor(
-                () => {
-                    const comboboxes = canvas.getAllByRole("combobox");
-                    expect(comboboxes).toHaveLength(2);
-                },
-                { timeout: 5000 },
-            );
-
-            // The text block style dropdown (second combobox) shows the custom label instead of "Default"
-            const textBlockStyleSelect = canvas.getAllByRole("combobox")[1];
-            expect(textBlockStyleSelect).toHaveTextContent("Paragraph Default");
-        });
-
-        await step("Opening the dropdown lists the custom default label alongside the configured style", async () => {
-            const textBlockStyleSelect = canvas.getAllByRole("combobox")[1];
-            await userEvent.click(textBlockStyleSelect);
-
-            await waitFor(
-                () => {
-                    const body = within(document.body);
-                    expect(body.getByRole("option", { name: "Paragraph Default" })).toBeInTheDocument();
-                    expect(body.getByRole("option", { name: "Paragraph Small" })).toBeInTheDocument();
-                },
-                { timeout: 3000 },
-            );
-        });
-    },
-};
-
 const SingleDropdownStylesBlock = createTipTapRichTextBlock({
     supports: ["history", "bold", "italic", "strike", "sub", "sup", "ordered-list", "unordered-list", "non-breaking-space", "soft-hyphen"],
     defaultTextBlockStyleLabel: "Copy Default",
@@ -293,6 +234,32 @@ function SingleDropdownStylesStory() {
  */
 export const SingleDropdownTextBlockStyles: StoryObj<typeof SingleDropdownStylesStory> = {
     render: () => <SingleDropdownStylesStory />,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Text block style dropdown shows the custom default label instead of 'Default'", async () => {
+            // Heading support is off, so the text block style dropdown is the only combobox
+            await waitFor(
+                () => {
+                    expect(canvas.getByRole("combobox")).toHaveTextContent("Copy Default");
+                },
+                { timeout: 5000 },
+            );
+        });
+
+        await step("Opening the dropdown lists the custom default label alongside the configured styles", async () => {
+            await userEvent.click(canvas.getByRole("combobox"));
+
+            await waitFor(
+                () => {
+                    const body = within(document.body);
+                    expect(body.getByRole("option", { name: "Copy Default" })).toBeInTheDocument();
+                    expect(body.getByRole("option", { name: "Copy Small" })).toBeInTheDocument();
+                    expect(body.getByRole("option", { name: "Headline One" })).toBeInTheDocument();
+                    expect(body.getByRole("option", { name: "Headline Two" })).toBeInTheDocument();
+                },
+                { timeout: 3000 },
+            );
+        });
+    },
 };
 
 const PlaceholdersBlock = createTipTapRichTextBlock({

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -53,9 +53,9 @@ export const Default: Story = {
                 { timeout: 5000 },
             );
 
-            // Heading select shows "Default"
+            // Block type select shows "Paragraph"
             expect(canvas.getByRole("combobox")).toBeInTheDocument();
-            expect(canvas.getByText("Default")).toBeInTheDocument();
+            expect(canvas.getByText("Paragraph")).toBeInTheDocument();
 
             // Toolbar has buttons (undo, redo, bold, italic, strike, more, ol, ul, indent, dedent, nbsp, shy)
             const buttons = canvas.getAllByRole("button");
@@ -141,7 +141,7 @@ export const TextBlockStyles: StoryObj<typeof TextBlockStylesStory> = {
     render: () => <TextBlockStylesStory />,
     play: async ({ canvas, userEvent, step }) => {
         await step("Editor is ready with text block style dropdown", async () => {
-            // Both heading select and text block style select show "Default"
+            // Block type select shows "Paragraph", text block style select shows "Default"
             await waitFor(
                 () => {
                     const comboboxes = canvas.getAllByRole("combobox");
@@ -150,8 +150,9 @@ export const TextBlockStyles: StoryObj<typeof TextBlockStylesStory> = {
                 { timeout: 5000 },
             );
 
-            const defaults = canvas.getAllByText("Default");
-            expect(defaults.length).toBeGreaterThanOrEqual(2);
+            const comboboxes = canvas.getAllByRole("combobox");
+            expect(comboboxes[0]).toHaveTextContent("Paragraph");
+            expect(comboboxes[1]).toHaveTextContent("Default");
         });
 
         await step("Select text block style 'Intro Text'", async () => {

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -94,9 +94,9 @@ export const BoldOnly: StoryObj<typeof BoldOnlyStory> = {
                 { timeout: 5000 },
             );
 
-            // Only bold button, no heading select
+            // Only bold button, no block type select
             expect(canvas.queryByRole("combobox")).not.toBeInTheDocument();
-            expect(canvas.queryByText("Default")).not.toBeInTheDocument();
+            expect(canvas.queryByText("Paragraph")).not.toBeInTheDocument();
 
             // Exactly 1 button (bold only — no undo/redo, no lists, no special chars)
             const buttons = canvas.getAllByRole("button");
@@ -194,25 +194,41 @@ export const TextBlockStyles: StoryObj<typeof TextBlockStylesStory> = {
 
 const SingleDropdownStylesBlock = createTipTapRichTextBlock({
     supports: ["history", "bold", "italic", "strike", "sub", "sup", "ordered-list", "unordered-list", "non-breaking-space", "soft-hyphen"],
-    defaultTextBlockStyleLabel: "Copy Default",
+    defaultTextBlockStyleLabel: "Copy 100",
     textBlockStyles: [
         {
-            name: "copy-small",
-            label: "Copy Small",
+            name: "copy-200",
+            label: "Copy 200",
             appliesTo: ["paragraph"],
-            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 11 }} {...props} />,
+            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 20, lineHeight: "28px" }} {...props} />,
         },
         {
-            name: "headline-one",
-            label: "Headline One",
+            name: "label-100",
+            label: "Label 100",
             appliesTo: ["paragraph"],
-            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 32, fontWeight: 700 }} {...props} />,
+            element: (props: HTMLAttributes<HTMLElement>) => (
+                <p style={{ fontSize: 12, fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase" }} {...props} />
+            ),
         },
         {
-            name: "headline-two",
-            label: "Headline Two",
+            name: "label-200",
+            label: "Label 200",
             appliesTo: ["paragraph"],
-            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 24, fontWeight: 600 }} {...props} />,
+            element: (props: HTMLAttributes<HTMLElement>) => (
+                <p style={{ fontSize: 14, fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase" }} {...props} />
+            ),
+        },
+        {
+            name: "headline-100",
+            label: "Headline 100",
+            appliesTo: ["paragraph"],
+            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 28, fontWeight: 600, lineHeight: "34px" }} {...props} />,
+        },
+        {
+            name: "headline-200",
+            label: "Headline 200",
+            appliesTo: ["paragraph"],
+            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 36, fontWeight: 700, lineHeight: "44px" }} {...props} />,
         },
     ],
 });
@@ -239,7 +255,7 @@ export const SingleDropdownTextBlockStyles: StoryObj<typeof SingleDropdownStyles
             // Heading support is off, so the text block style dropdown is the only combobox
             await waitFor(
                 () => {
-                    expect(canvas.getByRole("combobox")).toHaveTextContent("Copy Default");
+                    expect(canvas.getByRole("combobox")).toHaveTextContent("Copy 100");
                 },
                 { timeout: 5000 },
             );
@@ -251,10 +267,12 @@ export const SingleDropdownTextBlockStyles: StoryObj<typeof SingleDropdownStyles
             await waitFor(
                 () => {
                     const body = within(document.body);
-                    expect(body.getByRole("option", { name: "Copy Default" })).toBeInTheDocument();
-                    expect(body.getByRole("option", { name: "Copy Small" })).toBeInTheDocument();
-                    expect(body.getByRole("option", { name: "Headline One" })).toBeInTheDocument();
-                    expect(body.getByRole("option", { name: "Headline Two" })).toBeInTheDocument();
+                    expect(body.getByRole("option", { name: "Copy 100" })).toBeInTheDocument();
+                    expect(body.getByRole("option", { name: "Copy 200" })).toBeInTheDocument();
+                    expect(body.getByRole("option", { name: "Label 100" })).toBeInTheDocument();
+                    expect(body.getByRole("option", { name: "Label 200" })).toBeInTheDocument();
+                    expect(body.getByRole("option", { name: "Headline 100" })).toBeInTheDocument();
+                    expect(body.getByRole("option", { name: "Headline 200" })).toBeInTheDocument();
                 },
                 { timeout: 3000 },
             );

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -116,6 +116,11 @@ export interface TipTapChildBlock {
 interface TipTapRichTextBlockFactoryOptions {
     supports?: TipTapSupports[];
     textBlockStyles?: TipTapTextBlockStyle[];
+    /**
+     * Label for the entry with no text block style in the text block style dropdown.
+     * @defaultValue "Default"
+     */
+    defaultTextBlockStyleLabel?: ReactNode;
     inlineStyles?: TipTapInlineStyle[];
     placeholders?: TipTapPlaceholder[];
     link?: BlockInterface & LinkBlockInterface;
@@ -322,6 +327,7 @@ const TipTapEditor = ({
     updateState,
     supports,
     textBlockStyles,
+    defaultTextBlockStyleLabel,
     inlineStyles,
     placeholders,
     linkBlock,
@@ -333,6 +339,7 @@ const TipTapEditor = ({
     updateState: React.Dispatch<React.SetStateAction<TipTapRichTextBlockState>>;
     supports: TipTapSupports[];
     textBlockStyles: TipTapTextBlockStyle[];
+    defaultTextBlockStyleLabel?: ReactNode;
     inlineStyles: TipTapInlineStyle[];
     placeholders: TipTapPlaceholder[];
     linkBlock?: BlockInterface & LinkBlockInterface;
@@ -424,6 +431,7 @@ const TipTapEditor = ({
                             editor={editor}
                             supports={supports}
                             textBlockStyles={textBlockStyles}
+                            defaultTextBlockStyleLabel={defaultTextBlockStyleLabel}
                             inlineStyles={inlineStyles}
                             placeholders={placeholders}
                             linkBlock={linkBlock}
@@ -448,6 +456,7 @@ export const createTipTapRichTextBlock = (
 ): BlockInterface<TipTapRichTextBlockData, TipTapRichTextBlockState, TipTapRichTextBlockInput> => {
     let supports = options?.supports ?? defaultSupports;
     const textBlockStyles = options?.textBlockStyles ?? [];
+    const defaultTextBlockStyleLabel = options?.defaultTextBlockStyleLabel;
     const inlineStyles = options?.inlineStyles ?? [];
     const placeholders = options?.placeholders ?? [];
     const linkBlock = options?.link;
@@ -532,6 +541,7 @@ export const createTipTapRichTextBlock = (
                     updateState={updateState}
                     supports={supports}
                     textBlockStyles={textBlockStyles}
+                    defaultTextBlockStyleLabel={defaultTextBlockStyleLabel}
                     inlineStyles={inlineStyles}
                     placeholders={placeholders}
                     linkBlock={linkBlock}


### PR DESCRIPTION
The text block style dropdown always showed `Default` for the entry that applies no style.
When a block configures named styles, that fixed `Default` is inconsistent with the styles it sits next to.
A per-block label lets the entry match the block's naming.
The block type dropdown showed `Default` too, without conveying that it produces a paragraph.

- **Relabel the no-style entry instead of making a named style the default.**
  Making a named style the default (the DraftJS RTE's `standardBlockType` approach) would change stored data and also affect the API package — much more work than a naming change needs.
- **Only the text block style dropdown's entry is configurable.**
  The block type dropdown's entry is renamed but stays hardcoded, since its tag set is fixed and there is nothing for a consumer to rename; the inline style dropdown keeps `Default`, which already means no inline style.
- **The option lives in the admin package only, though `textBlockStyles` also exists in the API factory.**
  The label affects only the editor UI; the API handles data and validation, not display strings.
- **The demo drops its redundant paragraph style rather than renaming it.**
  It rendered the same as storing no style, so the dropdown offered the same result twice, and removing it needs a migration for content that already stores the style.

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-12548