### PR TITLE
Skip auto assign for bot pull requests

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -8,7 +8,3 @@ reviewers:
 skipKeywords:
     - Merge main into next
     - Version Packages
-
-skipUsers:
-    - renovate[bot]
-    - Copilot

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
     auto-assign:
+        # auto-assign-action has no option to skip pull requests based on their author,
+        # so bot pull requests (Renovate, Copilot, ...) are filtered out here.
+        if: github.event.pull_request.user.type != 'Bot'
         runs-on: ubuntu-latest
         steps:
             - uses: kentaro-m/auto-assign-action@v2.0.2


### PR DESCRIPTION
## Problem

Pull requests opened by Renovate and Copilot still get a reviewer and an assignee added, even though `.github/auto_assign.yml` contains a `skipUsers` list naming exactly those two bots.

The reason is that `skipUsers` is not an option of `kentaro-m/auto-assign-action`. Its `Config` interface only supports `addReviewers`, `addAssignees`, `reviewers`, `assignees`, `filterLabels`, `numberOfAssignees`, `numberOfReviewers`, `skipKeywords`, `useReviewGroups`, `useAssigneeGroups`, `reviewGroups`, `assigneeGroups` and `runOnDraft` — no author-based filtering of any kind. The option doesn't exist in the pinned `v2.0.2` either, nor on the action's current `main` branch, so there is no version to upgrade to.

The action loads the configuration file with `yaml.safeLoad()` and passes the result straight through, so unknown keys are silently dropped — no warning, no failing job. The block looked plausible but was inert from the moment it was added.

Visible in #5948: that pull request was authored by `Copilot` and has `VPS-Obi` in its assignees.

## Solution

Because the action offers no author filtering at all, the skip has to happen one level up, in the workflow's job condition:

```yaml
jobs:
    auto-assign:
        # auto-assign-action has no option to skip pull requests based on their author,
        # so bot pull requests (Renovate, Copilot, ...) are filtered out here.
        if: github.event.pull_request.user.type != 'Bot'
```

Checking `user.type` rather than matching logins keeps the condition short and avoids hardcoding bot account names. Both bots that were listed report `type: "Bot"` — Renovate as `renovate[bot]`, Copilot as `Copilot` — and it additionally covers `github-actions[bot]`, whose "Version Packages" and "Merge main into next" pull requests were previously only caught by the title-based `skipKeywords`.

The dead `skipUsers` block is removed from `.github/auto_assign.yml`. Leaving it in place would keep implying that the filtering happens there.

## Note on rollout

For `pull_request` events GitHub evaluates the workflow file from the base branch, so this takes effect for pull requests opened after it lands on `main`. It does not retroactively affect the bot pull requests that are currently open.

## Changeset

None — per CONTRIBUTING, changes to workflows and the dev setup don't get a changeset.