### PR TITLE
Materialize the `EntityInfo` snapshot used by the `block_index_dependencies` refresh

### DIFF
--- a/.changeset/block-index-dependencies-materialize-entity-info.md
+++ b/.changeset/block-index-dependencies-materialize-entity-info.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Materialize the `EntityInfo` snapshot used by the `block_index_dependencies` refresh
+
+The `block_index_dependencies` refresh joins `EntityInfo` for the root and target entity. `EntityInfo` is a plain view (a `UNION` over every entity, including a recursive DAM folder-path CTE), so each refresh re-evaluated it from scratch. The refresh now joins a materialized, indexed snapshot of `EntityInfo` that is refreshed as part of the refresh, turning the joins into indexed lookups against a table scanned once. The live `EntityInfo` view is unchanged, so full-text search and warnings keep reading up-to-date data.

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -24,6 +24,13 @@ interface PGStatActivity {
 // Advisory lock key for block_index_dependencies refresh deduplication.
 const BLOCK_INDEX_REFRESH_LOCK_KEY = 4201;
 
+// Materialized snapshot of the "EntityInfo" view that the block_index_dependencies refresh joins
+// against. Materializing it means the refresh joins an indexed table scanned once, instead of
+// re-evaluating the "EntityInfo" view (a UNION over every entity, incl. a recursive DAM folder-path
+// CTE) twice. The live "EntityInfo" view stays in place for other consumers (full-text search,
+// warnings), so their data remains up-to-date; this snapshot's freshness is tied to the refresh.
+const BLOCK_INDEX_ENTITY_INFO_VIEW = "block_index_entity_info";
+
 @Injectable()
 export class DependenciesService {
     private connection: Connection;
@@ -47,15 +54,25 @@ export class DependenciesService {
         await this.pageTreeFullTextService?.createPageTreeFullTextView();
         await this.entityInfoService.createEntityInfoView();
         await this.fullTextSearchService?.createEntityInfoFullTextView();
+        await this.createBlockIndexEntityInfoView();
         await this.createDependenciesView();
     }
 
     async dropViews(): Promise<void> {
         await this.connection.execute(`DROP MATERIALIZED VIEW IF EXISTS "block_index_dependencies"`);
+        await this.connection.execute(`DROP MATERIALIZED VIEW IF EXISTS "${BLOCK_INDEX_ENTITY_INFO_VIEW}"`);
         await this.connection.execute(`DROP VIEW IF EXISTS "block_index"`);
         await this.fullTextSearchService?.dropEntityInfoFullTextView();
         await this.entityInfoService.dropEntityInfoView();
         await this.pageTreeFullTextService?.dropPageTreeFullTextView();
+    }
+
+    private async createBlockIndexEntityInfoView(): Promise<void> {
+        console.time("creating block index entity info materialized view");
+        await this.connection.execute(`DROP MATERIALIZED VIEW IF EXISTS "${BLOCK_INDEX_ENTITY_INFO_VIEW}"`);
+        await this.connection.execute(`CREATE MATERIALIZED VIEW "${BLOCK_INDEX_ENTITY_INFO_VIEW}" AS SELECT * FROM "EntityInfo"`);
+        await this.connection.execute(`CREATE INDEX ON "${BLOCK_INDEX_ENTITY_INFO_VIEW}" ("entityName", "id")`);
+        console.timeEnd("creating block index entity info materialized view");
     }
 
     private async createDependenciesView(): Promise<void> {
@@ -134,9 +151,9 @@ export class DependenciesService {
                     FROM (
                         ${indexSelects.join("\n UNION ALL \n")}
                     ) blockIndex
-                    LEFT JOIN "EntityInfo" as ei_root ON ei_root."id" = blockIndex."rootId"::text
+                    LEFT JOIN "${BLOCK_INDEX_ENTITY_INFO_VIEW}" as ei_root ON ei_root."id" = blockIndex."rootId"::text
                         AND ei_root."entityName" = blockIndex."rootEntityName"
-                    LEFT JOIN "EntityInfo" as ei_target ON ei_target."id" = blockIndex."targetId"
+                    LEFT JOIN "${BLOCK_INDEX_ENTITY_INFO_VIEW}" as ei_target ON ei_target."id" = blockIndex."targetId"
                         AND ei_target."entityName" = blockIndex."targetEntityName"`;
 
         console.time("creating block dependency materialized view");
@@ -241,6 +258,10 @@ export class DependenciesService {
 
                 await trx("BlockIndexRefresh").insert({ id, startedAt: new Date(), finishedAt: null });
 
+                // Refresh the EntityInfo snapshot first so the dependency refresh joins up-to-date
+                // entity data. Non-concurrent is fine: only the dependency refresh reads it.
+                await trx.raw(`REFRESH MATERIALIZED VIEW "${BLOCK_INDEX_ENTITY_INFO_VIEW}"`);
+
                 await trx.raw(`REFRESH MATERIALIZED VIEW ${refreshOptions?.concurrently ? "CONCURRENTLY" : ""} block_index_dependencies`);
 
                 await trx("BlockIndexRefresh").where({ id }).update({ finishedAt: new Date() });
@@ -271,6 +292,7 @@ export class DependenciesService {
             await knex.transaction(async (trx) => {
                 await trx.raw(`SELECT pg_advisory_xact_lock(?)`, [BLOCK_INDEX_REFRESH_LOCK_KEY]);
                 await trx("BlockIndexRefresh").truncate();
+                await trx.raw(`REFRESH MATERIALIZED VIEW "${BLOCK_INDEX_ENTITY_INFO_VIEW}"`);
                 await trx.raw(`REFRESH MATERIALIZED VIEW block_index_dependencies`);
                 await trx("BlockIndexRefresh").insert({ id: uuid(), startedAt: new Date(), finishedAt: new Date() });
             });


### PR DESCRIPTION
## Description

Follow-up to #6043 (now merged), which joins `EntityInfo` once instead of per root block. The `block_index_dependencies` refresh still re-evaluates the `EntityInfo` view twice from scratch each time. `EntityInfo` is a plain view — a `UNION` over every entity type, including a recursive DAM folder-path CTE — so that re-evaluation is the bulk of the remaining cost over the v8 baseline.

This change introduces a materialized, indexed snapshot (`block_index_entity_info`) of `EntityInfo` that the dependency view joins instead. The snapshot is refreshed just before the dependency view, so the two joins become indexed lookups against a table scanned once rather than repeated evaluations of the recursive view. The refreshed view's columns and contents are unchanged.

## Decisions

- **Dedicated snapshot, not materializing the shared `EntityInfo` view.** `EntityInfo` is also read live by full-text search and the warnings resolver (`getEntityInfo`), which need up-to-date data. Materializing the shared view would make those stale. Instead only the dependency refresh — which is already eventually-consistent — reads the snapshot; the live `EntityInfo` view is untouched. Trade-off: the snapshot is a second materialized view to create/drop/refresh, and it duplicates the `EntityInfo` rows.
- **Refreshed non-concurrently, just before the dependency view, inside the same advisory-locked transaction.** It's fast (~2 s at prod scale) and only the dependency refresh reads it, so an `ACCESS EXCLUSIVE` refresh blocks nothing else.

## Verification

- `fixtures` (→ `createViews`) and `refreshBlockIndexViews` (normal **and** `--force`) run clean. `EntityInfo` stays a plain view; `block_index_entity_info` and `block_index_dependencies` are materialized. On refresh the snapshot syncs to the live `EntityInfo`, and the dependency view's row count/columns are unchanged (all targets resolve).
- **Benchmarked** on the same simulated production-scale dataset as #6043 (millions of index entries, a few hundred thousand dependency rows, ~236k `EntityInfo` rows):

  | Metric | v8 baseline | after #6043 | **this PR (+ snapshot)** |
  | --- | --- | --- | --- |
  | Dependency REFRESH (avg ×3) | 24.2 s | 31.1 s | **25.2 s** |
  | Snapshot REFRESH (new step) | — | — | ~1.8 s |
  | Full refresh cycle | 24.2 s | 31.1 s | **~27 s** |
  | Sort spill to disk | 0 | 234 MB | **0** |
  | Temp-file I/O (written + read) | 0 | 3.7 GB | **1.1 GB** |
  | Shared buffers touched | 1.20 GB | 4.44 GB | **2.40 GB** |

  The dependency refresh reaches ~v8 parity and the disk spill is eliminated; the only added cost is the ~2 s snapshot refresh.

- The concurrent (moderately-stale) refresh path was not exercised in this validation; the change there is only adding the non-concurrent snapshot refresh before the existing `REFRESH … CONCURRENTLY`, so please sanity-check that path in review.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-3093


---
_Generated by [Claude Code](https://claude.ai/code/session_017vm3B9L2R2cz586T2uYQAL)_