### PR TITLE
admin: Add a `describe-implemented` command for a component's source

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -34,7 +34,7 @@
             "project": ["./src/**/*.{ts,tsx}"]
         },
         "packages/admin/admin": {
-            "entry": ["./src/index.ts", "./src/future-ui/index.ts"],
+            "entry": ["./src/index.ts", "./src/future-ui/index.ts", "./src/**/__fixtures__/**"],
             "project": ["./src/**/*.{ts,tsx}"],
             "ignore": [".storybook/public/mockServiceWorker.js"],
             "ignoreDependencies": ["@mui/x-data-grid-premium", "sass"]

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -122,6 +122,7 @@
         "sass": "^1.93.0",
         "storybook": "^10.3.5",
         "storybook-addon-tag-badges": "^3.1.0",
+        "ts-morph": "^25.0.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
         "vite": "^7.3.1",

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -123,6 +123,7 @@
         "sass": "^1.93.0",
         "storybook": "^10.3.5",
         "storybook-addon-tag-badges": "^3.1.0",
+        "ts-morph": "^25.0.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
         "vite": "^7.3.1",

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -123,7 +123,7 @@
         "sass": "^1.93.0",
         "storybook": "^10.3.5",
         "storybook-addon-tag-badges": "^3.1.0",
-        "ts-morph": "^25.0.1",
+        "ts-morph": "^28.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
         "vite": "^7.3.1",

--- a/packages/admin/admin/src/future-ui/README.md
+++ b/packages/admin/admin/src/future-ui/README.md
@@ -196,6 +196,7 @@ Maintainer scripts, run through `pnpm --filter @comet/admin run …`:
 
 - **`future-ui-figma list`** prints the DDS component inventory as JSON — every component or component set a designer has marked for development in Figma (dev status "Ready for development" or "Completed"), skipping non-public `_`-prefixed names. It reads the Figma file over the REST API, so `FIGMA_TOKEN` must be set to a Figma [personal access token](https://developers.figma.com/docs/rest-api/personal-access-tokens/), or `list` fails with an `auth_missing` error. The token needs only the `file_content:read` scope.
 - **`future-ui-figma describe-target <component>`** prints the props one component's Figma design says it should have as JSON — each prop's type, an enum's options, and its default value.
+- **`future-ui-figma describe-implemented <component>`** prints the props one component's source implements, in the same shape as `describe-target`, reading the source instead of Figma.
 - **`generate-future-ui-theme-tokens`** regenerates the theme SCSS partials and types from a design-token export — see [Regenerating the tokens](#regenerating-the-tokens).
 
 ## Known issues

--- a/packages/admin/admin/src/future-ui/README.md
+++ b/packages/admin/admin/src/future-ui/README.md
@@ -215,6 +215,7 @@ Maintainer scripts, run through `pnpm --filter @comet/admin run …`:
 
 - **`future-ui-figma list`** prints the DDS component inventory as JSON — every component or component set a designer has marked for development in Figma (dev status "Ready for development" or "Completed"), skipping non-public `_`-prefixed names. It reads the Figma file over the REST API, so `FIGMA_TOKEN` must be set to a Figma [personal access token](https://developers.figma.com/docs/rest-api/personal-access-tokens/), or `list` fails with an `auth_missing` error. The token needs only the `file_content:read` scope.
 - **`future-ui-figma describe-target <component>`** prints the props one component's Figma design says it should have as JSON — each prop's type, an enum's options, and its default value.
+- **`future-ui-figma describe-implemented <component>`** prints the props one component's source implements, in the same shape as `describe-target`, reading the source instead of Figma.
 - **`generate-future-ui-theme-tokens`** regenerates the theme SCSS partials and types from a design-token export — see [Regenerating the tokens](#regenerating-the-tokens).
 
 ## Known issues

--- a/packages/admin/admin/src/future-ui/cli/figma/__fixtures__/Widget.tsx
+++ b/packages/admin/admin/src/future-ui/cli/figma/__fixtures__/Widget.tsx
@@ -1,0 +1,59 @@
+import type { ComponentPropsWithoutRef, ElementType, ReactNode, Ref } from "react";
+
+type WidgetVariant = "primary" | "secondary";
+
+interface WidgetLabelProps {
+    /**
+     * Where the widget places its label.
+     *
+     * @defaultValue `"top"`
+     */
+    labelPlacement?: "top" | "bottom";
+}
+
+export interface WidgetProps extends Omit<ComponentPropsWithoutRef<"div">, "className">, WidgetLabelProps {
+    /** The widget's caption. */
+    label: string;
+    /**
+     * Visual style.
+     *
+     * @defaultValue `"primary"`
+     */
+    variant?: WidgetVariant;
+    /**
+     * Prevents interaction with the widget.
+     *
+     * @defaultValue `false`
+     */
+    disabled?: boolean;
+    /** Replaces the widget's content with a progress indicator. */
+    loading?: boolean;
+    /**
+     * The semantic element to render, overriding the variant's default.
+     *
+     * @defaultValue The variant's default element
+     */
+    element?: "article" | "section";
+    /** How many items the widget summarizes. */
+    count?: number;
+    /** The icon to render before the label. */
+    startIcon?: ReactNode;
+    /** Added alongside the component's own classes. */
+    className?: string;
+    /** Sets which element a named inner part renders as. */
+    slots?: { startIcon?: ElementType };
+    /** Props for each slot, merged with the slot's own props rather than replacing them. */
+    slotProps?: { startIcon?: ComponentPropsWithoutRef<"span"> };
+    /** Ref forwarded to the root element. */
+    ref?: Ref<HTMLDivElement>;
+}
+
+/** A component standing in for a real one, declaring every kind of prop a description has to cover. */
+export function Widget({ label, children, variant = "primary", disabled = false, loading = false }: WidgetProps) {
+    return (
+        <div data-variant={variant} data-disabled={disabled} data-loading={loading}>
+            {label}
+            {children}
+        </div>
+    );
+}

--- a/packages/admin/admin/src/future-ui/cli/figma/describeImplementedComponent.ts
+++ b/packages/admin/admin/src/future-ui/cli/figma/describeImplementedComponent.ts
@@ -1,0 +1,46 @@
+import { existsSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { ComponentDescription } from "./componentDescription.js";
+import { FigmaCliError } from "./figmaCliError.js";
+import { extractFigmaNodeId } from "./figmaNodeId.js";
+import { describeComponentProps } from "./propDescription.js";
+import { createTsMorphProject } from "./tsMorphProject.js";
+
+const componentsDirectory = join(dirname(fileURLToPath(import.meta.url)), "../../components");
+
+function findFeatureFolder(componentArgument: string): string {
+    const featureFolders = readdirSync(componentsDirectory);
+    const featureFolder = featureFolders.find((entry) => entry.toLowerCase() === componentArgument.toLowerCase());
+    if (!featureFolder) {
+        throw new FigmaCliError(
+            "component_unknown",
+            `"${componentArgument}" is not a future-ui component. Known components: ${featureFolders.join(", ")}`,
+        );
+    }
+    return featureFolder;
+}
+
+function requireExistingFile(filePath: string): string {
+    if (!existsSync(filePath)) {
+        throw new FigmaCliError("source_incomplete", `Could not find "${filePath}"`);
+    }
+    return filePath;
+}
+
+export function describeImplementedComponent(componentArgument: string): ComponentDescription {
+    const featureFolder = findFeatureFolder(componentArgument);
+    const componentName = featureFolder.charAt(0).toUpperCase() + featureFolder.slice(1);
+    const featureDirectory = join(componentsDirectory, featureFolder);
+
+    const componentFilePath = requireExistingFile(join(featureDirectory, `${componentName}.tsx`));
+    const storyFilePath = requireExistingFile(join(featureDirectory, "__stories__", `${componentName}.stories.tsx`));
+    const project = createTsMorphProject();
+
+    return {
+        component: componentName,
+        nodeId: extractFigmaNodeId({ project, storyFilePath }),
+        props: describeComponentProps({ project, componentFilePath, propsInterfaceName: `${componentName}Props` }),
+    };
+}

--- a/packages/admin/admin/src/future-ui/cli/figma/figmaCliError.ts
+++ b/packages/admin/admin/src/future-ui/cli/figma/figmaCliError.ts
@@ -1,4 +1,11 @@
-type FigmaCliErrorCode = "auth_missing" | "scope_denied" | "rate_limited" | "figma_error" | "component_unknown" | "node_missing";
+type FigmaCliErrorCode =
+    | "auth_missing"
+    | "scope_denied"
+    | "rate_limited"
+    | "figma_error"
+    | "component_unknown"
+    | "node_missing"
+    | "source_incomplete";
 
 export class FigmaCliError extends Error {
     readonly code: FigmaCliErrorCode;
@@ -31,6 +38,7 @@ export function exitCodeForError(code: FigmaCliErrorCode): number {
         case "figma_error":
         case "component_unknown":
         case "node_missing":
+        case "source_incomplete":
             return exitCode.error;
     }
 }

--- a/packages/admin/admin/src/future-ui/cli/figma/figmaNodeId.ts
+++ b/packages/admin/admin/src/future-ui/cli/figma/figmaNodeId.ts
@@ -1,0 +1,39 @@
+import { Node, type Project, SyntaxKind } from "ts-morph";
+
+import { FigmaCliError } from "./figmaCliError.js";
+import { getOrAddSourceFile } from "./tsMorphProject.js";
+
+const FIGMA_DESIGN_HELPER_NAME = "figmaDesign";
+const URL_NODE_ID_SEPARATOR = "-";
+const REST_API_NODE_ID_SEPARATOR = ":";
+
+function toRestApiNodeId(urlNodeId: string): string {
+    return urlNodeId.split(URL_NODE_ID_SEPARATOR).join(REST_API_NODE_ID_SEPARATOR);
+}
+
+export function extractFigmaNodeId({ project, storyFilePath }: { project: Project; storyFilePath: string }): string {
+    const storyFile = getOrAddSourceFile(project, storyFilePath);
+
+    for (const call of storyFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+        if (call.getExpression().getText() !== FIGMA_DESIGN_HELPER_NAME) {
+            continue;
+        }
+
+        const [argument] = call.getArguments();
+        if (!argument || !Node.isObjectLiteralExpression(argument)) {
+            continue;
+        }
+
+        const nodeIdProperty = argument.getProperty("nodeId");
+        if (!nodeIdProperty || !Node.isPropertyAssignment(nodeIdProperty)) {
+            continue;
+        }
+
+        const nodeIdLiteral = nodeIdProperty.getInitializerIfKind(SyntaxKind.StringLiteral);
+        if (nodeIdLiteral) {
+            return toRestApiNodeId(nodeIdLiteral.getLiteralValue());
+        }
+    }
+
+    throw new FigmaCliError("source_incomplete", `Could not find a \`${FIGMA_DESIGN_HELPER_NAME}({ nodeId })\` call in "${storyFilePath}"`);
+}

--- a/packages/admin/admin/src/future-ui/cli/figma/futureUiFigma.ts
+++ b/packages/admin/admin/src/future-ui/cli/figma/futureUiFigma.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 
 import { ddsFigmaFileUrl } from "../../storybook/figmaDesign.js";
 import { discoverComponentInventory } from "./componentInventory.js";
+import { describeImplementedComponent } from "./describeImplementedComponent.js";
 import { FigmaRestClient, parseFigmaFileKey, resolveFigmaToken } from "./figmaClient.js";
 import { exitCode, exitCodeForError, FigmaCliError, isFigmaCliError } from "./figmaCliError.js";
 import { describeFigmaTarget } from "./figmaTargetDescription.js";
@@ -32,10 +33,18 @@ async function runDescribeTarget(componentName: string): Promise<void> {
     writeResult({ ok: true, ...describeFigmaTarget(nodes, component.nodeId) });
 }
 
+function runDescribeImplemented(componentName: string): void {
+    writeResult({ ok: true, ...describeImplementedComponent(componentName) });
+}
+
 const program = new Command();
 program.name("future-ui-figma").description("Figma bridge for the future-ui component library (experimental)");
 program.command("list").description("List the DDS component inventory discovered in the Figma file").action(runList);
 program.command("describe-target <component>").description("Describe what a future-ui component's Figma design specifies").action(runDescribeTarget);
+program
+    .command("describe-implemented <component>")
+    .description("Describe what a future-ui component's source implements")
+    .action(runDescribeImplemented);
 
 function toFigmaCliError(error: unknown): FigmaCliError {
     if (isFigmaCliError(error)) {

--- a/packages/admin/admin/src/future-ui/cli/figma/propDescription.test.ts
+++ b/packages/admin/admin/src/future-ui/cli/figma/propDescription.test.ts
@@ -1,0 +1,38 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import type { PropDescription } from "./componentDescription";
+import { describeComponentProps } from "./propDescription";
+import { createTsMorphProject } from "./tsMorphProject";
+
+const fixturesDirectory = join(dirname(fileURLToPath(import.meta.url)), "__fixtures__");
+
+function describeFixtureProps(propsInterfaceName: string): Record<string, PropDescription> {
+    return describeComponentProps({
+        project: createTsMorphProject(),
+        componentFilePath: join(fixturesDirectory, "Widget.tsx"),
+        propsInterfaceName,
+    });
+}
+
+describe("describeComponentProps", () => {
+    it("describes every kind of prop a component declares", () => {
+        expect(describeFixtureProps("WidgetProps")).toStrictEqual({
+            children: { type: "node" },
+            count: { type: "other" },
+            disabled: { type: "boolean", default: false },
+            element: { type: "enum", options: ["article", "section"] },
+            label: { type: "string" },
+            labelPlacement: { type: "enum", options: ["top", "bottom"], default: "top" },
+            loading: { type: "boolean" },
+            startIcon: { type: "node" },
+            variant: { type: "enum", options: ["primary", "secondary"], default: "primary" },
+        });
+    });
+
+    it("reports source_incomplete instead of describing a component without props", () => {
+        expect(() => describeFixtureProps("MissingProps")).toThrow(expect.objectContaining({ code: "source_incomplete" }));
+    });
+});

--- a/packages/admin/admin/src/future-ui/cli/figma/propDescription.ts
+++ b/packages/admin/admin/src/future-ui/cli/figma/propDescription.ts
@@ -1,0 +1,105 @@
+import { Node, type Project, type Symbol as TsMorphSymbol, type Type } from "ts-morph";
+
+import type { PropDescription } from "./componentDescription.js";
+import { FigmaCliError } from "./figmaCliError.js";
+import { getOrAddSourceFile } from "./tsMorphProject.js";
+
+/** The override API every component shares, which no Figma design describes. */
+const OVERRIDE_API_PROP_NAMES = ["className", "slots", "slotProps", "ref"];
+
+/** Inherited props a Figma design can specify, so the code side has to describe them. */
+const DESCRIBED_INHERITED_PROP_NAMES = ["children"];
+
+const REACT_NODE_TYPE_NAMES = ["ReactNode", "React.ReactNode"];
+
+function isInheritedFromRootElement(prop: TsMorphSymbol): boolean {
+    return prop.getDeclarations().every((declaration) => declaration.getSourceFile().isInNodeModules());
+}
+
+function isDescribedProp(prop: TsMorphSymbol): boolean {
+    const name = prop.getName();
+    if (OVERRIDE_API_PROP_NAMES.includes(name)) {
+        return false;
+    }
+    return !isInheritedFromRootElement(prop) || DESCRIBED_INHERITED_PROP_NAMES.includes(name);
+}
+
+function describePropType(propType: Type, declaration: Node): Pick<PropDescription, "type" | "options"> {
+    const members = propType.isUnion() ? propType.getUnionTypes() : [propType];
+    const definedMembers = members.filter((member) => !member.isUndefined());
+
+    if (definedMembers.every((member) => member.isBooleanLiteral())) {
+        return { type: "boolean" };
+    }
+    if (definedMembers.every((member) => member.isStringLiteral())) {
+        return { type: "enum", options: definedMembers.map((member) => String(member.getLiteralValue())) };
+    }
+    // `ReactNode` is a union of too many members to recognize by them; the checker prints its name even through an alias.
+    if (REACT_NODE_TYPE_NAMES.includes(propType.getText(declaration))) {
+        return { type: "node" };
+    }
+    if (definedMembers.length === 1 && definedMembers[0].isString()) {
+        return { type: "string" };
+    }
+    return { type: "other" };
+}
+
+/** The value of a backticked `@defaultValue` tag; a tag that describes the default in prose documents no value. */
+function parseDocumentedValue(tagText: string): string | boolean | undefined {
+    const backticked = tagText.trim().match(/^`([^`]*)`$/);
+    if (!backticked) {
+        return undefined;
+    }
+    const value = backticked[1].trim();
+    if (value === "true" || value === "false") {
+        return value === "true";
+    }
+    const quoted = value.match(/^"([^"]*)"$/) ?? value.match(/^'([^']*)'$/);
+    return quoted ? quoted[1] : value;
+}
+
+/** The documented default only; the default in the component's signature is deliberately not read. */
+function extractDocumentedDefault(declaration: Node): string | boolean | undefined {
+    if (!Node.isJSDocable(declaration)) {
+        return undefined;
+    }
+    const tags = declaration.getJsDocs().flatMap((jsDoc) => jsDoc.getTags());
+    const comment = tags.find((tag) => tag.getTagName() === "defaultValue")?.getCommentText();
+    return comment ? parseDocumentedValue(comment) : undefined;
+}
+
+function describeProp(prop: TsMorphSymbol): PropDescription {
+    const declaration = prop.getValueDeclaration() ?? prop.getDeclarations()[0];
+    const { type, options } = describePropType(prop.getTypeAtLocation(declaration), declaration);
+    const documentedDefault = type === "enum" || type === "boolean" ? extractDocumentedDefault(declaration) : undefined;
+
+    return {
+        type,
+        ...(options ? { options } : {}),
+        ...(documentedDefault !== undefined ? { default: documentedDefault } : {}),
+    };
+}
+
+export function describeComponentProps({
+    project,
+    componentFilePath,
+    propsInterfaceName,
+}: {
+    project: Project;
+    componentFilePath: string;
+    propsInterfaceName: string;
+}): Record<string, PropDescription> {
+    const propsInterface = getOrAddSourceFile(project, componentFilePath).getInterface(propsInterfaceName);
+    if (!propsInterface) {
+        throw new FigmaCliError("source_incomplete", `Could not find interface \`${propsInterfaceName}\` in "${componentFilePath}"`);
+    }
+
+    const describedProps = propsInterface
+        .getType()
+        .getProperties()
+        .filter(isDescribedProp)
+        .map((prop): [name: string, description: PropDescription] => [prop.getName(), describeProp(prop)])
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+    return Object.fromEntries(describedProps);
+}

--- a/packages/admin/admin/src/future-ui/cli/figma/tsMorphProject.ts
+++ b/packages/admin/admin/src/future-ui/cli/figma/tsMorphProject.ts
@@ -1,0 +1,14 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Project, type SourceFile } from "ts-morph";
+
+const adminTsConfigPath = join(dirname(fileURLToPath(import.meta.url)), "../../../../tsconfig.json");
+
+export function createTsMorphProject(): Project {
+    return new Project({ tsConfigFilePath: adminTsConfigPath, skipAddingFilesFromTsConfig: true });
+}
+
+export function getOrAddSourceFile(project: Project, filePath: string): SourceFile {
+    return project.getSourceFile(filePath) ?? project.addSourceFileAtPath(filePath);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -977,6 +977,9 @@ importers:
       storybook-addon-tag-badges:
         specifier: ^3.1.0
         version: 3.1.0(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      ts-morph:
+        specifier: ^25.0.1
+        version: 25.0.1
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.41)(@types/node@24.12.4)(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,7 +321,7 @@ importers:
         version: 6.6.14(@mikro-orm/core@6.6.14)
       '@nestjs/apollo':
         specifier: ^13.4.0
-        version: 13.4.0(@apollo/server@5.5.1(graphql@16.14.2))(@as-integrations/express5@1.1.2(@apollo/server@5.5.1(graphql@16.14.2))(express@5.2.1))(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(@nestjs/graphql@13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@25.0.1))(graphql@16.14.2)
+        version: 13.4.0(@apollo/server@5.5.1(graphql@16.14.2))(@as-integrations/express5@1.1.2(@apollo/server@5.5.1(graphql@16.14.2))(express@5.2.1))(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(@nestjs/graphql@13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@28.0.0))(graphql@16.14.2)
       '@nestjs/common':
         specifier: ^11.1.21
         version: 11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -330,7 +330,7 @@ importers:
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/graphql':
         specifier: ^13.4.0
-        version: 13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@25.0.1)
+        version: 13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@28.0.0)
       '@nestjs/jwt':
         specifier: ^11.0.2
         version: 11.0.2(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))
@@ -981,8 +981,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       ts-morph:
-        specifier: ^25.0.1
-        version: 25.0.1
+        specifier: ^28.0.0
+        version: 28.0.0
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.41)(@types/node@24.12.4)(typescript@5.9.3)
@@ -2010,7 +2010,7 @@ importers:
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/graphql':
         specifier: ^13.4.0
-        version: 13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@25.0.1)
+        version: 13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@28.0.0)
       '@nestjs/platform-express':
         specifier: ^11.1.21
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)
@@ -2230,7 +2230,7 @@ importers:
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/graphql':
         specifier: ^13.4.0
