### PR TITLE
cms-api: Export convertDraftJsToTipTap

### DIFF
--- a/.changeset/export-convert-draftjs-to-tiptap.md
+++ b/.changeset/export-convert-draftjs-to-tiptap.md
@@ -1,0 +1,15 @@
+---
+"@comet/cms-api": minor
+---
+
+Export `convertDraftJsToTipTap`
+
+The function converting DraftJS content to a TipTap document is now part of the public API, so it can be used in custom migrations instead of only through `buildDraftJsToTipTapMigration`.
+
+**Example**
+
+```ts
+import { convertDraftJsToTipTap } from "@comet/cms-api";
+
+const tipTapContent = convertDraftJsToTipTap(draftContent, { supports: ["bold", "italic"] });
+```

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -108,6 +108,11 @@ export {
     type CreateTipTapRichTextBlockOptions,
     type TipTapRichTextBlockContent,
 } from "./blocks/tipTap/createTipTapRichTextBlock";
+export {
+    convertDraftJsToTipTap,
+    type ConvertOptions as ConvertDraftJsToTipTapOptions,
+    type DraftJsContent,
+} from "./blocks/tipTap/migrations/convertDraftJsToTipTap";
 export { transformToBlockSaveIndex } from "./blocks/transformToBlockSaveIndex/transformToBlockSaveIndex";
 export { IsLinkTarget } from "./blocks/validator/is-link-target.validator";
 export { VimeoVideoBlock } from "./blocks/vimeo-video.block";


### PR DESCRIPTION
Converting DraftJS content to a TipTap document was only possible through buildDraftJsToTipTapMigration. Exporting the function directly allows using it in custom migrations.