### PR TITLE
Responsive UI for breadcrumbs

### DIFF
--- a/packages/admin/admin/src/common/breadcrumbs/Breadcrumbs.slots.ts
+++ b/packages/admin/admin/src/common/breadcrumbs/Breadcrumbs.slots.ts
@@ -106,6 +106,11 @@ export const Separator = createComponentSlot("div")<BreadcrumbsClassKey>({
     align-items: flex-end;
 `);
 
+/**
+ * Content of the `Ellipsis` slot. It labels the overflow button on desktop and replaces all parent items on mobile.
+ */
+export const ellipsisLabel = ". . .";
+
 export const Ellipsis = createComponentSlot(Typography)<BreadcrumbsClassKey>({
     componentName: "Breadcrumbs",
     slotName: "ellipsis",

--- a/packages/admin/admin/src/common/breadcrumbs/Breadcrumbs.slots.ts
+++ b/packages/admin/admin/src/common/breadcrumbs/Breadcrumbs.slots.ts
@@ -194,8 +194,10 @@ export const MenuContainer = createComponentSlot("div")<BreadcrumbsClassKey, Men
     `,
 );
 
-export const EllipsisMeasureLayer = styled("div")`
+export const MeasureLayer = styled("div")`
     position: absolute;
+    display: flex;
+    width: max-content;
     visibility: hidden;
     pointer-events: none;
     height: 0;

--- a/packages/admin/admin/src/common/breadcrumbs/Breadcrumbs.styles.ts
+++ b/packages/admin/admin/src/common/breadcrumbs/Breadcrumbs.styles.ts
@@ -1,0 +1,318 @@
+import { ButtonBase, Popover as MuiPopover, Typography } from "@mui/material";
+import { alpha, css, styled, type Theme } from "@mui/material/styles";
+
+import { createComponentSlot } from "../../helpers/createComponentSlot";
+
+export type BreadcrumbsClassKey =
+    | "root"
+    | "item"
+    | "activeItem"
+    | "separator"
+    | "ellipsis"
+    | "overflowButton"
+    | "overflowMenu"
+    | "overflowMenuItem"
+    | "menuContainer"
+    | "toolbarContainer"
+    | "expandedMenu"
+    | "expandedMenuItem"
+    | "expandedMenuActiveItem"
+    | "expandedMenuActiveItemWrapper"
+    | "pageTreeVerticalLine"
+    | "expandedMenuSubitemWrapper"
+    | "mobileMenuIcon"
+    | "mobileRootButton";
+
+export const Root = createComponentSlot("div")<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "root",
+})(
+    ({ theme }) => css`
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        height: 40px;
+        padding: 0 ${theme.spacing(2)};
+        cursor: pointer;
+
+        &::after {
+            content: "";
+            position: absolute;
+            left: ${theme.spacing(2)};
+            right: ${theme.spacing(2)};
+            bottom: 0;
+            height: 1px;
+            background-color: ${theme.palette.grey[100]};
+        }
+
+        ${theme.breakpoints.up("sm")} {
+            height: 50px;
+            cursor: default;
+
+            &::after {
+                content: none;
+            }
+        }
+    `,
+);
+
+export const Item = createComponentSlot(Typography)<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "item",
+})(
+    ({ theme }) => css`
+        color: ${theme.palette.grey[900]};
+        white-space: nowrap;
+
+        &:not(:last-child):hover {
+            color: ${theme.palette.primary.main};
+        }
+
+        &:last-child {
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+    `,
+) as typeof Typography;
+
+export const ActiveItem = createComponentSlot(Typography)<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "activeItem",
+})(
+    ({ theme }) => css`
+        color: ${theme.palette.grey[900]};
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 14px;
+        line-height: 16px;
+        font-weight: 600;
+
+        ${theme.breakpoints.up("sm")} {
+            font-size: 16px;
+            line-height: 20px;
+            font-weight: bold;
+        }
+    `,
+) as typeof Typography;
+
+export const Separator = createComponentSlot("div")<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "separator",
+})(css`
+    margin: 0 5px;
+    display: flex;
+    align-items: flex-end;
+`);
+
+export const Ellipsis = createComponentSlot(Typography)<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "ellipsis",
+})(
+    ({ theme }) => css`
+        margin-right: 5px;
+        color: inherit;
+        font-size: 14px;
+        line-height: 16px;
+
+        ${theme.breakpoints.up("sm")} {
+            font-size: 16px;
+            line-height: 20px;
+        }
+    `,
+);
+
+export const OverflowButton = createComponentSlot(ButtonBase)<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "overflowButton",
+})(
+    ({ theme }) => css`
+        color: ${theme.palette.grey[900]};
+
+        &:hover {
+            color: ${theme.palette.primary.main};
+        }
+    `,
+);
+
+export const OverflowMenu = createComponentSlot(MuiPopover)<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "overflowMenu",
+})(
+    ({ theme }) => css`
+        & .MuiPaper-root {
+            min-width: 220px;
+            padding: 10px 0;
+            border-radius: 4px;
+            background-color: ${theme.palette.background.paper};
+            box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.1);
+        }
+    `,
+);
+
+export const OverflowMenuItem = createComponentSlot("a")<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "overflowMenuItem",
+})(
+    ({ theme }) => css`
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        height: 35px;
+        padding: 8px 15px;
+        color: ${theme.palette.grey[900]};
+        text-decoration: none;
+
+        & > svg {
+            font-size: 16px;
+        }
+
+        &:hover {
+            color: ${theme.palette.primary.main};
+        }
+    `,
+);
+
+type MenuContainerOwnerState = { isCurrentItem: boolean };
+
+export const MenuContainer = createComponentSlot("div")<BreadcrumbsClassKey, MenuContainerOwnerState>({
+    componentName: "Breadcrumbs",
+    slotName: "menuContainer",
+})(
+    ({ ownerState }) => css`
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        flex-shrink: ${ownerState.isCurrentItem ? 1 : 0};
+        min-width: ${ownerState.isCurrentItem ? 0 : "auto"};
+    `,
+);
+
+export const EllipsisMeasureLayer = styled("div")`
+    position: absolute;
+    visibility: hidden;
+    pointer-events: none;
+    height: 0;
+    overflow: hidden;
+    white-space: nowrap;
+`;
+
+export const ToolbarContainer = createComponentSlot("div")<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "toolbarContainer",
+})(
+    ({ theme }) => css`
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        height: 40px;
+        padding: 0;
+
+        ${theme.breakpoints.up("sm")} {
+            flex: 1;
+            min-width: 0;
+            justify-content: flex-start;
+            overflow: hidden;
+            height: 50px;
+        }
+    `,
+);
+
+export const ExpandedMenu = createComponentSlot("div")<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "expandedMenu",
+})(
+    ({ theme }) => css`
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 100%;
+        display: flex;
+        flex-direction: column;
+        background-color: ${theme.palette.background.paper};
+        z-index: 1;
+    `,
+);
+
+export const ExpandedMenuItem = createComponentSlot(Typography)<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "expandedMenuItem",
+})(
+    ({ theme }) => css`
+        color: ${theme.palette.grey[900]};
+    `,
+) as typeof Typography;
+
+export const ExpandedMenuActiveItem = createComponentSlot(Typography)<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "expandedMenuActiveItem",
+})(
+    ({ theme }) => css`
+        color: ${theme.palette.grey[900]};
+    `,
+) as typeof Typography;
+
+type WrapperOwnerState = { indentation: number };
+
+const wrapperPaddingLeft = (theme: Theme, indentation: number) =>
+    indentation === 0 ? theme.spacing(3) : `calc(${theme.spacing(1)} + 17px * ${indentation})`;
+
+export const ExpandedMenuActiveItemWrapper = createComponentSlot("div")<BreadcrumbsClassKey, WrapperOwnerState>({
+    componentName: "Breadcrumbs",
+    slotName: "expandedMenuActiveItemWrapper",
+})(
+    ({ theme, ownerState }) => css`
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        height: 45px;
+        padding-left: ${wrapperPaddingLeft(theme, ownerState.indentation)};
+        padding-right: ${theme.spacing(3)};
+        background-color: ${alpha(theme.palette.primary.main, 0.1)};
+    `,
+);
+
+export const ExpandedMenuSubitemWrapper = createComponentSlot("div")<BreadcrumbsClassKey, WrapperOwnerState>({
+    componentName: "Breadcrumbs",
+    slotName: "expandedMenuSubitemWrapper",
+})(
+    ({ theme, ownerState }) => css`
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        height: 45px;
+        padding-left: ${wrapperPaddingLeft(theme, ownerState.indentation)};
+        padding-right: ${theme.spacing(3)};
+    `,
+);
+
+export const MobileMenuIcon = createComponentSlot("div")<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "mobileMenuIcon",
+})(css`
+    display: flex;
+    align-items: center;
+`);
+
+export const MobileRootButton = createComponentSlot(ButtonBase)<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "mobileRootButton",
+})(css`
+    display: block;
+    width: 100%;
+    text-align: left;
+`);
+
+export const PageTreeVerticalLine = createComponentSlot("div")<BreadcrumbsClassKey>({
+    componentName: "Breadcrumbs",
+    slotName: "pageTreeVerticalLine",
+})(
+    ({ theme }) => css`
+        width: 4px;
+        height: 25px;
+        border-left: 1px solid ${theme.palette.grey[100]};
+        border-bottom: 1px solid ${theme.palette.grey[100]};
+        align-self: flex-start;
+    `,
+);

--- a/packages/admin/admin/src/common/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/admin/admin/src/common/breadcrumbs/Breadcrumbs.tsx
@@ -1,27 +1,32 @@
 import { ChevronDown, ChevronRight, ChevronUp } from "@comet/admin-icons";