-        version: 13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@25.0.1)
+        version: 13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@28.0.0)
       '@nestjs/jwt':
         specifier: ^11.0.2
         version: 11.0.2(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))
@@ -8498,6 +8498,9 @@ packages:
 
   '@ts-morph/common@0.26.1':
     resolution: {integrity: sha512-Sn28TGl/4cFpcM+jwsH1wLncYq3FtN/BIpem+HOygfBWPT5pAeS5dB4VFVzV8FbnOKHpDLZmvAl4AjPEev5idA==}
+
+  '@ts-morph/common@0.29.0':
+    resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
 
   '@tsconfig/node10@1.0.9':
     resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
@@ -16876,6 +16879,9 @@ packages:
   ts-morph@25.0.1:
     resolution: {integrity: sha512-QJEiTdnz1YjrB3JFhd626gX4rKHDLSjSVMvGGG4v7ONc3RBwa0Eei98G9AT9uNFDMtV54JyuXsFeC+OH0n6bXQ==}
 
+  ts-morph@28.0.0:
+    resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
+
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -22825,13 +22831,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@nestjs/apollo@13.4.0(@apollo/server@5.5.1(graphql@16.14.2))(@as-integrations/express5@1.1.2(@apollo/server@5.5.1(graphql@16.14.2))(express@5.2.1))(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(@nestjs/graphql@13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@25.0.1))(graphql@16.14.2)':
+  '@nestjs/apollo@13.4.0(@apollo/server@5.5.1(graphql@16.14.2))(@as-integrations/express5@1.1.2(@apollo/server@5.5.1(graphql@16.14.2))(express@5.2.1))(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(@nestjs/graphql@13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@28.0.0))(graphql@16.14.2)':
     dependencies:
       '@apollo/server': 5.5.1(graphql@16.14.2)
       '@apollo/server-plugin-landing-page-graphql-playground': 4.0.1(@apollo/server@5.5.1(graphql@16.14.2))
       '@nestjs/common': 11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/graphql': 13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@25.0.1)
