### PR TITLE
admin: Add unit tests for Future UI's `resolveSlotProps`

### DIFF
--- a/packages/admin/admin/src/future-ui/utils/slotProps.test.tsx
+++ b/packages/admin/admin/src/future-ui/utils/slotProps.test.tsx
@@ -1,0 +1,52 @@
+import userEvent from "@testing-library/user-event";
+import type { ComponentPropsWithRef } from "react";
+import { cleanup, render, screen } from "test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveSlotProps, type SlotPropsValue } from "./slotProps";
+
+// Testing Library only registers its own cleanup when Vitest's globals are enabled, which they are not.
+afterEach(cleanup);
+
+type ProbeOwnerState = { variant: "primary" | "secondary" };
+
+/**
+ * A test-only component that renders the merged props the way a slot does, for
+ * the behavior that is only observable on a real element.
+ */
+function SlotProbe({ ownProps, slotProps }: { ownProps: ComponentPropsWithRef<"span">; slotProps?: SlotPropsValue<ProbeOwnerState, "span"> }) {
+    return <span {...resolveSlotProps<ProbeOwnerState, "span", "span">(ownProps, slotProps, { variant: "primary" })}>probe</span>;
+}
+
+describe("resolveSlotProps", () => {
+    it("keeps the own props when the consumer passes no value", () => {
+        const merged = resolveSlotProps<ProbeOwnerState, "span", "span">({ className: "own" }, undefined, { variant: "primary" });
+
+        expect(merged).toMatchObject({ className: "own" });
+    });
+
+    it("adds the consumer's class alongside the own class", () => {
+        render(<SlotProbe ownProps={{ className: "own" }} slotProps={{ className: "consumer" }} />);
+
+        expect(screen.getByText("probe")).toHaveClass("own", "consumer");
+    });
+
+    it("resolves a function value with the ownerState and merges its result", () => {
+        const consumerValue: SlotPropsValue<ProbeOwnerState, "span"> = (ownerState) => ({ title: ownerState.variant });
+
+        const merged = resolveSlotProps<ProbeOwnerState, "span", "span">({ className: "own" }, consumerValue, { variant: "secondary" });
+
+        expect(merged).toMatchObject({ className: "own", title: "secondary" });
+    });
+
+    it("runs the own and the consumer event handler", async () => {
+        const handleOwnClick = vi.fn();
+        const handleConsumerClick = vi.fn();
+
+        render(<SlotProbe ownProps={{ onClick: handleOwnClick }} slotProps={{ onClick: handleConsumerClick }} />);
+        await userEvent.click(screen.getByText("probe"));
+
+        expect(handleOwnClick).toHaveBeenCalledOnce();
+        expect(handleConsumerClick).toHaveBeenCalledOnce();
+    });
+});


### PR DESCRIPTION
Every Future UI slot passes its props through `resolveSlotProps`, so it decides whether a component's contract class survives when a consumer sets props of their own.

- **The class test checks that both class names are present, not the merged string.**
  The order of class names in the attribute does not affect which styles apply, so asserting the exact string would fail on a change that breaks nothing.

---

Task: https://vivid-planet.atlassian.net/browse/COM-3078