-import { ButtonBase, type ComponentsOverrides, Typography, useMediaQuery } from "@mui/material";
-import { alpha, css, type Theme, useThemeProps } from "@mui/material/styles";
-import { Fragment, type ReactNode, useState } from "react";
+import { type ButtonBase, type ComponentsOverrides, type Popover as MuiPopover, Typography, useMediaQuery } from "@mui/material";
+import { type Theme, useThemeProps } from "@mui/material/styles";
+import { type ReactNode, type Ref, useRef, useState } from "react";
 
-import { createComponentSlot } from "../../helpers/createComponentSlot";
 import type { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
-
-type BreadcrumbsClassKey =
-    | "root"
-    | "item"
-    | "activeItem"
-    | "separator"
-    | "ellipsis"
-    | "menuContainer"
-    | "toolbarContainer"
-    | "expandedMenu"
-    | "expandedMenuItem"
-    | "expandedMenuActiveItem"
-    | "expandedMenuActiveItemWrapper"
-    | "pageTreeVerticalLine"
-    | "expandedMenuSubitemWrapper"
-    | "mobileMenuIcon"
-    | "mobileRootButton";
+import {
+    ActiveItem,
+    type BreadcrumbsClassKey,
+    Ellipsis,
+    EllipsisMeasureLayer,
+    ExpandedMenu,
+    ExpandedMenuActiveItem,
+    ExpandedMenuActiveItemWrapper,
+    ExpandedMenuItem,
+    ExpandedMenuSubitemWrapper,
+    Item,
+    MenuContainer,
+    MobileMenuIcon,
+    MobileRootButton,
+    OverflowButton,
+    OverflowMenu,
+    OverflowMenuItem,
+    PageTreeVerticalLine,
+    Root,
+    Separator,
+    ToolbarContainer,
+} from "./Breadcrumbs.styles";
+import { useBreadcrumbsOverflow } from "./useBreadcrumbsOverflow";
 
 export interface Breadcrumb {
     url: string;
@@ -35,6 +40,9 @@ interface BreadcrumbsProps
         activeItem: typeof Typography;
         separator: "div";
         ellipsis: typeof Typography;
+        overflowButton: typeof ButtonBase;
+        overflowMenu: typeof MuiPopover;
+        overflowMenuItem: "a";
         menuContainer: "div";
         toolbarContainer: "div";
         expandedMenu: "div";
@@ -50,243 +58,190 @@ interface BreadcrumbsProps
     iconMapping?: { separator?: ReactNode; openMenu?: ReactNode; closeMenu?: ReactNode };
 }
 
-const Root = createComponentSlot("div")<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "root",
-})(
-    ({ theme }) => css`
-        position: relative;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        height: 40px;
-        padding: 0 ${theme.spacing(2)};
-        cursor: pointer;
+type BreadcrumbsSlotProps = BreadcrumbsProps["slotProps"];
 
-        &::after {
-            content: "";
-            position: absolute;
-            left: ${theme.spacing(2)};
-            right: ${theme.spacing(2)};
-            bottom: 0;
-            height: 1px;
-            background-color: ${theme.palette.grey[100]};
-        }
+const ellipsisLabel = ". . .";
 
-        ${theme.breakpoints.up("sm")} {
-            height: 50px;
-            cursor: default;
-
-            &::after {
-                content: none;
-            }
-        }
-    `,
+const BreadcrumbItemLink = ({ item, separatorIcon, slotProps }: { item: Breadcrumb; separatorIcon: ReactNode; slotProps?: BreadcrumbsSlotProps }) => (
+    <MenuContainer ownerState={{ isCurrentItem: false }} {...slotProps?.menuContainer}>
+        {/* @ts-expect-error The component prop does not work properly with MUIs `styled()`, see: https://mui.com/material-ui/guides/typescript/#complications-with-the-component-prop */}
+        <Item component="a" href={item.url} {...slotProps?.item}>
+            {item.title}
+        </Item>
+        <Separator {...slotProps?.separator}>{separatorIcon}</Separator>
+    </MenuContainer>
 );
 
-const Item = createComponentSlot(Typography)<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "item",
-})(
-    ({ theme }) => css`
-        color: ${theme.palette.grey[900]};
-        white-space: nowrap;
-
-        &:not(:last-child):hover {
-            color: ${theme.palette.primary.main};
-        }
-
-        &:last-child {
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-    `,
-) as typeof Typography;
-
-const ActiveItem = createComponentSlot(Typography)<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "activeItem",
-})(
-    ({ theme }) => css`
-        color: ${theme.palette.grey[900]};
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        font-size: 14px;
-        line-height: 16px;
-        font-weight: 600;
-
-        ${theme.breakpoints.up("sm")} {
-            font-size: 16px;
-            line-height: 20px;
-            font-weight: bold;
-        }
-    `,
-) as typeof Typography;
-
-const Separator = createComponentSlot("div")<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "separator",
-})(css`
-    margin: 0 5px;
-    display: flex;
-    align-items: flex-end;
-`);
-
-const Ellipsis = createComponentSlot(Typography)<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "ellipsis",
-})(
-    ({ theme }) => css`
-        margin-right: 5px;
-        color: inherit;
-        font-size: 14px;
-        line-height: 16px;
-
-        ${theme.breakpoints.up("sm")} {
-            font-size: 16px;
-            line-height: 20px;
-        }
-    `,
+const CurrentBreadcrumbItem = ({ item, slotProps }: { item: Breadcrumb; slotProps?: BreadcrumbsSlotProps }) => (
+    <MenuContainer ownerState={{ isCurrentItem: true }} {...slotProps?.menuContainer}>
+        <ActiveItem {...slotProps?.activeItem}>{item.title}</ActiveItem>
+    </MenuContainer>
 );
 
-const MenuContainer = createComponentSlot("div")<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "menuContainer",
-})(
-    ({ theme }) => css`
-        display: none;
-
-        ${theme.breakpoints.up("sm")} {
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-            justify-content: center;
-        }
-    `,
+const OverflowEllipsis = ({
+    separatorIcon,
+    slotProps,
+    onClick,
+    buttonRef,
+}: {
+    separatorIcon: ReactNode;
+    slotProps?: BreadcrumbsSlotProps;
+    onClick?: () => void;
+    buttonRef?: Ref<HTMLButtonElement>;
+}) => (
+    <MenuContainer ownerState={{ isCurrentItem: false }} {...slotProps?.menuContainer}>
+        <OverflowButton ref={buttonRef} onClick={onClick} {...slotProps?.overflowButton}>
+            <Ellipsis {...slotProps?.ellipsis}>{ellipsisLabel}</Ellipsis>
+        </OverflowButton>
+        <Separator {...slotProps?.separator}>{separatorIcon}</Separator>
+    </MenuContainer>
 );
 
-const ToolbarContainer = createComponentSlot("div")<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "toolbarContainer",
-})(
-    ({ theme }) => css`
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        height: 40px;
-        padding: 0;
+const ExpandedMenuEntry = ({
+    item,
+    indentation,
+    isCurrentItem,
+    slotProps,
+}: {
+    item: Breadcrumb;
+    indentation: number;
+    isCurrentItem: boolean;
+    slotProps?: BreadcrumbsSlotProps;
+}) => {
+    const Wrapper = isCurrentItem ? ExpandedMenuActiveItemWrapper : ExpandedMenuSubitemWrapper;
+    const wrapperSlotProps = isCurrentItem ? slotProps?.expandedMenuActiveItemWrapper : slotProps?.expandedMenuSubitemWrapper;
 
-        ${theme.breakpoints.up("sm")} {
-            height: 50px;
-            padding: 0 ${theme.spacing(2)};
-        }
-    `,
-);
+    return (
+        <Wrapper ownerState={{ indentation }} {...wrapperSlotProps}>
+            {indentation > 0 && <PageTreeVerticalLine {...slotProps?.pageTreeVerticalLine} />}
+            {isCurrentItem ? (
+                <ExpandedMenuActiveItem variant="subtitle2" {...slotProps?.expandedMenuActiveItem}>
+                    {item.title}
+                </ExpandedMenuActiveItem>
+            ) : (
+                <ExpandedMenuItem variant="body2" {...slotProps?.expandedMenuItem}>
+                    {item.title}
+                </ExpandedMenuItem>
+            )}
+        </Wrapper>
+    );
+};
 
-const ExpandedMenu = createComponentSlot("div")<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "expandedMenu",
-})(
-    ({ theme }) => css`
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 100%;
-        display: flex;
-        flex-direction: column;
-        background-color: ${theme.palette.background.paper};
-        z-index: 1;
-    `,
-);
+interface DesktopBreadcrumbsProps extends Omit<BreadcrumbsProps, "iconMapping"> {
+    separatorIcon: ReactNode;
+}
 
-const ExpandedMenuItem = createComponentSlot(Typography)<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "expandedMenuItem",
-})(
-    ({ theme }) => css`
-        color: ${theme.palette.grey[900]};
-    `,
-) as typeof Typography;
+const DesktopBreadcrumbs = ({ items, separatorIcon, slotProps, ...restProps }: DesktopBreadcrumbsProps) => {
+    const [isOverflowMenuOpen, setIsOverflowMenuOpen] = useState(false);
+    const toolbarRef = useRef<HTMLDivElement>(null);
+    const ellipsisMeasureRef = useRef<HTMLDivElement>(null);
+    const overflowButtonRef = useRef<HTMLButtonElement>(null);
 
-const ExpandedMenuActiveItem = createComponentSlot(Typography)<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "expandedMenuActiveItem",
-})(
-    ({ theme }) => css`
-        color: ${theme.palette.grey[900]};
-    `,
-) as typeof Typography;
+    const { isMeasuring, numberOfHiddenItems } = useBreadcrumbsOverflow({ items, itemsRef: toolbarRef, ellipsisRef: ellipsisMeasureRef });
+    const hasHiddenItems = !isMeasuring && numberOfHiddenItems > 0;
+    const hiddenItems = hasHiddenItems ? items.slice(1, 1 + numberOfHiddenItems) : [];
 