+      '@nestjs/graphql': 13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@28.0.0)
       graphql: 16.14.2
       iterall: 1.3.0
       lodash.omit: 4.18.0
@@ -22934,6 +22940,35 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.14.3
       ts-morph: 25.0.1
+    transitivePeerDependencies:
+      - '@fastify/websocket'
+      - bufferutil
+      - crossws
+      - utf-8-validate
+
+  '@nestjs/graphql@13.4.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.14.2)(reflect-metadata@0.2.2)(ts-morph@28.0.0)':
+    dependencies:
+      '@graphql-tools/merge': 9.1.9(graphql@16.14.2)
+      '@graphql-tools/schema': 10.0.33(graphql@16.14.2)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.2)
+      '@nestjs/common': 11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
+      chokidar: 4.0.3
+      fast-glob: 3.3.3
+      graphql: 16.14.2
+      graphql-tag: 2.12.6(graphql@16.14.2)
+      graphql-ws: 6.0.8(graphql@16.14.2)(ws@8.20.0)
+      lodash: 4.18.1
+      normalize-path: 3.0.0
+      reflect-metadata: 0.2.2
+      subscriptions-transport-ws: 0.11.0(graphql@16.14.2)
+      tslib: 2.8.1
+      ws: 8.20.0
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.3
+      ts-morph: 28.0.0
     transitivePeerDependencies:
       - '@fastify/websocket'
       - bufferutil