-type WrapperOwnerState = { indentation: number };
+    // While measuring, all items are rendered so that `useBreadcrumbsOverflow` can determine their widths.
+    const itemsAfterFirst = items.slice(1);
+    const visibleTrailingItems = isMeasuring ? itemsAfterFirst : itemsAfterFirst.slice(numberOfHiddenItems);
 
-const wrapperPaddingLeft = (theme: Theme, indentation: number) =>
-    indentation === 0 ? theme.spacing(3) : `calc(${theme.spacing(1)} + 17px * ${indentation})`;
+    return (
+        <Root {...slotProps?.root} {...restProps}>
+            <ToolbarContainer ref={toolbarRef} {...slotProps?.toolbarContainer}>
+                {items.length <= 1 ? (
+                    items.map((item) => <CurrentBreadcrumbItem key={item.url} item={item} slotProps={slotProps} />)
+                ) : (
+                    <>
+                        <BreadcrumbItemLink item={items[0]} separatorIcon={separatorIcon} slotProps={slotProps} />
+                        {hasHiddenItems && (
+                            <OverflowEllipsis
+                                separatorIcon={separatorIcon}
+                                slotProps={slotProps}
+                                onClick={() => setIsOverflowMenuOpen((prev) => !prev)}
+                                buttonRef={overflowButtonRef}
+                            />
+                        )}
+                        {visibleTrailingItems.map((item, index) =>
+                            index === visibleTrailingItems.length - 1 ? (
+                                <CurrentBreadcrumbItem key={item.url} item={item} slotProps={slotProps} />
+                            ) : (
+                                <BreadcrumbItemLink key={item.url} item={item} separatorIcon={separatorIcon} slotProps={slotProps} />
+                            ),
+                        )}
+                    </>
+                )}
+            </ToolbarContainer>
 
-const ExpandedMenuActiveItemWrapper = createComponentSlot("div")<BreadcrumbsClassKey, WrapperOwnerState>({
-    componentName: "Breadcrumbs",
-    slotName: "expandedMenuActiveItemWrapper",
-})(
-    ({ theme, ownerState }) => css`
-        display: flex;
-        align-items: center;
-        gap: 5px;
-        height: 45px;
-        padding-left: ${wrapperPaddingLeft(theme, ownerState.indentation)};
-        padding-right: ${theme.spacing(3)};
-        background-color: ${alpha(theme.palette.primary.main, 0.1)};
-    `,
-);
+            <EllipsisMeasureLayer ref={ellipsisMeasureRef} aria-hidden>
+                <OverflowEllipsis separatorIcon={separatorIcon} slotProps={slotProps} />
+            </EllipsisMeasureLayer>
 
-const ExpandedMenuSubitemWrapper = createComponentSlot("div")<BreadcrumbsClassKey, WrapperOwnerState>({
-    componentName: "Breadcrumbs",
-    slotName: "expandedMenuSubitemWrapper",
-})(
-    ({ theme, ownerState }) => css`
-        display: flex;
-        align-items: center;
-        gap: 5px;
-        height: 45px;
-        padding-left: ${wrapperPaddingLeft(theme, ownerState.indentation)};
-        padding-right: ${theme.spacing(3)};
-    `,
-);
+            <OverflowMenu
+                open={isOverflowMenuOpen && hiddenItems.length > 0}
+                anchorEl={overflowButtonRef.current}
+                anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+                transformOrigin={{ vertical: "top", horizontal: "left" }}
+                marginThreshold={0}
+                onClose={() => setIsOverflowMenuOpen(false)}
+                {...slotProps?.overflowMenu}
+            >
+                {hiddenItems.map((item) => (
+                    <OverflowMenuItem key={item.url} href={item.url} {...slotProps?.overflowMenuItem}>
+                        <ChevronRight />
+                        <Typography variant="body2">{item.title}</Typography>
+                    </OverflowMenuItem>
+                ))}
+            </OverflowMenu>
+        </Root>
+    );
+};
 
-const MobileMenuIcon = createComponentSlot("div")<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "mobileMenuIcon",
-})(css`
-    display: flex;
-    align-items: center;
-`);
+interface MobileBreadcrumbsProps extends Omit<BreadcrumbsProps, "iconMapping"> {
+    separatorIcon: ReactNode;
+    openMenuIcon: ReactNode;
+    closeMenuIcon: ReactNode;
+}
 
-const MobileRootButton = createComponentSlot(ButtonBase)<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "mobileRootButton",
-})(css`
-    display: block;
-    width: 100%;
-    text-align: left;
-`);
+const MobileBreadcrumbs = ({ items, separatorIcon, openMenuIcon, closeMenuIcon, slotProps, ...restProps }: MobileBreadcrumbsProps) => {
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const currentItem = items[items.length - 1];
 
-const PageTreeVerticalLine = createComponentSlot("div")<BreadcrumbsClassKey>({
-    componentName: "Breadcrumbs",
-    slotName: "pageTreeVerticalLine",
-})(
-    ({ theme }) => css`
-        width: 4px;
-        height: 25px;
-        border-left: 1px solid ${theme.palette.grey[100]};
-        border-bottom: 1px solid ${theme.palette.grey[100]};
-        align-self: flex-start;
-    `,
-);
+    return (
+        <MobileRootButton onClick={() => setIsMenuOpen((prev) => !prev)} {...slotProps?.mobileRootButton}>
+            <Root {...slotProps?.root} {...restProps}>
+                <ToolbarContainer {...slotProps?.toolbarContainer}>
+                    {items.length > 1 && (
+                        <>
+                            <Ellipsis {...slotProps?.ellipsis}>{ellipsisLabel}</Ellipsis>
+                            <Separator {...slotProps?.separator}>{separatorIcon}</Separator>
+                        </>
+                    )}
+                    <ActiveItem {...slotProps?.activeItem}>{currentItem.title}</ActiveItem>
+                </ToolbarContainer>
+
+                {isMenuOpen && (
+                    <ExpandedMenu {...slotProps?.expandedMenu}>
+                        {items.map((item, index) => (
+                            <ExpandedMenuEntry
+                                key={item.url}
+                                item={item}
+                                indentation={index}
+                                isCurrentItem={index === items.length - 1}
+                                slotProps={slotProps}
+                            />
+                        ))}
+                    </ExpandedMenu>
+                )}
+
+                <MobileMenuIcon {...slotProps?.mobileMenuIcon}>{isMenuOpen ? closeMenuIcon : openMenuIcon}</MobileMenuIcon>
+            </Root>
+        </MobileRootButton>
+    );
+};
 
 export const Breadcrumbs = (inProps: BreadcrumbsProps) => {
-    const { iconMapping = {}, items, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminBreadcrumbs" });
-    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const { iconMapping = {}, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminBreadcrumbs" });
     const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
-    const ellipsis = ". . .";
 
     const {
         separator: separatorIcon = <ChevronRight />,
@@ -294,85 +249,11 @@ export const Breadcrumbs = (inProps: BreadcrumbsProps) => {
         closeMenu: closeMenuIcon = <ChevronUp />,
     } = iconMapping;
 
-    const toggleMenu = () => {
-        setIsMenuOpen((prev) => !prev);
-    };
-
-    const coreNode = (
-        <Root {...slotProps?.root} {...restProps}>
-            <ToolbarContainer {...slotProps?.toolbarContainer}>
-                {items.map((item, index) => {
-                    const isCurrentPage = index === items.length - 1;
-                    const hasMultipleItems = items.length > 1;
-
-                    if (isCurrentPage) {
-                        return (
-                            <Fragment key={item.url}>
-                                {hasMultipleItems && isMobile && (
-                                    <>
-                                        <Ellipsis {...slotProps?.ellipsis}>{ellipsis}</Ellipsis>
-                                        <Separator {...slotProps?.separator}>{separatorIcon}</Separator>
-                                    </>
-                                )}
-                                <ActiveItem key={item.url} {...slotProps?.activeItem}>
-                                    {item.title}
-                                </ActiveItem>
-                            </Fragment>
-                        );
-                    }
-
-                    if (isMobile) {
-                        return null;
-                    }
-
-                    return (
-                        <MenuContainer key={item.url} {...slotProps?.menuContainer}>
-                            {/* @ts-expect-error The component prop does not work properly with MUIs `styled()`, see: https://mui.com/material-ui/guides/typescript/#complications-with-the-component-prop */}
-                            <Item component="a" href={item.url} {...slotProps?.item}>
-                                {item.title}
-                            </Item>
-                            <Separator {...slotProps?.separator}>{separatorIcon}</Separator>
-                        </MenuContainer>
-                    );
-                })}
-                {isMenuOpen && (
-                    <ExpandedMenu {...slotProps?.expandedMenu}>
-                        {items.map((item, index) => {
-                            const isActive = index === items.length - 1;
-                            const Wrapper = isActive ? ExpandedMenuActiveItemWrapper : ExpandedMenuSubitemWrapper;
-                            const wrapperSlotProps = isActive ? slotProps?.expandedMenuActiveItemWrapper : slotProps?.expandedMenuSubitemWrapper;
-                            return (
-                                <Wrapper key={item.url} ownerState={{ indentation: index }} {...wrapperSlotProps}>
-                                    {index > 0 && <PageTreeVerticalLine {...slotProps?.pageTreeVerticalLine} />}
-                                    {isActive ? (
-                                        <ExpandedMenuActiveItem variant="subtitle2" {...slotProps?.expandedMenuActiveItem}>
-                                            {item.title}
-                                        </ExpandedMenuActiveItem>
-                                    ) : (
-                                        <ExpandedMenuItem variant="body2" {...slotProps?.expandedMenuItem}>
-                                            {item.title}
-                                        </ExpandedMenuItem>
-                                    )}
-                                </Wrapper>
-                            );
-                        })}
-                    </ExpandedMenu>
-                )}
-            </ToolbarContainer>
-
-            {isMobile && <MobileMenuIcon {...slotProps?.mobileMenuIcon}>{isMenuOpen ? closeMenuIcon : openMenuIcon}</MobileMenuIcon>}
-        </Root>
-    );
-
     if (isMobile) {
-        return (
-            <MobileRootButton onClick={toggleMenu} {...slotProps?.mobileRootButton}>
-                {coreNode}
-            </MobileRootButton>
-        );
+        return <MobileBreadcrumbs separatorIcon={separatorIcon} openMenuIcon={openMenuIcon} closeMenuIcon={closeMenuIcon} {...restProps} />;
     }
 
-    return coreNode;
+    return <DesktopBreadcrumbs separatorIcon={separatorIcon} {...restProps} />;
 };
 
 declare module "@mui/material/styles" {

--- a/packages/admin/admin/src/common/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/admin/admin/src/common/breadcrumbs/Breadcrumbs.tsx
@@ -1,39 +1,19 @@
 import { ChevronDown, ChevronRight, ChevronUp } from "@comet/admin-icons";
-import { type ButtonBase, type ComponentsOverrides, type Popover as MuiPopover, Typography, useMediaQuery } from "@mui/material";
+import { type ButtonBase, type ComponentsOverrides, type Popover as MuiPopover, type Typography, useMediaQuery } from "@mui/material";
 import { type Theme, useThemeProps } from "@mui/material/styles";
-import { type ReactNode, type Ref, useRef, useState } from "react";
+import type { ReactNode } from "react";
 
 import type { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
-import {
-    ActiveItem,
-    type BreadcrumbsClassKey,
-    Ellipsis,
-    EllipsisMeasureLayer,
-    ExpandedMenu,
-    ExpandedMenuActiveItem,
-    ExpandedMenuActiveItemWrapper,
-    ExpandedMenuItem,
-    ExpandedMenuSubitemWrapper,
-    Item,
-    MenuContainer,
-    MobileMenuIcon,
-    MobileRootButton,
-    OverflowButton,
-    OverflowMenu,
-    OverflowMenuItem,
-    PageTreeVerticalLine,
-    Root,
-    Separator,
-    ToolbarContainer,
-} from "./Breadcrumbs.styles";
-import { useBreadcrumbsOverflow } from "./useBreadcrumbsOverflow";
+import type { BreadcrumbsClassKey } from "./Breadcrumbs.slots";
+import { DesktopBreadcrumbs } from "./DesktopBreadcrumbs";
+import { MobileBreadcrumbs } from "./MobileBreadcrumbs";
 
 export interface Breadcrumb {
     url: string;
     title: ReactNode;
 }
 
-interface BreadcrumbsProps
+export interface BreadcrumbsProps
     extends ThemedComponentBaseProps<{
         root: "div";
         item: typeof Typography;
@@ -58,190 +38,11 @@ interface BreadcrumbsProps
     iconMapping?: { separator?: ReactNode; openMenu?: ReactNode; closeMenu?: ReactNode };
 }
 
-type BreadcrumbsSlotProps = BreadcrumbsProps["slotProps"];
-
-const ellipsisLabel = ". . .";
-
-const BreadcrumbItemLink = ({ item, separatorIcon, slotProps }: { item: Breadcrumb; separatorIcon: ReactNode; slotProps?: BreadcrumbsSlotProps }) => (
-    <MenuContainer ownerState={{ isCurrentItem: false }} {...slotProps?.menuContainer}>
-        {/* @ts-expect-error The component prop does not work properly with MUIs `styled()`, see: https://mui.com/material-ui/guides/typescript/#complications-with-the-component-prop */}
-        <Item component="a" href={item.url} {...slotProps?.item}>
-            {item.title}
-        </Item>
-        <Separator {...slotProps?.separator}>{separatorIcon}</Separator>
-    </MenuContainer>
-);
-
-const CurrentBreadcrumbItem = ({ item, slotProps }: { item: Breadcrumb; slotProps?: BreadcrumbsSlotProps }) => (
-    <MenuContainer ownerState={{ isCurrentItem: true }} {...slotProps?.menuContainer}>
-        <ActiveItem {...slotProps?.activeItem}>{item.title}</ActiveItem>
-    </MenuContainer>
-);
-
-const OverflowEllipsis = ({
-    separatorIcon,
-    slotProps,
-    onClick,
-    buttonRef,
-}: {
-    separatorIcon: ReactNode;
-    slotProps?: BreadcrumbsSlotProps;
-    onClick?: () => void;
-    buttonRef?: Ref<HTMLButtonElement>;
-}) => (
-    <MenuContainer ownerState={{ isCurrentItem: false }} {...slotProps?.menuContainer}>
-        <OverflowButton ref={buttonRef} onClick={onClick} {...slotProps?.overflowButton}>
-            <Ellipsis {...slotProps?.ellipsis}>{ellipsisLabel}</Ellipsis>
-        </OverflowButton>
-        <Separator {...slotProps?.separator}>{separatorIcon}</Separator>
-    </MenuContainer>
-);
-
-const ExpandedMenuEntry = ({
-    item,
-    indentation,
-    isCurrentItem,
-    slotProps,
-}: {
-    item: Breadcrumb;
-    indentation: number;
-    isCurrentItem: boolean;
-    slotProps?: BreadcrumbsSlotProps;
-}) => {
-    const Wrapper = isCurrentItem ? ExpandedMenuActiveItemWrapper : ExpandedMenuSubitemWrapper;
-    const wrapperSlotProps = isCurrentItem ? slotProps?.expandedMenuActiveItemWrapper : slotProps?.expandedMenuSubitemWrapper;
-
-    return (
-        <Wrapper ownerState={{ indentation }} {...wrapperSlotProps}>
-            {indentation > 0 && <PageTreeVerticalLine {...slotProps?.pageTreeVerticalLine} />}
-            {isCurrentItem ? (
-                <ExpandedMenuActiveItem variant="subtitle2" {...slotProps?.expandedMenuActiveItem}>
-                    {item.title}
-                </ExpandedMenuActiveItem>
-            ) : (
-                <ExpandedMenuItem variant="body2" {...slotProps?.expandedMenuItem}>
-                    {item.title}
-                </ExpandedMenuItem>
-            )}
-        </Wrapper>
-    );
-};
-
-interface DesktopBreadcrumbsProps extends Omit<BreadcrumbsProps, "iconMapping"> {
-    separatorIcon: ReactNode;
-}
-
-const DesktopBreadcrumbs = ({ items, separatorIcon, slotProps, ...restProps }: DesktopBreadcrumbsProps) => {
-    const [isOverflowMenuOpen, setIsOverflowMenuOpen] = useState(false);
-    const toolbarRef = useRef<HTMLDivElement>(null);
-    const ellipsisMeasureRef = useRef<HTMLDivElement>(null);
-    const overflowButtonRef = useRef<HTMLButtonElement>(null);
-
-    const { isMeasuring, numberOfHiddenItems } = useBreadcrumbsOverflow({ items, itemsRef: toolbarRef, ellipsisRef: ellipsisMeasureRef });
-    const hasHiddenItems = !isMeasuring && numberOfHiddenItems > 0;
-    const hiddenItems = hasHiddenItems ? items.slice(1, 1 + numberOfHiddenItems) : [];
-
-    // While measuring, all items are rendered so that `useBreadcrumbsOverflow` can determine their widths.
-    const itemsAfterFirst = items.slice(1);
-    const visibleTrailingItems = isMeasuring ? itemsAfterFirst : itemsAfterFirst.slice(numberOfHiddenItems);
-
-    return (
-        <Root {...slotProps?.root} {...restProps}>
-            <ToolbarContainer ref={toolbarRef} {...slotProps?.toolbarContainer}>
-                {items.length <= 1 ? (
-                    items.map((item) => <CurrentBreadcrumbItem key={item.url} item={item} slotProps={slotProps} />)
-                ) : (
-                    <>
-                        <BreadcrumbItemLink item={items[0]} separatorIcon={separatorIcon} slotProps={slotProps} />
-                        {hasHiddenItems && (
-                            <OverflowEllipsis
-                                separatorIcon={separatorIcon}
-                                slotProps={slotProps}
-                                onClick={() => setIsOverflowMenuOpen((prev) => !prev)}
-                                buttonRef={overflowButtonRef}
-                            />
-                        )}
-                        {visibleTrailingItems.map((item, index) =>
-                            index === visibleTrailingItems.length - 1 ? (
-                                <CurrentBreadcrumbItem key={item.url} item={item} slotProps={slotProps} />
-                            ) : (
-                                <BreadcrumbItemLink key={item.url} item={item} separatorIcon={separatorIcon} slotProps={slotProps} />
-                            ),
-                        )}
-                    </>
-                )}
-            </ToolbarContainer>
-
-            <EllipsisMeasureLayer ref={ellipsisMeasureRef} aria-hidden>
-                <OverflowEllipsis separatorIcon={separatorIcon} slotProps={slotProps} />
-            </EllipsisMeasureLayer>
-
-            <OverflowMenu
-                open={isOverflowMenuOpen && hiddenItems.length > 0}
-                anchorEl={overflowButtonRef.current}
-                anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-                transformOrigin={{ vertical: "top", horizontal: "left" }}
-                marginThreshold={0}
-                onClose={() => setIsOverflowMenuOpen(false)}
-                {...slotProps?.overflowMenu}
-            >
-                {hiddenItems.map((item) => (
-                    <OverflowMenuItem key={item.url} href={item.url} {...slotProps?.overflowMenuItem}>
-                        <ChevronRight />
-                        <Typography variant="body2">{item.title}</Typography>
-                    </OverflowMenuItem>
-                ))}
-            </OverflowMenu>
-        </Root>
-    );
-};
-
-interface MobileBreadcrumbsProps extends Omit<BreadcrumbsProps, "iconMapping"> {
-    separatorIcon: ReactNode;
-    openMenuIcon: ReactNode;
-    closeMenuIcon: ReactNode;
-}
-
-const MobileBreadcrumbs = ({ items, separatorIcon, openMenuIcon, closeMenuIcon, slotProps, ...restProps }: MobileBreadcrumbsProps) => {
-    const [isMenuOpen, setIsMenuOpen] = useState(false);
-    const currentItem = items[items.length - 1];
-
-    return (
-        <MobileRootButton onClick={() => setIsMenuOpen((prev) => !prev)} {...slotProps?.mobileRootButton}>
-            <Root {...slotProps?.root} {...restProps}>
-                <ToolbarContainer {...slotProps?.toolbarContainer}>
-                    {items.length > 1 && (
-                        <>
-                            <Ellipsis {...slotProps?.ellipsis}>{ellipsisLabel}</Ellipsis>
-                            <Separator {...slotProps?.separator}>{separatorIcon}</Separator>
-                        </>
-                    )}
-                    <ActiveItem {...slotProps?.activeItem}>{currentItem.title}</ActiveItem>
-                </ToolbarContainer>
-
-                {isMenuOpen && (
-                    <ExpandedMenu {...slotProps?.expandedMenu}>
-                        {items.map((item, index) => (
-                            <ExpandedMenuEntry
-                                key={item.url}
-                                item={item}
-                                indentation={index}
-                                isCurrentItem={index === items.length - 1}
-                                slotProps={slotProps}
-                            />
-                        ))}
-                    </ExpandedMenu>
-                )}
-
-                <MobileMenuIcon {...slotProps?.mobileMenuIcon}>{isMenuOpen ? closeMenuIcon : openMenuIcon}</MobileMenuIcon>
-            </Root>
-        </MobileRootButton>
-    );
-};
+export type BreadcrumbsSlotProps = BreadcrumbsProps["slotProps"];
 
 export const Breadcrumbs = (inProps: BreadcrumbsProps) => {
     const { iconMapping = {}, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminBreadcrumbs" });
-    const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
+    const isDesktop = useMediaQuery((theme: Theme) => theme.breakpoints.up("sm"));
 
     const {
         separator: separatorIcon = <ChevronRight />,
@@ -249,11 +50,11 @@ export const Breadcrumbs = (inProps: BreadcrumbsProps) => {
         closeMenu: closeMenuIcon = <ChevronUp />,
     } = iconMapping;
 
-    if (isMobile) {
-        return <MobileBreadcrumbs separatorIcon={separatorIcon} openMenuIcon={openMenuIcon} closeMenuIcon={closeMenuIcon} {...restProps} />;
+    if (isDesktop) {
+        return <DesktopBreadcrumbs separatorIcon={separatorIcon} {...restProps} />;
     }
 
-    return <DesktopBreadcrumbs separatorIcon={separatorIcon} {...restProps} />;
+    return <MobileBreadcrumbs separatorIcon={separatorIcon} openMenuIcon={openMenuIcon} closeMenuIcon={closeMenuIcon} {...restProps} />;
 };
 
 declare module "@mui/material/styles" {

--- a/packages/admin/admin/src/common/breadcrumbs/DesktopBreadcrumbs.tsx
+++ b/packages/admin/admin/src/common/breadcrumbs/DesktopBreadcrumbs.tsx
@@ -1,0 +1,124 @@
+import { ChevronRight } from "@comet/admin-icons";
+import { Typography } from "@mui/material";
+import { type ReactNode, type Ref, useRef, useState } from "react";
+
+import type { Breadcrumb, BreadcrumbsProps, BreadcrumbsSlotProps } from "./Breadcrumbs";
+import {
+    ActiveItem,
+    Ellipsis,
+    ellipsisLabel,
+    EllipsisMeasureLayer,
+    Item,
+    MenuContainer,
+    OverflowButton,
+    OverflowMenu,
+    OverflowMenuItem,
+    Root,
+    Separator,
+    ToolbarContainer,
+} from "./Breadcrumbs.slots";
+import { useBreadcrumbsOverflow } from "./useBreadcrumbsOverflow";
+
+interface DesktopBreadcrumbsProps extends Omit<BreadcrumbsProps, "iconMapping"> {
+    separatorIcon: ReactNode;
+}
+
+const BreadcrumbItemLink = ({ item, separatorIcon, slotProps }: { item: Breadcrumb; separatorIcon: ReactNode; slotProps?: BreadcrumbsSlotProps }) => (
+    <MenuContainer ownerState={{ isCurrentItem: false }} {...slotProps?.menuContainer}>
+        {/* @ts-expect-error The component prop does not work properly with MUIs `styled()`, see: https://mui.com/material-ui/guides/typescript/#complications-with-the-component-prop */}
+        <Item component="a" href={item.url} {...slotProps?.item}>
+            {item.title}
+        </Item>
+        <Separator {...slotProps?.separator}>{separatorIcon}</Separator>
+    </MenuContainer>
+);
+
+const CurrentBreadcrumbItem = ({ item, slotProps }: { item: Breadcrumb; slotProps?: BreadcrumbsSlotProps }) => (
+    <MenuContainer ownerState={{ isCurrentItem: true }} {...slotProps?.menuContainer}>
+        <ActiveItem {...slotProps?.activeItem}>{item.title}</ActiveItem>
+    </MenuContainer>
+);
+
+const OverflowEllipsis = ({
+    separatorIcon,
+    slotProps,
+    onClick,
+    buttonRef,
+}: {
+    separatorIcon: ReactNode;
+    slotProps?: BreadcrumbsSlotProps;
+    onClick?: () => void;
+    buttonRef?: Ref<HTMLButtonElement>;
+}) => (
+    <MenuContainer ownerState={{ isCurrentItem: false }} {...slotProps?.menuContainer}>
+        <OverflowButton ref={buttonRef} onClick={onClick} {...slotProps?.overflowButton}>
+            <Ellipsis {...slotProps?.ellipsis}>{ellipsisLabel}</Ellipsis>
+        </OverflowButton>
+        <Separator {...slotProps?.separator}>{separatorIcon}</Separator>
+    </MenuContainer>
+);
+
+export const DesktopBreadcrumbs = ({ items, separatorIcon, slotProps, ...restProps }: DesktopBreadcrumbsProps) => {
+    const [isOverflowMenuOpen, setIsOverflowMenuOpen] = useState(false);
+    const toolbarRef = useRef<HTMLDivElement>(null);
+    const ellipsisMeasureRef = useRef<HTMLDivElement>(null);
+    const overflowButtonRef = useRef<HTMLButtonElement>(null);
+
+    const { isMeasuring, numberOfHiddenItems } = useBreadcrumbsOverflow({ items, itemsRef: toolbarRef, ellipsisRef: ellipsisMeasureRef });
+    const hasHiddenItems = !isMeasuring && numberOfHiddenItems > 0;
+    const hiddenItems = hasHiddenItems ? items.slice(1, 1 + numberOfHiddenItems) : [];
+
+    // While measuring, all items are rendered so that `useBreadcrumbsOverflow` can determine their widths.
+    const itemsAfterFirst = items.slice(1);
+    const visibleTrailingItems = isMeasuring ? itemsAfterFirst : itemsAfterFirst.slice(numberOfHiddenItems);
+
+    return (
+        <Root {...slotProps?.root} {...restProps}>
+            <ToolbarContainer ref={toolbarRef} {...slotProps?.toolbarContainer}>
+                {items.length <= 1 ? (
+                    items.map((item) => <CurrentBreadcrumbItem key={item.url} item={item} slotProps={slotProps} />)
+                ) : (
+                    <>
+                        <BreadcrumbItemLink item={items[0]} separatorIcon={separatorIcon} slotProps={slotProps} />
+                        {hasHiddenItems && (
+                            <OverflowEllipsis
+                                separatorIcon={separatorIcon}
+                                slotProps={slotProps}
+                                onClick={() => setIsOverflowMenuOpen((prev) => !prev)}
+                                buttonRef={overflowButtonRef}
+                            />
+                        )}
+                        {visibleTrailingItems.map((item, index) =>
+                            index === visibleTrailingItems.length - 1 ? (
+                                <CurrentBreadcrumbItem key={item.url} item={item} slotProps={slotProps} />
+                            ) : (
+                                <BreadcrumbItemLink key={item.url} item={item} separatorIcon={separatorIcon} slotProps={slotProps} />
+                            ),
+                        )}
+                    </>
+                )}
+            </ToolbarContainer>
+
+            <EllipsisMeasureLayer ref={ellipsisMeasureRef} aria-hidden>
+                <OverflowEllipsis separatorIcon={separatorIcon} slotProps={slotProps} />
+            </EllipsisMeasureLayer>
+
+            <OverflowMenu
+                open={isOverflowMenuOpen && hiddenItems.length > 0}
+                anchorEl={overflowButtonRef.current}
+                anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+                transformOrigin={{ vertical: "top", horizontal: "left" }}
+                marginThreshold={0}
+                onClose={() => setIsOverflowMenuOpen(false)}
+                {...slotProps?.overflowMenu}
+            >
+                {hiddenItems.map((item) => (
+                    <OverflowMenuItem key={item.url} href={item.url} {...slotProps?.overflowMenuItem}>
+                        <ChevronRight />
+                        <Typography variant="body2">{item.title}</Typography>
+                    </OverflowMenuItem>
+                ))}
+            </OverflowMenu>
+        </Root>
+    );
+};

--- a/packages/admin/admin/src/common/breadcrumbs/DesktopBreadcrumbs.tsx
+++ b/packages/admin/admin/src/common/breadcrumbs/DesktopBreadcrumbs.tsx
@@ -7,8 +7,8 @@ import {
     ActiveItem,
     Ellipsis,
     ellipsisLabel,
-    EllipsisMeasureLayer,
     Item,
+    MeasureLayer,
     MenuContainer,
     OverflowButton,
     OverflowMenu,
@@ -61,47 +61,42 @@ const OverflowEllipsis = ({
 export const DesktopBreadcrumbs = ({ items, separatorIcon, slotProps, ...restProps }: DesktopBreadcrumbsProps) => {
     const [isOverflowMenuOpen, setIsOverflowMenuOpen] = useState(false);
     const toolbarRef = useRef<HTMLDivElement>(null);
-    const ellipsisMeasureRef = useRef<HTMLDivElement>(null);
+    const measureRef = useRef<HTMLDivElement>(null);
     const overflowButtonRef = useRef<HTMLButtonElement>(null);
 
-    const { isMeasuring, numberOfHiddenItems } = useBreadcrumbsOverflow({ items, itemsRef: toolbarRef, ellipsisRef: ellipsisMeasureRef });
-    const hasHiddenItems = !isMeasuring && numberOfHiddenItems > 0;
-    const hiddenItems = hasHiddenItems ? items.slice(1, 1 + numberOfHiddenItems) : [];
-
-    // While measuring, all items are rendered so that `useBreadcrumbsOverflow` can determine their widths.
-    const itemsAfterFirst = items.slice(1);
-    const visibleTrailingItems = isMeasuring ? itemsAfterFirst : itemsAfterFirst.slice(numberOfHiddenItems);
+    const { leadingItem, hiddenItems, trailingItems } = useBreadcrumbsOverflow({ items, containerRef: toolbarRef, measureRef });
 
     return (
         <Root {...slotProps?.root} {...restProps}>
             <ToolbarContainer ref={toolbarRef} {...slotProps?.toolbarContainer}>
-                {items.length <= 1 ? (
-                    items.map((item) => <CurrentBreadcrumbItem key={item.url} item={item} slotProps={slotProps} />)
-                ) : (
-                    <>
-                        <BreadcrumbItemLink item={items[0]} separatorIcon={separatorIcon} slotProps={slotProps} />
-                        {hasHiddenItems && (
-                            <OverflowEllipsis
-                                separatorIcon={separatorIcon}
-                                slotProps={slotProps}
-                                onClick={() => setIsOverflowMenuOpen((prev) => !prev)}
-                                buttonRef={overflowButtonRef}
-                            />
-                        )}
-                        {visibleTrailingItems.map((item, index) =>
-                            index === visibleTrailingItems.length - 1 ? (
-                                <CurrentBreadcrumbItem key={item.url} item={item} slotProps={slotProps} />
-                            ) : (
-                                <BreadcrumbItemLink key={item.url} item={item} separatorIcon={separatorIcon} slotProps={slotProps} />
-                            ),
-                        )}
-                    </>
+                {leadingItem && <BreadcrumbItemLink item={leadingItem} separatorIcon={separatorIcon} slotProps={slotProps} />}
+                {hiddenItems.length > 0 && (
+                    <OverflowEllipsis
+                        separatorIcon={separatorIcon}
+                        slotProps={slotProps}
+                        onClick={() => setIsOverflowMenuOpen((prev) => !prev)}
+                        buttonRef={overflowButtonRef}
+                    />
+                )}
+                {trailingItems.map((item, index) =>
+                    index === trailingItems.length - 1 ? (
+                        <CurrentBreadcrumbItem key={item.url} item={item} slotProps={slotProps} />
+                    ) : (
+                        <BreadcrumbItemLink key={item.url} item={item} separatorIcon={separatorIcon} slotProps={slotProps} />
+                    ),
                 )}
             </ToolbarContainer>
 
-            <EllipsisMeasureLayer ref={ellipsisMeasureRef} aria-hidden>
+            <MeasureLayer ref={measureRef} aria-hidden>
+                {items.map((item, index) =>
+                    index === items.length - 1 ? (
+                        <CurrentBreadcrumbItem key={item.url} item={item} slotProps={slotProps} />
+                    ) : (
+                        <BreadcrumbItemLink key={item.url} item={item} separatorIcon={separatorIcon} slotProps={slotProps} />
+                    ),
+                )}
                 <OverflowEllipsis separatorIcon={separatorIcon} slotProps={slotProps} />
-            </EllipsisMeasureLayer>
+            </MeasureLayer>
 
             <OverflowMenu
                 open={isOverflowMenuOpen && hiddenItems.length > 0}

--- a/packages/admin/admin/src/common/breadcrumbs/DesktopBreadcrumbs.tsx
+++ b/packages/admin/admin/src/common/breadcrumbs/DesktopBreadcrumbs.tsx
@@ -1,6 +1,6 @@
 import { ChevronRight } from "@comet/admin-icons";
 import { Typography } from "@mui/material";
-import { type ReactNode, type Ref, useRef, useState } from "react";
+import { type ReactNode, type Ref, useEffect, useRef, useState } from "react";
 
 import type { Breadcrumb, BreadcrumbsProps, BreadcrumbsSlotProps } from "./Breadcrumbs";
 import {
@@ -65,12 +65,19 @@ export const DesktopBreadcrumbs = ({ items, separatorIcon, slotProps, ...restPro
     const overflowButtonRef = useRef<HTMLButtonElement>(null);
 
     const { leadingItem, hiddenItems, trailingItems } = useBreadcrumbsOverflow({ items, containerRef: toolbarRef, measureRef });
+    const hasHiddenItems = hiddenItems.length > 0;
+
+    useEffect(() => {
+        if (!hasHiddenItems) {
+            setIsOverflowMenuOpen(false);
+        }
+    }, [hasHiddenItems]);
 
     return (
         <Root {...slotProps?.root} {...restProps}>
             <ToolbarContainer ref={toolbarRef} {...slotProps?.toolbarContainer}>
                 {leadingItem && <BreadcrumbItemLink item={leadingItem} separatorIcon={separatorIcon} slotProps={slotProps} />}
-                {hiddenItems.length > 0 && (
+                {hasHiddenItems && (
                     <OverflowEllipsis
                         separatorIcon={separatorIcon}
                         slotProps={slotProps}
@@ -98,22 +105,24 @@ export const DesktopBreadcrumbs = ({ items, separatorIcon, slotProps, ...restPro
                 <OverflowEllipsis separatorIcon={separatorIcon} slotProps={slotProps} />
             </MeasureLayer>
 
-            <OverflowMenu
-                open={isOverflowMenuOpen && hiddenItems.length > 0}
-                anchorEl={overflowButtonRef.current}
-                anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-                transformOrigin={{ vertical: "top", horizontal: "left" }}
-                marginThreshold={0}
-                onClose={() => setIsOverflowMenuOpen(false)}
-                {...slotProps?.overflowMenu}
-            >
-                {hiddenItems.map((item) => (
-                    <OverflowMenuItem key={item.url} href={item.url} {...slotProps?.overflowMenuItem}>
-                        <ChevronRight />
-                        <Typography variant="body2">{item.title}</Typography>
-                    </OverflowMenuItem>
-                ))}
-            </OverflowMenu>
+            {hasHiddenItems && (
+                <OverflowMenu
+                    open={isOverflowMenuOpen}
+                    anchorEl={overflowButtonRef.current}
+                    anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+                    transformOrigin={{ vertical: "top", horizontal: "left" }}
+                    marginThreshold={0}
+                    onClose={() => setIsOverflowMenuOpen(false)}
+                    {...slotProps?.overflowMenu}
+                >
+                    {hiddenItems.map((item) => (
+                        <OverflowMenuItem key={item.url} href={item.url} {...slotProps?.overflowMenuItem}>
+                            <ChevronRight />
+                            <Typography variant="body2">{item.title}</Typography>
+                        </OverflowMenuItem>
+                    ))}
+                </OverflowMenu>
+            )}
         </Root>
     );
 };

--- a/packages/admin/admin/src/common/breadcrumbs/MobileBreadcrumbs.tsx
+++ b/packages/admin/admin/src/common/breadcrumbs/MobileBreadcrumbs.tsx
@@ -1,0 +1,92 @@
+import { type ReactNode, useState } from "react";
+
+import type { Breadcrumb, BreadcrumbsProps, BreadcrumbsSlotProps } from "./Breadcrumbs";
+import {
+    ActiveItem,
+    Ellipsis,
+    ellipsisLabel,
+    ExpandedMenu,
+    ExpandedMenuActiveItem,
+    ExpandedMenuActiveItemWrapper,
+    ExpandedMenuItem,
+    ExpandedMenuSubitemWrapper,
+    MobileMenuIcon,
+    MobileRootButton,
+    PageTreeVerticalLine,
+    Root,
+    Separator,
+    ToolbarContainer,
+} from "./Breadcrumbs.slots";
+
+interface MobileBreadcrumbsProps extends Omit<BreadcrumbsProps, "iconMapping"> {
+    separatorIcon: ReactNode;
+    openMenuIcon: ReactNode;
+    closeMenuIcon: ReactNode;
+}
+
+const ExpandedMenuEntry = ({
+    item,
+    indentation,
+    isCurrentItem,
+    slotProps,
+}: {
+    item: Breadcrumb;
+    indentation: number;
+    isCurrentItem: boolean;
+    slotProps?: BreadcrumbsSlotProps;
+}) => {
+    const Wrapper = isCurrentItem ? ExpandedMenuActiveItemWrapper : ExpandedMenuSubitemWrapper;
+    const wrapperSlotProps = isCurrentItem ? slotProps?.expandedMenuActiveItemWrapper : slotProps?.expandedMenuSubitemWrapper;
+
+    return (
+        <Wrapper ownerState={{ indentation }} {...wrapperSlotProps}>
+            {indentation > 0 && <PageTreeVerticalLine {...slotProps?.pageTreeVerticalLine} />}
+            {isCurrentItem ? (
+                <ExpandedMenuActiveItem variant="subtitle2" {...slotProps?.expandedMenuActiveItem}>
+                    {item.title}
+                </ExpandedMenuActiveItem>
+            ) : (
+                <ExpandedMenuItem variant="body2" {...slotProps?.expandedMenuItem}>
+                    {item.title}
+                </ExpandedMenuItem>
+            )}
+        </Wrapper>
+    );
+};
+
+export const MobileBreadcrumbs = ({ items, separatorIcon, openMenuIcon, closeMenuIcon, slotProps, ...restProps }: MobileBreadcrumbsProps) => {
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const currentItem = items[items.length - 1];
+
+    return (
+        <MobileRootButton onClick={() => setIsMenuOpen((prev) => !prev)} {...slotProps?.mobileRootButton}>
+            <Root {...slotProps?.root} {...restProps}>
+                <ToolbarContainer {...slotProps?.toolbarContainer}>
+                    {items.length > 1 && (
+                        <>
+                            <Ellipsis {...slotProps?.ellipsis}>{ellipsisLabel}</Ellipsis>
+                            <Separator {...slotProps?.separator}>{separatorIcon}</Separator>
+                        </>
+                    )}
+                    <ActiveItem {...slotProps?.activeItem}>{currentItem.title}</ActiveItem>
+                </ToolbarContainer>
+
+                {isMenuOpen && (
+                    <ExpandedMenu {...slotProps?.expandedMenu}>
+                        {items.map((item, index) => (
+                            <ExpandedMenuEntry
+                                key={item.url}
+                                item={item}
+                                indentation={index}
+                                isCurrentItem={index === items.length - 1}
+                                slotProps={slotProps}
+                            />
+                        ))}
+                    </ExpandedMenu>
+                )}
+
+                <MobileMenuIcon {...slotProps?.mobileMenuIcon}>{isMenuOpen ? closeMenuIcon : openMenuIcon}</MobileMenuIcon>
+            </Root>
+        </MobileRootButton>
+    );
+};

--- a/packages/admin/admin/src/common/breadcrumbs/__stories__/Breadcrumbs.stories.tsx
+++ b/packages/admin/admin/src/common/breadcrumbs/__stories__/Breadcrumbs.stories.tsx
@@ -39,3 +39,15 @@ export const Five = () => {
 export const Seven = () => {
     return <Breadcrumbs items={sevenItems} />;
 };
+
+export const ResponsiveDesktop = () => {
+    return (
+        <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+            {[760, 560, 400, 280].map((width) => (
+                <div key={width} style={{ width }}>
+                    <Breadcrumbs items={sevenItems} />
+                </div>
+            ))}
+        </div>
+    );
+};

--- a/packages/admin/admin/src/common/breadcrumbs/__stories__/Breadcrumbs.stories.tsx
+++ b/packages/admin/admin/src/common/breadcrumbs/__stories__/Breadcrumbs.stories.tsx
@@ -44,7 +44,7 @@ export const ResponsiveDesktop = () => {
     return (
         <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
             {[760, 560, 400, 280].map((width) => (
-                <div key={width} style={{ width }}>
+                <div key={width} style={{ maxWidth: width }}>
                     <Breadcrumbs items={sevenItems} />
                 </div>
             ))}

--- a/packages/admin/admin/src/common/breadcrumbs/useBreadcrumbsOverflow.ts
+++ b/packages/admin/admin/src/common/breadcrumbs/useBreadcrumbsOverflow.ts
@@ -1,84 +1,99 @@
-import { type RefObject, useEffect, useMemo, useState } from "react";
+import { type RefObject, useEffect, useState } from "react";
 
 import { getElementOuterWidth } from "../../utils/getElementOuterWidth";
 import { useObservedWidth } from "../../utils/useObservedWidth";
 import type { Breadcrumb } from "./Breadcrumbs";
 
-// Determines how many items (starting after the first one) need to be collapsed into the overflow ellipsis so that
-// the first item, the ellipsis and as many trailing items as possible fit into the available width. The first item
-// (root) and the last item (current page) are always kept, matching the responsive behavior of `StackBreadcrumbs`.
-const getNumberOfHiddenItems = ({
-    itemWidths,
-    ellipsisWidth,
+type MeasuredWidths = { itemWidths: number[]; ellipsisWidth: number };
+
+type BreadcrumbsOverflow = {
+    leadingItem?: Breadcrumb;
+    hiddenItems: Breadcrumb[];
+    trailingItems: Breadcrumb[];
+};
+
+const getOverflow = ({
+    items,
+    measuredWidths,
     containerWidth,
 }: {
-    itemWidths: number[];
-    ellipsisWidth: number;
+    items: Breadcrumb[];
+    measuredWidths?: MeasuredWidths;
     containerWidth: number;
-}): number => {
-    if (itemWidths.length <= 2) {
-        return 0;
+}): BreadcrumbsOverflow => {
+    const lastIndex = items.length - 1;
+
+    if (lastIndex < 1) {
+        return { hiddenItems: [], trailingItems: items };
     }
 
-    const totalWidth = itemWidths.reduce((sum, width) => sum + width, 0);
-    if (totalWidth <= containerWidth) {
-        return 0;
+    const allItemsVisible = { leadingItem: items[0], hiddenItems: [], trailingItems: items.slice(1) };
+
+    if (!measuredWidths || measuredWidths.itemWidths.length !== items.length) {
+        return allItemsVisible;
     }
 
-    const lastIndex = itemWidths.length - 1;
-    const availableWidthForTrailingItems = containerWidth - itemWidths[0] - ellipsisWidth;
+    const { itemWidths, ellipsisWidth } = measuredWidths;
 
-    let usedWidth = itemWidths[lastIndex]; // The last item (current page) is always shown.
-    let firstVisibleTrailingIndex = lastIndex;
+    if (itemWidths.reduce((sum, width) => sum + width, 0) <= containerWidth) {
+        return allItemsVisible;
+    }
 
-    for (let index = lastIndex - 1; index >= 1; index--) {
-        if (usedWidth + itemWidths[index] > availableWidthForTrailingItems) {
+    const isRootVisible = itemWidths[0] + ellipsisWidth + itemWidths[lastIndex] <= containerWidth;
+    const firstCollapsibleIndex = isRootVisible ? 1 : 0;
+    const availableWidth = containerWidth - ellipsisWidth - (isRootVisible ? itemWidths[0] : 0);
+
+    let usedWidth = itemWidths[lastIndex];
+    let firstTrailingIndex = lastIndex;
+
+    for (let index = lastIndex - 1; index >= firstCollapsibleIndex; index--) {
+        if (usedWidth + itemWidths[index] > availableWidth) {
             break;
         }
         usedWidth += itemWidths[index];
-        firstVisibleTrailingIndex = index;
+        firstTrailingIndex = index;
     }
 
-    return firstVisibleTrailingIndex - 1;
+    return {
+        leadingItem: isRootVisible ? items[0] : undefined,
+        hiddenItems: items.slice(firstCollapsibleIndex, firstTrailingIndex),
+        trailingItems: items.slice(firstTrailingIndex),
+    };
 };
 
 /**
- * Measures the rendered breadcrumb items and the overflow ellipsis to determine how many items don't fit into the
- * available width. While `isMeasuring` is `true`, all items must be rendered so that their widths can be measured.
+ * Distributes the breadcrumb items over the leading item, the overflow menu and the trailing items, based on the
+ * available width.
+ *
+ * The widths are measured in a hidden layer instead of on the visible items, because the current item shrinks and
+ * truncates as soon as the items overflow. Measuring the visible items would report that already-shrunk width and
+ * therefore never detect the overflow it is supposed to resolve.
  */
 export const useBreadcrumbsOverflow = ({
     items,
-    itemsRef,
-    ellipsisRef,
+    containerRef,
+    measureRef,
 }: {
     items: Breadcrumb[];
-    itemsRef: RefObject<HTMLElement | null>;
-    ellipsisRef: RefObject<HTMLElement | null>;
-}): { isMeasuring: boolean; numberOfHiddenItems: number } => {
-    const containerWidth = useObservedWidth(itemsRef);
-    const [itemWidths, setItemWidths] = useState<number[] | undefined>();
-    const [ellipsisWidth, setEllipsisWidth] = useState<number | undefined>();
+    containerRef: RefObject<HTMLElement | null>;
+    measureRef: RefObject<HTMLElement | null>;
+}): BreadcrumbsOverflow => {
+    const containerWidth = useObservedWidth(containerRef);
+    const [measuredWidths, setMeasuredWidths] = useState<MeasuredWidths>();
     const itemsKey = items.map((item) => item.url).join("|");
 
     useEffect(() => {
-        setItemWidths(undefined);
-    }, [itemsKey]);
+        const children = measureRef.current?.children;
 
-    useEffect(() => {
-        if (items.length && !itemWidths?.length) {
-            const children = itemsRef.current?.children;
-            setItemWidths(children ? Array.from(children).map(getElementOuterWidth) : []);
+        if (!children?.length) {
+            setMeasuredWidths(undefined);
+            return;
         }
-        if (ellipsisRef.current && ellipsisWidth === undefined) {
-            setEllipsisWidth(getElementOuterWidth(ellipsisRef.current));
-        }
-    }, [items.length, itemsKey, itemWidths, ellipsisWidth, itemsRef, ellipsisRef]);
 
-    const isMeasuring = !itemWidths?.length || ellipsisWidth === undefined;
-    const numberOfHiddenItems = useMemo(
-        () => (isMeasuring ? 0 : getNumberOfHiddenItems({ itemWidths, ellipsisWidth, containerWidth })),
-        [isMeasuring, itemWidths, ellipsisWidth, containerWidth],
-    );
+        const widths = Array.from(children).map(getElementOuterWidth);
 
-    return { isMeasuring, numberOfHiddenItems };
+        setMeasuredWidths({ itemWidths: widths.slice(0, -1), ellipsisWidth: widths[widths.length - 1] });
+    }, [itemsKey, measureRef]);
+
+    return getOverflow({ items, measuredWidths, containerWidth });
 };

--- a/packages/admin/admin/src/common/breadcrumbs/useBreadcrumbsOverflow.ts
+++ b/packages/admin/admin/src/common/breadcrumbs/useBreadcrumbsOverflow.ts
@@ -1,10 +1,8 @@
 import { type RefObject, useEffect, useMemo, useState } from "react";
 
+import { getElementOuterWidth } from "../../utils/getElementOuterWidth";
 import { useObservedWidth } from "../../utils/useObservedWidth";
 import type { Breadcrumb } from "./Breadcrumbs";
-
-const getElementOuterWidth = (element: Element): number =>
-    element.clientWidth + parseFloat(getComputedStyle(element).marginLeft) + parseFloat(getComputedStyle(element).marginRight);
 
 // Determines how many items (starting after the first one) need to be collapsed into the overflow ellipsis so that
 // the first item, the ellipsis and as many trailing items as possible fit into the available width. The first item

--- a/packages/admin/admin/src/common/breadcrumbs/useBreadcrumbsOverflow.ts
+++ b/packages/admin/admin/src/common/breadcrumbs/useBreadcrumbsOverflow.ts
@@ -1,0 +1,86 @@
+import { type RefObject, useEffect, useMemo, useState } from "react";
+
+import { useObservedWidth } from "../../utils/useObservedWidth";
+import type { Breadcrumb } from "./Breadcrumbs";
+
+const getElementOuterWidth = (element: Element): number =>
+    element.clientWidth + parseFloat(getComputedStyle(element).marginLeft) + parseFloat(getComputedStyle(element).marginRight);
+
+// Determines how many items (starting after the first one) need to be collapsed into the overflow ellipsis so that
+// the first item, the ellipsis and as many trailing items as possible fit into the available width. The first item
+// (root) and the last item (current page) are always kept, matching the responsive behavior of `StackBreadcrumbs`.
+const getNumberOfHiddenItems = ({
+    itemWidths,
+    ellipsisWidth,
+    containerWidth,
+}: {
+    itemWidths: number[];
+    ellipsisWidth: number;
+    containerWidth: number;
+}): number => {
+    if (itemWidths.length <= 2) {
+        return 0;
+    }
+
+    const totalWidth = itemWidths.reduce((sum, width) => sum + width, 0);
+    if (totalWidth <= containerWidth) {
+        return 0;
+    }
+
+    const lastIndex = itemWidths.length - 1;
+    const availableWidthForTrailingItems = containerWidth - itemWidths[0] - ellipsisWidth;
+
+    let usedWidth = itemWidths[lastIndex]; // The last item (current page) is always shown.
+    let firstVisibleTrailingIndex = lastIndex;
+
+    for (let index = lastIndex - 1; index >= 1; index--) {
+        if (usedWidth + itemWidths[index] > availableWidthForTrailingItems) {
+            break;
+        }
+        usedWidth += itemWidths[index];
+        firstVisibleTrailingIndex = index;
+    }
+
+    return firstVisibleTrailingIndex - 1;
+};
+
+/**
+ * Measures the rendered breadcrumb items and the overflow ellipsis to determine how many items don't fit into the
+ * available width. While `isMeasuring` is `true`, all items must be rendered so that their widths can be measured.
+ */
+export const useBreadcrumbsOverflow = ({
+    items,
+    itemsRef,
+    ellipsisRef,
+}: {
+    items: Breadcrumb[];
+    itemsRef: RefObject<HTMLElement | null>;
+    ellipsisRef: RefObject<HTMLElement | null>;
+}): { isMeasuring: boolean; numberOfHiddenItems: number } => {
+    const containerWidth = useObservedWidth(itemsRef);
+    const [itemWidths, setItemWidths] = useState<number[] | undefined>();
+    const [ellipsisWidth, setEllipsisWidth] = useState<number | undefined>();
+    const itemsKey = items.map((item) => item.url).join("|");
+
+    useEffect(() => {
+        setItemWidths(undefined);
+    }, [itemsKey]);
+
+    useEffect(() => {
+        if (items.length && !itemWidths?.length) {
+            const children = itemsRef.current?.children;
+            setItemWidths(children ? Array.from(children).map(getElementOuterWidth) : []);
+        }
+        if (ellipsisRef.current && ellipsisWidth === undefined) {
+            setEllipsisWidth(getElementOuterWidth(ellipsisRef.current));
+        }
+    }, [items.length, itemsKey, itemWidths, ellipsisWidth, itemsRef, ellipsisRef]);
+
+    const isMeasuring = !itemWidths?.length || ellipsisWidth === undefined;
+    const numberOfHiddenItems = useMemo(
+        () => (isMeasuring ? 0 : getNumberOfHiddenItems({ itemWidths, ellipsisWidth, containerWidth })),
+        [isMeasuring, itemWidths, ellipsisWidth, containerWidth],
+    );
+
+    return { isMeasuring, numberOfHiddenItems };
+};

--- a/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
@@ -6,9 +6,10 @@ import type { Link } from "react-router-dom";
 
 import { createComponentSlot } from "../../helpers/createComponentSlot";
 import type { ThemedComponentBaseProps } from "../../helpers/ThemedComponentBaseProps";
+import { getElementOuterWidth } from "../../utils/getElementOuterWidth";
 import { useObservedWidth } from "../../utils/useObservedWidth";
 import { useStackApi } from "../Api";
-import { getElementOuterWidth, useItemsToRender } from "./utils";
+import { useItemsToRender } from "./utils";
 
 export type StackBreadcrumbsClassKey =
     | "root"

--- a/packages/admin/admin/src/stack/breadcrumbs/utils.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/utils.tsx
@@ -5,9 +5,6 @@ import { BreadcrumbsEntry } from "./BreadcrumbsEntry";
 import { BreadcrumbsOverflow } from "./BreadcrumbsOverflow";
 import type { StackBreadcrumbsProps } from "./StackBreadcrumbs";
 
-export const getElementOuterWidth = (element: Element): number =>
-    element.clientWidth + parseFloat(getComputedStyle(element).marginLeft) + parseFloat(getComputedStyle(element).marginRight);
-
 const NUMBER_OF_ITEMS_BEFORE_OVERFLOW_MENU = 1;
 
 const useNumberOfItemsToBeHidden = (

--- a/packages/admin/admin/src/utils/getElementOuterWidth.ts
+++ b/packages/admin/admin/src/utils/getElementOuterWidth.ts
@@ -1,0 +1,2 @@
+export const getElementOuterWidth = (element: Element): number =>
+    element.clientWidth + parseFloat(getComputedStyle(element).marginLeft) + parseFloat(getComputedStyle(element).marginRight);


### PR DESCRIPTION
JIRA: https://vivid-planet.atlassian.net/browse/COM-2717
Figma: https://www.figma.com/design/Swzee5YSEkPVlCXHcyL7mp/COMET-DXP-Library?node-id=1227-14437&p=f&m=dev

## Problem

The `Breadcrumbs` admin component only collapsed its items on mobile. On desktop the full trail was always rendered, so long breadcrumb paths overflowed horizontally and could push the current page (the last item) out of view.

## Solution

Make the breadcrumbs responsive on desktop as well: items that don't fit are collapsed into a `. . .` overflow ellipsis, and clicking it opens the same page-tree dropdown the mobile variant already uses (new `overflowButton` slot). The mobile variant itself is unchanged.

The current page is never given up in favour of its parents. Items collapse in this order:

1. The parents between the root and the current page move into the overflow menu, from left to right — the root stays visible: `Blocks > . . . > Select > Select Item`
2. Once the root no longer fits next to the ellipsis and the current page, it moves into the menu as well: `. . . > Select Item`
3. Only when everything else is already in the menu does the current page truncate with a text ellipsis.

**Measuring**

The available width comes from `useObservedWidth`. The item widths are measured in a hidden layer that renders every item plus the ellipsis at `width: max-content` — deliberately *not* on the visible items: the visible row is `overflow: hidden` and the current item is the only one allowed to shrink, so the measured widths would always add up to exactly the container width and the overflow would never be detected.

## Screenshots

<!-- TODO: replace the placeholders below -->

Desktop, collapsing step by step (widths 760 / 560 / 400 / 280 px):

<img width="610" height="252" alt="Screenshot 2026-08-03 at 12 32 33" src="https://github.com/user-attachments/assets/1dd0d8a3-0fc5-48b1-ada3-41fe3e1caa38" />

Desktop, overflow menu opened:

<img width="536" height="239" alt="Screenshot 2026-08-03 at 13 05 30" src="https://github.com/user-attachments/assets/6505ba25-c51e-469d-a1e8-1639e0247ec0" />


Mobile:

<img width="352" height="425" alt="Screenshot 2026-08-03 at 12 35 35" src="https://github.com/user-attachments/assets/92d75d55-10ba-45f9-a1a6-795be259dcae" />

## Further information

No changeset: `Breadcrumbs` is not exported from `src/index.ts` yet, so this doesn't change the package's public API.