@@ -25106,6 +25141,12 @@ snapshots:
       fast-glob: 3.3.3
       minimatch: 9.0.5
       path-browserify: 1.0.1
+
+  '@ts-morph/common@0.29.0':
+    dependencies:
+      minimatch: 10.2.4
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.15
 
   '@tsconfig/node10@1.0.9': {}
 
@@ -35296,6 +35337,11 @@ snapshots:
   ts-morph@25.0.1:
     dependencies:
       '@ts-morph/common': 0.26.1
+      code-block-writer: 13.0.3
+
+  ts-morph@28.0.0:
+    dependencies:
+      '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
 
   ts-node@10.9.2(@swc/core@1.15.41)(@types/node@24.12.4)(typescript@5.9.3):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,6 +980,9 @@ importers:
       storybook-addon-tag-badges:
         specifier: ^3.1.0
         version: 3.1.0(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      ts-morph:
+        specifier: ^25.0.1
+        version: 25.0.1
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.41)(@types/node@24.12.4)(typescript@5.9.3)


### PR DESCRIPTION
A component's code and its Figma design drift apart over time, and nothing compares them as they stand.
This command describes the props the code implements, in the shape `describe-target` (https://github.com/vivid-planet/comet/pull/6050) describes the design's, so a later `diff` command can report where the code does not meet the design.
It reads the committed source and calls no Figma API.

- **A prop's type comes from the TypeScript compiler, not from `react-docgen`.**
  That parser reads the source as written, so it resolves neither the values behind a type alias nor the props an interface inherits.
- **The props a component inherits from its root element are left out, except `children`.**
  They are hundreds of React and base library props no design describes, and they change with every React types update.
- **The override props (`className`, `slots`, `slotProps`, `ref`) are left out too.**
  No Figma design describes them, and the same list applies to every component.
- **A default comes from the `@defaultValue` tag, not from the default in the component's signature.**
  A prop whose default is undocumented is a documentation gap, and the comparison reports it as one instead of filling it in.

**Example**

```bash
pnpm --filter @comet/admin run future-ui-figma describe-implemented Button
```

<details>
<summary>Output</summary>

```json
{
  "ok": true,
  "component": "Button",
  "nodeId": "25:2",
  "props": {
    "children": {
      "type": "node"
    },
    "disabled": {
      "type": "boolean",
      "default": false
    },
    "endIcon": {
      "type": "node"
    },
    "startIcon": {
      "type": "node"
    },
    "variant": {
      "type": "enum",
      "options": [
        "primary",
        "secondary"
      ],
      "default": "primary"
    }
  }
}
```

</details>

---

Task: https://vivid-planet.atlassian.net/browse/COM-3079