### PR TITLE
Rebrand the theme to Dextinity

### DIFF
--- a/demo/admin/src/theme.ts
+++ b/demo/admin/src/theme.ts
@@ -1,3 +1,3 @@
-import { createCometTheme } from "@dextinity/admin";
+import { createDextinityTheme } from "@dextinity/admin";
 
-export const createTheme = (muiLocale: object[]) => createCometTheme({}, ...muiLocale);
+export const createTheme = (muiLocale: object[]) => createDextinityTheme({}, ...muiLocale);

--- a/docs/docs/1-getting-started/4-packages-tools.md
+++ b/docs/docs/1-getting-started/4-packages-tools.md
@@ -37,7 +37,7 @@ Components for use in forms generally have an accompanying component, optimized 
 
 Navigation and routing are managed by [react-router](https://reactrouter.com/).
 
-Using the `createCometTheme` function, you can create a theme that contains all the default styling for your admin. Custom options and styles can be added the same way as with MUI's [createTheme](https://mui.com/material-ui/customization/theming/#api) function. The resulting theme can simply be used with MUI's [ThemeProvider](https://mui.com/material-ui/customization/theming/#theme-provider).
+Using the `createDextinityTheme` function, you can create a theme that contains all the default styling for your admin. Custom options and styles can be added the same way as with MUI's [createTheme](https://mui.com/material-ui/customization/theming/#api) function. The resulting theme can simply be used with MUI's [ThemeProvider](https://mui.com/material-ui/customization/theming/#theme-provider).
 
 #### @dextinity/admin-icons
 

--- a/docs/docs/5-admin-components/1-customization-and-styling.mdx
+++ b/docs/docs/5-admin-components/1-customization-and-styling.mdx
@@ -76,9 +76,9 @@ Overriding the styles of a component can be done in the theme using the componen
 In this case, we override the background of the `root` slot and the font styles of the `openDialogIcon` slot.
 
 ```ts
-const theme = createCometTheme({
+const theme = createDextinityTheme({
     components: {
-        CometAdminContentOverflow: {
+        DextinityAdminContentOverflow: {
             styleOverrides: {
                 root: {
                     backgroundColor: "lime",
@@ -99,9 +99,9 @@ Overriding the default props of a component can be done in the theme using the c
 In this case, we replace the `openDialog` icon using the `iconMapping` prop.
 
 ```ts
-const theme = createCometTheme({
+const theme = createDextinityTheme({
     components: {
-        CometAdminContentOverflow: {
+        DextinityAdminContentOverflow: {
             defaultProps: {
                 iconMapping: {
                     openDialog: <Preview fontSize="large" />,

--- a/docs/docs/8-dextinity-core-development/1-creating-customizable-admin-components.md
+++ b/docs/docs/8-dextinity-core-development/1-creating-customizable-admin-components.md
@@ -79,11 +79,11 @@ export interface MyComponentProps
 Props should not be used directly but through the `useThemeProps` hook instead.
 This ensures that the component's `defaultProps` from the theme are merged with the passed-in props.
 
-Note that the name passed to the `useThemeProps` hook must be the same as the component's name, prefixed with `CometAdmin`.
+Note that the name passed to the `useThemeProps` hook must be the same as the component's name, prefixed with `DextinityAdmin`.
 
 ```tsx
 export function MyComponent(inProps: MyComponentProps) {
-    const { children, variant } = useThemeProps({ props: inProps, name: "CometAdminMyComponent" });
+    const { children, variant } = useThemeProps({ props: inProps, name: "DextinityAdminMyComponent" });
     return (
         // ...
     )
@@ -102,7 +102,7 @@ Exceptions would be for props that should never be overridden.
 export function MyComponent(inProps: MyComponentProps) {
     const { slotProps, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminMyComponent",
+        name: "DextinityAdminMyComponent",
     });
     return (
         <Root {...slotProps?.root} {...restProps}>
@@ -146,14 +146,14 @@ export function MyComponent(inProps: MyComponentProps) {
 
 ## A slot's `classesResolver`
 
-By default, a slot's class name consists of the component and slot names, prefixed with `CometAdmin`.
-For example, the `root` slot of `MyComponent` would have the class name `CometAdminMyComponent-root`, while the `title` slot would have the class name `CometAdminMyComponent-title`.
+By default, a slot's class name consists of the component and slot names, prefixed with `DextinityAdmin`.
+For example, the `root` slot of `MyComponent` would have the class name `DextinityAdminMyComponent-root`, while the `title` slot would have the class name `DextinityAdminMyComponent-title`.
 
 Additional class names can be added to a slot by returning an array of class keys in `classesResolver()`.
 This allows easy customization using the resulting class name in a selector outside the component.
 
 In the following example, a component has a conditional `highlighted` state.
-If `true`, the class name `CometAdminMyComponent-highlighted` is added to the `root` slot by returning the `highlighted` class key in `classesResolver`.
+If `true`, the class name `DextinityAdminMyComponent-highlighted` is added to the `root` slot by returning the `highlighted` class key in `classesResolver`.
 If `false`, the `classesResolver` does not return the class key, so no additional class name is added.
 
 ```tsx
@@ -195,7 +195,7 @@ The icons can then be used by destructuring them, renaming them with `Icon` as a
 export function MyComponent(inProps: MyComponentProps) {
     const { iconMapping = {}, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminMyComponent",
+        name: "DextinityAdminMyComponent",
     });
     const {
         fullscreenButton: fullscreenButtonIcon = <Expand />,
@@ -217,7 +217,7 @@ export function MyComponent(inProps: MyComponentProps) {
 ## Adding the component to MUI's theme type
 
 To allow setting the components `defaultProps` and `styleOverrides` in the theme, the component must be added to the `ComponentsPropsList`, `ComponentNameToClassKey`, and `Components` interfaces.
-The key should be the component name, prefixed with `CometAdmin`.
+The key should be the component name, prefixed with `DextinityAdmin`.
 
 Note that the `defaultProps` inside the `Components` interface should be a `Partial<>` of the `ComponentsPropsList` type.
 This is because `defaultProps` are optional changes to the component's props, so nothing is required to be passed in.
@@ -225,17 +225,17 @@ This is because `defaultProps` are optional changes to the component's props, so
 ```tsx
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminMyComponent: MyComponentProps;
+        DextinityAdminMyComponent: MyComponentProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminMyComponent: MyComponentClassKey;
+        DextinityAdminMyComponent: MyComponentClassKey;
     }
 
     interface Components {
-        CometAdminMyComponent?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminMyComponent"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminMyComponent"];
+        DextinityAdminMyComponent?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminMyComponent"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminMyComponent"];
         };
     }
 }

--- a/packages/admin/admin-color-picker/src/ColorPicker.tsx
+++ b/packages/admin/admin-color-picker/src/ColorPicker.tsx
@@ -83,7 +83,7 @@ export const ColorPicker = (inProps: ColorPickerProps) => {
         components = {},
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminColorPicker" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminColorPicker" });
     const {
         ColorPickerColorPreview: ColorPreview = DefaultColorPreviewIndicator,
         ColorPickerInvalidPreview: InvalidPreview = DefaultNoColorPreviewIndicator,
@@ -232,17 +232,17 @@ export const ColorPicker = (inProps: ColorPickerProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminColorPicker: ColorPickerClassKey;
+        DextinityAdminColorPicker: ColorPickerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminColorPicker: ColorPickerProps;
+        DextinityAdminColorPicker: ColorPickerProps;
     }
 
     interface Components {
-        CometAdminColorPicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminColorPicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminColorPicker"];
+        DextinityAdminColorPicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminColorPicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminColorPicker"];
         };
     }
 }

--- a/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
+++ b/packages/admin/admin-date-time/src/DatePickerNavigation.tsx
@@ -25,7 +25,7 @@ export interface DatePickerNavigationProps
 export const DatePickerNavigation = (inProps: DatePickerNavigationProps) => {
     const { focusedDate, changeShownDate, minDate, maxDate, slotProps, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminDatePickerNavigation",
+        name: "DextinityAdminDatePickerNavigation",
     });
     const intl = useIntl();
 
@@ -210,17 +210,17 @@ const SelectYearMenu = createComponentSlot(Menu)<DatePickerNavigationClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminDatePickerNavigation: DatePickerNavigationClassKey;
+        DextinityAdminDatePickerNavigation: DatePickerNavigationClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminDatePickerNavigation: DatePickerNavigationProps;
+        DextinityAdminDatePickerNavigation: DatePickerNavigationProps;
     }
 
     interface Components {
-        CometAdminDatePickerNavigation?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDatePickerNavigation"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDatePickerNavigation"];
+        DextinityAdminDatePickerNavigation?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDatePickerNavigation"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDatePickerNavigation"];
         };
     }
 }

--- a/packages/admin/admin-date-time/src/datePicker/DatePicker.tsx
+++ b/packages/admin/admin-date-time/src/datePicker/DatePicker.tsx
@@ -39,7 +39,7 @@ export const DatePicker = (inProps: DatePickerProps) => {
         slotProps,
         endAdornment,
         ...inputWithPopperProps
-    } = useThemeProps({ props: inProps, name: "CometAdminLegacyDatePicker" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminLegacyDatePicker" });
     const intl = useIntl();
     const dateFnsLocale = useDateFnsLocale();
     const dateValue = value ? new Date(value) : undefined;
@@ -94,17 +94,17 @@ export const DatePicker = (inProps: DatePickerProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminLegacyDatePicker: DatePickerClassKey;
+        DextinityAdminLegacyDatePicker: DatePickerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminLegacyDatePicker: DatePickerProps;
+        DextinityAdminLegacyDatePicker: DatePickerProps;
     }
 
     interface Components {
-        CometAdminLegacyDatePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminLegacyDatePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminLegacyDatePicker"];
+        DextinityAdminLegacyDatePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminLegacyDatePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminLegacyDatePicker"];
         };
     }
 }

--- a/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateRangePicker/DateRangePicker.tsx
@@ -89,7 +89,7 @@ export const DateRangePicker = (inProps: DateRangePickerProps) => {
         maxDate = defaultMaxDate,
         slotProps,
         ...inputWithPopperProps
-    } = useThemeProps({ props: inProps, name: "CometAdminLegacyDateRangePicker" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminLegacyDateRangePicker" });
     const intl = useIntl();
     const textValue = useDateRangeTextValue(value, rangeStringSeparator, formatDateOptions);
     const dateFnsLocale = useDateFnsLocale();
@@ -156,17 +156,17 @@ export const DateRangePicker = (inProps: DateRangePickerProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminLegacyDateRangePicker: DateRangePickerClassKey;
+        DextinityAdminLegacyDateRangePicker: DateRangePickerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminLegacyDateRangePicker: DateRangePickerProps;
+        DextinityAdminLegacyDateRangePicker: DateRangePickerProps;
     }
 
     interface Components {
-        CometAdminLegacyDateRangePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminLegacyDateRangePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminLegacyDateRangePicker"];
+        DextinityAdminLegacyDateRangePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminLegacyDateRangePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminLegacyDateRangePicker"];
         };
     }
 }

--- a/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
+++ b/packages/admin/admin-date-time/src/dateTimePicker/DateTimePicker.tsx
@@ -98,7 +98,7 @@ export interface DateTimePickerProps
 export const DateTimePicker = (inProps: DateTimePickerProps) => {
     const { onChange, value, required, disabled, slotProps, onBlur, onFocus, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminLegacyDateTimePicker",
+        name: "DextinityAdminLegacyDateTimePicker",
     });
     const intl = useIntl();
     const datePickerRef = useRef<HTMLElement>(null);
@@ -181,17 +181,17 @@ export const DateTimePicker = (inProps: DateTimePickerProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminLegacyDateTimePicker: DateTimePickerClassKey;
+        DextinityAdminLegacyDateTimePicker: DateTimePickerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminLegacyDateTimePicker: DateTimePickerProps;
+        DextinityAdminLegacyDateTimePicker: DateTimePickerProps;
     }
 
     interface Components {
-        CometAdminLegacyDateTimePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminLegacyDateTimePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminLegacyDateTimePicker"];
+        DextinityAdminLegacyDateTimePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminLegacyDateTimePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminLegacyDateTimePicker"];
         };
     }
 }

--- a/packages/admin/admin-date-time/src/timePicker/TimePicker.tsx
+++ b/packages/admin/admin-date-time/src/timePicker/TimePicker.tsx
@@ -75,7 +75,7 @@ export const TimePicker = (inProps: TimePickerProps) => {
         max = "23:59",
         slotProps,
         ...inputWithPopperProps
-    } = useThemeProps({ props: inProps, name: "CometAdminLegacyTimePicker" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminLegacyTimePicker" });
     const intl = useIntl();
     const focusedItemRef = useRef<HTMLLIElement>(null);
 
@@ -166,17 +166,17 @@ export const TimePicker = (inProps: TimePickerProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminLegacyTimePicker: TimePickerClassKey;
+        DextinityAdminLegacyTimePicker: TimePickerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminLegacyTimePicker: TimePickerProps;
+        DextinityAdminLegacyTimePicker: TimePickerProps;
     }
 
     interface Components {
-        CometAdminLegacyTimePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminLegacyTimePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminLegacyTimePicker"];
+        DextinityAdminLegacyTimePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminLegacyTimePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminLegacyTimePicker"];
         };
     }
 }

--- a/packages/admin/admin-date-time/src/timeRangePicker/TimeRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/timeRangePicker/TimeRangePicker.tsx
@@ -99,7 +99,7 @@ export const TimeRangePicker = (inProps: TimeRangePickerProps) => {
         required,
         slotProps,
         ...propsForBothTimePickers
-    } = useThemeProps({ props: inProps, name: "CometAdminLegacyTimeRangePicker" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminLegacyTimeRangePicker" });
     const intl = useIntl();
 
     const [startTime, setStartTime] = useState<IndividualTimeValue>(value?.start);
@@ -186,17 +186,17 @@ export const TimeRangePicker = (inProps: TimeRangePickerProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminLegacyTimeRangePicker: TimeRangePickerClassKey;
+        DextinityAdminLegacyTimeRangePicker: TimeRangePickerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminLegacyTimeRangePicker: TimeRangePickerProps;
+        DextinityAdminLegacyTimeRangePicker: TimeRangePickerProps;
     }
 
     interface Components {
-        CometAdminLegacyTimeRangePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminLegacyTimeRangePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminLegacyTimeRangePicker"];
+        DextinityAdminLegacyTimeRangePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminLegacyTimeRangePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminLegacyTimeRangePicker"];
         };
     }
 }

--- a/packages/admin/admin-rte/src/core/BlockElement.tsx
+++ b/packages/admin/admin-rte/src/core/BlockElement.tsx
@@ -112,7 +112,7 @@ export interface RteBlockElementProps
 }
 
 export function BlockElement(inProps: RteBlockElementProps) {
-    const { type, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminRteBlockElement" });
+    const { type, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminRteBlockElement" });
     const ownerState: OwnerState = {
         type,
     };
@@ -121,17 +121,17 @@ export function BlockElement(inProps: RteBlockElementProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminRteBlockElement: RteBlockElementClassKey;
+        DextinityAdminRteBlockElement: RteBlockElementClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminRteBlockElement: RteBlockElementProps;
+        DextinityAdminRteBlockElement: RteBlockElementProps;
     }
 
     interface Components {
-        CometAdminRteBlockElement?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminRteBlockElement"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminRteBlockElement"];
+        DextinityAdminRteBlockElement?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminRteBlockElement"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminRteBlockElement"];
         };
     }
 }

--- a/packages/admin/admin-rte/src/core/Controls/BlockTypesControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/BlockTypesControls.tsx
@@ -56,7 +56,7 @@ const Select = createComponentSlot(MuiSelect)<RteBlockTypeControlsClassKey>({
     ({ theme }) => css`
         .${selectClasses.select}.${inputBaseClasses.input} {
             min-height: 0;
-            color: ${getRteTheme(theme.components?.CometAdminRte?.defaultProps).colors.buttonIcon};
+            color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors.buttonIcon};
             min-width: 180px;
             line-height: 24px;
             font-size: 14px;
@@ -66,7 +66,7 @@ const Select = createComponentSlot(MuiSelect)<RteBlockTypeControlsClassKey>({
 );
 
 function StyledBlockTypesControls(inProps: Props) {
-    const { disabled, blockTypes, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminRteBlockTypeControls" });
+    const { disabled, blockTypes, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminRteBlockTypeControls" });
     const { dropdownFeatures, activeDropdownBlockType, handleBlockTypeChange } = blockTypes;
 
     const blockTypesListItems: Array<{ name: string; label: ReactNode }> = dropdownFeatures.map((c) => ({ name: c.name, label: c.label }));
@@ -106,12 +106,12 @@ export default (p: IControlProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminRteBlockTypeControls: RteBlockTypeControlsClassKey;
+        DextinityAdminRteBlockTypeControls: RteBlockTypeControlsClassKey;
     }
 
     interface Components {
-        CometAdminRteBlockTypeControls?: {
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminRteBlockTypeControls"];
+        DextinityAdminRteBlockTypeControls?: {
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminRteBlockTypeControls"];
         };
     }
 }

--- a/packages/admin/admin-rte/src/core/Controls/ControlButton.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/ControlButton.tsx
@@ -17,7 +17,7 @@ const Root = createComponentSlot("button")<RteControlButtonClassKey, OwnerState>
         return [ownerState.selected && "selected", Boolean(ownerState.Icon) && "renderAsIcon"];
     },
 })(({ ownerState, theme }) => {
-    const rteTheme = getRteTheme(theme.components?.CometAdminRte?.defaultProps);
+    const rteTheme = getRteTheme(theme.components?.DextinityAdminRte?.defaultProps);
     return css`
         display: flex;
         justify-content: center;
@@ -89,7 +89,7 @@ export function ControlButton(inProps: PropsWithChildren<IProps>) {
         Icon: deprecatedIcon,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminRteControlButton" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminRteControlButton" });
 
     const Icon = icon || deprecatedIcon;
 
@@ -108,12 +108,12 @@ export function ControlButton(inProps: PropsWithChildren<IProps>) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminRteControlButton: RteControlButtonClassKey;
+        DextinityAdminRteControlButton: RteControlButtonClassKey;
     }
 
     interface Components {
-        CometAdminRteControlButton?: {
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminRteControlButton"];
+        DextinityAdminRteControlButton?: {
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminRteControlButton"];
         };
     }
 }

--- a/packages/admin/admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
@@ -29,7 +29,7 @@ export function FeaturesButtonGroup(inProps: IProps) {
         maxVisible,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminRteFeaturesButtonGroup" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminRteFeaturesButtonGroup" });
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
     const handleMoreOptionsClick = (event: MouseEvent<HTMLButtonElement>) => {
@@ -151,12 +151,12 @@ const ListItemIcon = createComponentSlot(MuiListItemIcon)<RteFeaturesButtonGroup
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminRteFeaturesButtonGroup: RteFeaturesButtonGroupClassKey;
+        DextinityAdminRteFeaturesButtonGroup: RteFeaturesButtonGroupClassKey;
     }
 
     interface Components {
-        CometAdminRteFeaturesButtonGroup?: {
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminRteFeaturesButtonGroup"];
+        DextinityAdminRteFeaturesButtonGroup?: {
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminRteFeaturesButtonGroup"];
         };
     }
 }

--- a/packages/admin/admin-rte/src/core/Controls/LinkControls.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/LinkControls.tsx
@@ -13,7 +13,7 @@ export interface RteLinkControlsProps
         }> {}
 
 function StyledLinkControls(inProps: RteLinkControlsProps) {
-    const props = useThemeProps({ props: inProps, name: "CometAdminRteLinkControls" });
+    const props = useThemeProps({ props: inProps, name: "DextinityAdminRteLinkControls" });
     const {
         options: { supports: supportedThings, overwriteLinkButton, overwriteLinksRemoveButton },
         slotProps,
@@ -62,17 +62,17 @@ export default (p: IControlProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminRteLinkControls: RteLinkControlsProps;
+        DextinityAdminRteLinkControls: RteLinkControlsProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminRteLinkControls: RteLinkControlsClassKey;
+        DextinityAdminRteLinkControls: RteLinkControlsClassKey;
     }
 
     interface Components {
-        CometAdminRteLinkControls?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminRteLinkControls"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminRteLinkControls"];
+        DextinityAdminRteLinkControls?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminRteLinkControls"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminRteLinkControls"];
         };
     }
 }

--- a/packages/admin/admin-rte/src/core/Controls/Toolbar/Toolbar.styles.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/Toolbar/Toolbar.styles.tsx
@@ -16,7 +16,7 @@ export const Root = createComponentSlot("div")<RteToolbarClassKey>({
         display: flex;
         flex-wrap: wrap;
         border-top: 1px solid var(--comet-admin-rte-outer-border-color);
-        background-color: ${getRteTheme(theme.components?.CometAdminRte?.defaultProps).colors?.toolbarBackground};
+        background-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors?.toolbarBackground};
         padding-left: 6px;
         padding-right: 6px;
         overflow: hidden;
@@ -42,7 +42,7 @@ export const Slot = createComponentSlot("div")<RteToolbarClassKey>({
         &::after {
             content: "";
             position: absolute;
-            background-color: ${getRteTheme(theme.components?.CometAdminRte?.defaultProps).colors?.border};
+            background-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors?.border};
         }
 
         &::before {

--- a/packages/admin/admin-rte/src/core/Controls/Toolbar/Toolbar.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/Toolbar/Toolbar.tsx
@@ -16,7 +16,7 @@ interface RteToolbarProps
 }
 
 export function Toolbar(inProps: RteToolbarProps) {
-    const { children, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminRteToolbar" });
+    const { children, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminRteToolbar" });
 
     const childrenElements = children
         .filter((c) => {
@@ -30,7 +30,7 @@ export function Toolbar(inProps: RteToolbarProps) {
 
     return (
         // TODO: Find alternative to className
-        <Root {...slotProps?.root} {...restProps} className="CometAdminRteToolbar-root">
+        <Root {...slotProps?.root} {...restProps} className="DextinityAdminRteToolbar-root">
             {childrenElements.map((c, idx) => {
                 return (
                     <Slot key={idx} {...slotProps?.slot}>
@@ -44,17 +44,17 @@ export function Toolbar(inProps: RteToolbarProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminRteToolbar: RteToolbarProps;
+        DextinityAdminRteToolbar: RteToolbarProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminRteToolbar: RteToolbarClassKey;
+        DextinityAdminRteToolbar: RteToolbarClassKey;
     }
 
     interface Components {
-        CometAdminRteToolbar?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminRteToolbar"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminRteToolbar"];
+        DextinityAdminRteToolbar?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminRteToolbar"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminRteToolbar"];
         };
     }
 }

--- a/packages/admin/admin-rte/src/core/Rte.tsx
+++ b/packages/admin/admin-rte/src/core/Rte.tsx
@@ -168,7 +168,7 @@ export const Rte: ForwardRefExoticComponent<PropsWithoutRef<RteProps> & RefAttri
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminRte",
+        name: "DextinityAdminRte",
     });
 
     const ownerState: OwnerState = {
@@ -348,18 +348,18 @@ const Root = createComponentSlot("div")<RteClassKey, OwnerState>({
     },
 })(
     ({ theme }) => css`
-        --comet-admin-rte-outer-border-color: ${getRteTheme(theme.components?.CometAdminRte?.defaultProps).colors.border};
+        --comet-admin-rte-outer-border-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors.border};
         border: 1px solid var(--comet-admin-rte-outer-border-color);
         border-top-width: 0; // To prevent the top border from being hidden, when to toolbar is sticky, the top border must be handled by the Toolbar itself
         background-color: #fff;
         border-radius: 2px;
 
         &:hover {
-            --comet-admin-rte-outer-border-color: ${getRteTheme(theme.components?.CometAdminRte?.defaultProps).colors.outerBorderOnHover};
+            --comet-admin-rte-outer-border-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors.outerBorderOnHover};
         }
 
         &:focus-within {
-            --comet-admin-rte-outer-border-color: ${getRteTheme(theme.components?.CometAdminRte?.defaultProps).colors.outerBorderOnFocus};
+            --comet-admin-rte-outer-border-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors.outerBorderOnFocus};
         }
     `,
 );
@@ -393,17 +393,17 @@ const Editor = createComponentSlot("div")<RteClassKey, OwnerState>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminRte: RteClassKey;
+        DextinityAdminRte: RteClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminRte: RteProps;
+        DextinityAdminRte: RteProps;
     }
 
     interface Components {
-        CometAdminRte?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminRte"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminRte"];
+        DextinityAdminRte?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminRte"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminRte"];
         };
     }
 }

--- a/packages/admin/admin/.storybook/decorators/ThemeProvider.decorator.tsx
+++ b/packages/admin/admin/.storybook/decorators/ThemeProvider.decorator.tsx
@@ -5,7 +5,7 @@ import { createTheme as createMuiTheme, CssBaseline } from "@mui/material";
 import { type Decorator } from "@storybook/react-vite";
 
 export enum ThemeOption {
-    Comet = "comet",
+    Dextinity = "dextinity",
     Mui = "mui",
 }
 

--- a/packages/admin/admin/.storybook/decorators/ThemeProvider.decorator.tsx
+++ b/packages/admin/admin/.storybook/decorators/ThemeProvider.decorator.tsx
@@ -1,4 +1,4 @@
-import { createCometTheme } from "../../src/theme/createCometTheme";
+import { createDextinityTheme } from "../../src/theme/createDextinityTheme";
 import { MuiThemeProvider } from "../../src/mui/ThemeProvider";
 
 import { createTheme as createMuiTheme, CssBaseline } from "@mui/material";
@@ -11,7 +11,7 @@ export enum ThemeOption {
 
 export const ThemeProviderDecorator: Decorator = (fn, context) => {
     const { theme: selectedTheme } = context.globals;
-    const theme = selectedTheme === ThemeOption.Mui ? createMuiTheme() : createCometTheme();
+    const theme = selectedTheme === ThemeOption.Mui ? createMuiTheme() : createDextinityTheme();
     return (
         <MuiThemeProvider theme={theme}>
             <CssBaseline />

--- a/packages/admin/admin/.storybook/preview.ts
+++ b/packages/admin/admin/.storybook/preview.ts
@@ -17,7 +17,7 @@ export const globalTypes: GlobalTypes = {
             title: "Theme",
             icon: "paintbrush",
             items: [
-                { value: ThemeOption.Comet, right: "🟩", title: "Comet Theme" },
+                { value: ThemeOption.Dextinity, right: "🟩", title: "Dextinity Theme" },
                 { value: ThemeOption.Mui, right: "🟦", title: "Mui Theme" },
             ],
             dynamicTitle: true,

--- a/packages/admin/admin/src/ContentOverflow.tsx
+++ b/packages/admin/admin/src/ContentOverflow.tsx
@@ -57,7 +57,7 @@ export const ContentOverflow = (inProps: PropsWithChildren<ContentOverflowProps>
         iconMapping = {},
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminContentOverflow" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminContentOverflow" });
     const { openDialog: openDialogIcon = <Maximize fontSize="inherit" />, closeDialog: closeDialogIcon = <Close /> } = iconMapping;
 
     const [open, setOpen] = useState(false);
@@ -208,17 +208,17 @@ const InnerDialogContent = createComponentSlot("div")<ContentOverflowClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminContentOverflow: ContentOverflowClassKey;
+        DextinityAdminContentOverflow: ContentOverflowClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminContentOverflow: ContentOverflowProps;
+        DextinityAdminContentOverflow: ContentOverflowProps;
     }
 
     interface Components {
-        CometAdminContentOverflow?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminContentOverflow"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminContentOverflow"];
+        DextinityAdminContentOverflow?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminContentOverflow"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminContentOverflow"];
         };
     }
 }

--- a/packages/admin/admin/src/FinalFormSaveCancelButtonsLegacy.tsx
+++ b/packages/admin/admin/src/FinalFormSaveCancelButtonsLegacy.tsx
@@ -45,7 +45,10 @@ const StyledSaveButton = createComponentSlot(SaveButton)<FinalFormSaveCancelButt
 );
 
 export function FinalFormSaveCancelButtonsLegacy(inProps: FinalFormSaveCancelButtonsLegacyProps) {
-    const { cancelIcon, saveIcon, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminFinalFormSaveCancelButtonsLegacy" });
+    const { cancelIcon, saveIcon, slotProps, ...restProps } = useThemeProps({
+        props: inProps,
+        name: "DextinityAdminFinalFormSaveCancelButtonsLegacy",
+    });
     const stackApi = useStackApi();
     const formState = useFormState();
 
@@ -72,17 +75,17 @@ export function FinalFormSaveCancelButtonsLegacy(inProps: FinalFormSaveCancelBut
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFinalFormSaveCancelButtonsLegacy: FinalFormSaveCancelButtonsLegacyClassKey;
+        DextinityAdminFinalFormSaveCancelButtonsLegacy: FinalFormSaveCancelButtonsLegacyClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFinalFormSaveCancelButtonsLegacy: FinalFormSaveCancelButtonsLegacyProps;
+        DextinityAdminFinalFormSaveCancelButtonsLegacy: FinalFormSaveCancelButtonsLegacyProps;
     }
 
     interface Components {
-        CometAdminFinalFormSaveCancelButtonsLegacy?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFinalFormSaveCancelButtonsLegacy"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFinalFormSaveCancelButtonsLegacy"];
+        DextinityAdminFinalFormSaveCancelButtonsLegacy?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFinalFormSaveCancelButtonsLegacy"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFinalFormSaveCancelButtonsLegacy"];
         };
     }
 }

--- a/packages/admin/admin/src/alert/Alert.tsx
+++ b/packages/admin/admin/src/alert/Alert.tsx
@@ -67,7 +67,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>((inProps, ref) => {
         action,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminAlert" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminAlert" });
     const singleRow = !title && (action || onClose);
 
     const ownerState: OwnerState = {
@@ -179,17 +179,17 @@ const CloseIcon = createComponentSlot(IconButton)<AlertClassKey, OwnerState>({
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminAlert: AlertProps;
+        DextinityAdminAlert: AlertProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminAlert: AlertClassKey;
+        DextinityAdminAlert: AlertClassKey;
     }
 
     interface Components {
-        CometAdminAlert?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminAlert"]>;
-            styleOverrides?: ComponentNameToClassKey["CometAdminAlert"];
+        DextinityAdminAlert?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminAlert"]>;
+            styleOverrides?: ComponentNameToClassKey["DextinityAdminAlert"];
         };
     }
 }

--- a/packages/admin/admin/src/appHeader/AppHeader.tsx
+++ b/packages/admin/admin/src/appHeader/AppHeader.tsx
@@ -39,7 +39,7 @@ const AppHeaderRoot = createComponentSlot(MuiAppBar)<AppHeaderClassKey, OwnerSta
 );
 
 export const AppHeader = (inProps: AppHeaderProps) => {
-    const props = useThemeProps({ props: inProps, name: "CometAdminAppHeader" });
+    const props = useThemeProps({ props: inProps, name: "DextinityAdminAppHeader" });
     const { children, headerHeight: passedHeaderHeight, position = "fixed", color = "primary", ...restProps } = props;
 
     const { headerHeight: masterLayoutHeaderHeight } = useContext(MasterLayoutContext);
@@ -65,17 +65,17 @@ export const AppHeader = (inProps: AppHeaderProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminAppHeader: AppHeaderClassKey;
+        DextinityAdminAppHeader: AppHeaderClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminAppHeader: AppHeaderProps;
+        DextinityAdminAppHeader: AppHeaderProps;
     }
 
     interface Components {
-        CometAdminAppHeader?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminAppHeader"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminAppHeader"];
+        DextinityAdminAppHeader?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminAppHeader"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminAppHeader"];
         };
     }
 }

--- a/packages/admin/admin/src/appHeader/__stories__/ThemableAppHeader.stories.tsx
+++ b/packages/admin/admin/src/appHeader/__stories__/ThemableAppHeader.stories.tsx
@@ -1,6 +1,6 @@
 import { CometLogo } from "../../common/CometLogo";
 import { MuiThemeProvider } from "../../mui/ThemeProvider";
-import { createCometTheme } from "../../theme/createCometTheme";
+import { createDextinityTheme } from "../../theme/createDextinityTheme";
 import { AppHeader } from "../AppHeader";
 
 export default {
@@ -9,9 +9,9 @@ export default {
 
 export const ThemableAppHeader = {
     render: () => {
-        const theme = createCometTheme({
+        const theme = createDextinityTheme({
             components: {
-                CometAdminAppHeader: {
+                DextinityAdminAppHeader: {
                     defaultProps: {
                         headerHeight: 60,
                     },

--- a/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
+++ b/packages/admin/admin/src/appHeader/button/AppHeaderButton.tsx
@@ -22,7 +22,7 @@ export interface AppHeaderButtonProps
 export function AppHeaderButton(inProps: AppHeaderButtonProps) {
     const { children, disableTypography, slotProps, onClick, startIcon, endIcon, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminAppHeaderButton",
+        name: "DextinityAdminAppHeaderButton",
     });
 
     return (
@@ -46,17 +46,17 @@ export function AppHeaderButton(inProps: AppHeaderButtonProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminAppHeaderButton: AppHeaderButtonProps;
+        DextinityAdminAppHeaderButton: AppHeaderButtonProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminAppHeaderButton: AppHeaderButtonClassKey;
+        DextinityAdminAppHeaderButton: AppHeaderButtonClassKey;
     }
 
     interface Components {
-        CometAdminAppHeaderButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminAppHeaderButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminAppHeaderButton"];
+        DextinityAdminAppHeaderButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminAppHeaderButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminAppHeaderButton"];
         };
     }
 }

--- a/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
+++ b/packages/admin/admin/src/appHeader/dropdown/AppHeaderDropdown.tsx
@@ -49,7 +49,7 @@ export function AppHeaderDropdown(inProps: AppHeaderDropdownProps) {
         onOpenChange,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminAppHeaderDropdown" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminAppHeaderDropdown" });
 
     const [uncontrolledOpen, setUncontrolledOpen] = useState<boolean>(false);
 
@@ -102,17 +102,17 @@ export function AppHeaderDropdown(inProps: AppHeaderDropdownProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminAppHeaderDropdown: AppHeaderDropdownProps;
+        DextinityAdminAppHeaderDropdown: AppHeaderDropdownProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminAppHeaderDropdown: AppHeaderDropdownClassKey;
+        DextinityAdminAppHeaderDropdown: AppHeaderDropdownClassKey;
     }
 
     interface Components {
-        CometAdminAppHeaderDropdown?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminAppHeaderDropdown"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminAppHeaderDropdown"];
+        DextinityAdminAppHeaderDropdown?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminAppHeaderDropdown"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminAppHeaderDropdown"];
         };
     }
 }

--- a/packages/admin/admin/src/appHeader/fillSpace/AppHeaderFillSpace.tsx
+++ b/packages/admin/admin/src/appHeader/fillSpace/AppHeaderFillSpace.tsx
@@ -21,23 +21,23 @@ const Root = createComponentSlot("div")<AppHeaderFillSpaceClassKey>({
  * @deprecated Use `FillSpace` instead.
  */
 export function AppHeaderFillSpace(inProps: AppHeaderFillSpaceProps) {
-    const { slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminAppHeaderFillSpace" });
+    const { slotProps, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminAppHeaderFillSpace" });
 
     return <Root {...slotProps?.root} {...restProps} />;
 }
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminAppHeaderFillSpace: AppHeaderFillSpaceProps;
+        DextinityAdminAppHeaderFillSpace: AppHeaderFillSpaceProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminAppHeaderFillSpace: AppHeaderFillSpaceClassKey;
+        DextinityAdminAppHeaderFillSpace: AppHeaderFillSpaceClassKey;
     }
 
     interface Components {
-        CometAdminAppHeaderFillSpace?: {
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminAppHeaderFillSpace"];
+        DextinityAdminAppHeaderFillSpace?: {
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminAppHeaderFillSpace"];
         };
     }
 }

--- a/packages/admin/admin/src/appHeader/menuButton/AppHeaderMenuButton.tsx
+++ b/packages/admin/admin/src/appHeader/menuButton/AppHeaderMenuButton.tsx
@@ -10,7 +10,7 @@ export type AppHeaderMenuButtonProps = IconButtonProps;
 export type AppHeaderMenuButtonClassKey = IconButtonClassKey;
 
 export const AppHeaderMenuButton = (inProps: AppHeaderMenuButtonProps) => {
-    const { children: propChildren, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminAppHeaderMenuButton" });
+    const { children: propChildren, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminAppHeaderMenuButton" });
     const { toggleOpen, open, drawerVariant, hasMultipleMenuItems } = useMainNavigation();
 
     if (!hasMultipleMenuItems) {
@@ -55,17 +55,17 @@ const Root = createComponentSlot(IconButton)<AppHeaderMenuButtonClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminAppHeaderMenuButton: AppHeaderMenuButtonClassKey;
+        DextinityAdminAppHeaderMenuButton: AppHeaderMenuButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminAppHeaderMenuButton: AppHeaderMenuButtonProps;
+        DextinityAdminAppHeaderMenuButton: AppHeaderMenuButtonProps;
     }
 
     interface Components {
-        CometAdminAppHeaderMenuButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminAppHeaderMenuButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminAppHeaderMenuButton"];
+        DextinityAdminAppHeaderMenuButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminAppHeaderMenuButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminAppHeaderMenuButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/ClearInputAdornment.tsx
+++ b/packages/admin/admin/src/common/ClearInputAdornment.tsx
@@ -36,7 +36,7 @@ export const ClearInputAdornment = (inProps: ClearInputAdornmentProps) => {
         icon = <Clear fontSize="inherit" />,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminClearInputAdornment" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminClearInputAdornment" });
 
     const ownerState: OwnerState = {
         position,
@@ -100,17 +100,17 @@ const Button = createComponentSlot(ButtonBase)<ClearInputAdornmentClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminClearInputAdornment: ClearInputAdornmentClassKey;
+        DextinityAdminClearInputAdornment: ClearInputAdornmentClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminClearInputAdornment: ClearInputAdornmentProps;
+        DextinityAdminClearInputAdornment: ClearInputAdornmentProps;
     }
 
     interface Components {
-        CometAdminClearInputAdornment?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminClearInputAdornment"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminClearInputAdornment"];
+        DextinityAdminClearInputAdornment?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminClearInputAdornment"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminClearInputAdornment"];
         };
     }
 }

--- a/packages/admin/admin/src/common/Dialog.tsx
+++ b/packages/admin/admin/src/common/Dialog.tsx
@@ -41,7 +41,7 @@ export function Dialog(inProps: DialogProps) {
         children,
         onClose,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminDialog" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminDialog" });
     const { closeIcon = <Close color="inherit" /> } = iconMapping;
 
     const ownerState: OwnerState = {
@@ -98,17 +98,17 @@ const CloseButton = createComponentSlot(IconButton)<DialogClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminDialog: DialogProps;
+        DextinityAdminDialog: DialogProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminDialog: DialogClassKey;
+        DextinityAdminDialog: DialogClassKey;
     }
 
     interface Components {
-        CometAdminDialog?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDialog"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDialog"];
+        DextinityAdminDialog?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDialog"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDialog"];
         };
     }
 }

--- a/packages/admin/admin/src/common/FieldSet.tsx
+++ b/packages/admin/admin/src/common/FieldSet.tsx
@@ -57,7 +57,7 @@ export const FieldSet = (inProps: PropsWithChildren<FieldSetProps>) => {
         disablePadding = false,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminFieldSet" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminFieldSet" });
     const [expanded, setExpanded] = useState(initiallyExpanded);
 
     const handleChange = (event: SyntheticEvent, isExpanded: boolean) => {
@@ -225,17 +225,17 @@ const Children = createComponentSlot(MuiAccordionDetails)<FieldSetClassKey, Owne
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminFieldSet: FieldSetProps;
+        DextinityAdminFieldSet: FieldSetProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminFieldSet: FieldSetClassKey;
+        DextinityAdminFieldSet: FieldSetClassKey;
     }
 
     interface Components {
-        CometAdminFieldSet?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFieldSet"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFieldSet"];
+        DextinityAdminFieldSet?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFieldSet"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFieldSet"];
         };
     }
 }

--- a/packages/admin/admin/src/common/FillSpace.tsx
+++ b/packages/admin/admin/src/common/FillSpace.tsx
@@ -18,22 +18,22 @@ const Root = createComponentSlot("div")<FillSpaceClassKey>({
 `);
 
 export function FillSpace(inProps: FillSpaceProps) {
-    const { slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminFillSpace" });
+    const { slotProps, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminFillSpace" });
     return <Root {...slotProps?.root} {...restProps} />;
 }
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminFillSpace: FillSpaceProps;
+        DextinityAdminFillSpace: FillSpaceProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminFillSpace: FillSpaceClassKey;
+        DextinityAdminFillSpace: FillSpaceClassKey;
     }
 
     interface Components {
-        CometAdminFillSpace?: {
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFillSpace"];
+        DextinityAdminFillSpace?: {
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFillSpace"];
         };
     }
 }

--- a/packages/admin/admin/src/common/FullHeightContent.tsx
+++ b/packages/admin/admin/src/common/FullHeightContent.tsx
@@ -22,7 +22,7 @@ export type FullHeightContentProps = ThemedComponentBaseProps<{
 export const FullHeightContent = (inProps: FullHeightContentProps) => {
     const { children, slotProps, disableBottomContentSpacing, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminFullHeightContent",
+        name: "DextinityAdminFullHeightContent",
     });
 
     const elementRef = useRef<HTMLDivElement>(null);
@@ -58,17 +58,17 @@ const Root = createComponentSlot("div")<FullHeightContentClassKey, OwnerState>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFullHeightContent: FullHeightContentClassKey;
+        DextinityAdminFullHeightContent: FullHeightContentClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFullHeightContent: FullHeightContentProps;
+        DextinityAdminFullHeightContent: FullHeightContentProps;
     }
 
     interface Components {
-        CometAdminFullHeightContent?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFullHeightContent"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFullHeightContent"];
+        DextinityAdminFullHeightContent?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFullHeightContent"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFullHeightContent"];
         };
     }
 }

--- a/packages/admin/admin/src/common/HoverActions.tsx
+++ b/packages/admin/admin/src/common/HoverActions.tsx
@@ -18,7 +18,7 @@ export interface HoverActionsProps
 export type HoverActionsClassKey = "root" | "hoverAreaExpansion" | "actions" | "children";
 
 export const HoverActions = (inProps: HoverActionsProps) => {
-    const { actions, children, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminHoverActions" });
+    const { actions, children, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminHoverActions" });
     const [isHovering, setIsHovering] = useState<boolean>(false);
 
     return (
@@ -78,17 +78,17 @@ const Children = createComponentSlot("div")<HoverActionsClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminHoverActions: HoverActionsClassKey;
+        DextinityAdminHoverActions: HoverActionsClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminHoverActions: HoverActionsProps;
+        DextinityAdminHoverActions: HoverActionsProps;
     }
 
     interface Components {
-        CometAdminHoverActions?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminHoverActions"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminHoverActions"];
+        DextinityAdminHoverActions?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminHoverActions"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminHoverActions"];
         };
     }
 }

--- a/packages/admin/admin/src/common/MainContent.tsx
+++ b/packages/admin/admin/src/common/MainContent.tsx
@@ -78,7 +78,7 @@ export interface MainContentProps extends ThemedComponentBaseProps {
 export function MainContent(inProps: MainContentProps) {
     const { children, fullHeight, disablePaddingTop, disablePaddingBottom, disablePadding, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminMainContent",
+        name: "DextinityAdminMainContent",
     });
 
     const mainRef = useRef<HTMLElement>(null);
@@ -99,17 +99,17 @@ export function MainContent(inProps: MainContentProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminMainContent: MainContentClassKey;
+        DextinityAdminMainContent: MainContentClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminMainContent: MainContentProps;
+        DextinityAdminMainContent: MainContentProps;
     }
 
     interface Components {
-        CometAdminMainContent?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminMainContent"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminMainContent"];
+        DextinityAdminMainContent?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminMainContent"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminMainContent"];
         };
     }
 }

--- a/packages/admin/admin/src/common/OpenPickerAdornment.tsx
+++ b/packages/admin/admin/src/common/OpenPickerAdornment.tsx
@@ -33,7 +33,7 @@ export const OpenPickerAdornment = (inProps: OpenPickerAdornmentProps) => {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminOpenPickerAdornment",
+        name: "DextinityAdminOpenPickerAdornment",
     });
 
     const ownerState: OwnerState = {
@@ -79,17 +79,17 @@ const OpenPickerButton = createComponentSlot(IconButton)<OpenPickerAdornmentClas
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminOpenPickerAdornment: OpenPickerAdornmentProps;
+        DextinityAdminOpenPickerAdornment: OpenPickerAdornmentProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminOpenPickerAdornment: OpenPickerAdornmentClassKey;
+        DextinityAdminOpenPickerAdornment: OpenPickerAdornmentClassKey;
     }
 
     interface Components {
-        CometAdminOpenPickerAdornment?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminOpenPickerAdornment"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminOpenPickerAdornment"];
+        DextinityAdminOpenPickerAdornment?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminOpenPickerAdornment"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminOpenPickerAdornment"];
         };
     }
 }

--- a/packages/admin/admin/src/common/ReadOnlyAdornment.tsx
+++ b/packages/admin/admin/src/common/ReadOnlyAdornment.tsx
@@ -22,7 +22,7 @@ export const ReadOnlyAdornment = (inProps: ReadOnlyAdornmentProps) => {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminReadOnlyAdornment",
+        name: "DextinityAdminReadOnlyAdornment",
     });
 
     if (!inputIsReadOnly) {
@@ -45,17 +45,17 @@ const Root = createComponentSlot(InputAdornment)<ReadOnlyAdornmentClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminReadOnlyAdornment: ReadOnlyAdornmentProps;
+        DextinityAdminReadOnlyAdornment: ReadOnlyAdornmentProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminReadOnlyAdornment: ReadOnlyAdornmentClassKey;
+        DextinityAdminReadOnlyAdornment: ReadOnlyAdornmentClassKey;
     }
 
     interface Components {
-        CometAdminReadOnlyAdornment?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminReadOnlyAdornment"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminReadOnlyAdornment"];
+        DextinityAdminReadOnlyAdornment?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminReadOnlyAdornment"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminReadOnlyAdornment"];
         };
     }
 }

--- a/packages/admin/admin/src/common/Tooltip.tsx
+++ b/packages/admin/admin/src/common/Tooltip.tsx
@@ -173,7 +173,7 @@ const Text = createComponentSlot(Typography)<TooltipClassKey>({
 })();
 
 export const Tooltip = (inProps: TooltipProps) => {
-    const props = useThemeProps({ props: inProps, name: "CometAdminTooltip" });
+    const props = useThemeProps({ props: inProps, name: "DextinityAdminTooltip" });
     const { color = "dark", disableInteractive, arrow, children, title, description, customContent, slotProps = {}, ...restProps } = props;
     const theme = useTheme();
 
@@ -256,17 +256,17 @@ const getMuiTooltipTitle = ({ title, description, customContent }: TooltipConten
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminTooltip: TooltipProps;
+        DextinityAdminTooltip: TooltipProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminTooltip: TooltipClassKey;
+        DextinityAdminTooltip: TooltipClassKey;
     }
 
     interface Components {
-        CometAdminTooltip?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminTooltip"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTooltip"];
+        DextinityAdminTooltip?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminTooltip"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminTooltip"];
         };
     }
 }

--- a/packages/admin/admin/src/common/buttons/Button.tsx
+++ b/packages/admin/admin/src/common/buttons/Button.tsx
@@ -86,7 +86,7 @@ export const Button = forwardRef(<C extends ElementType = "button">(inProps: But
         endIcon,
         children,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminButton" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminButton" });
 
     const windowSize = useWindowSize();
     const theme = useTheme();
@@ -175,17 +175,17 @@ const MobileTooltip = createComponentSlot(Tooltip)<ButtonClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminButton: ButtonClassKey;
+        DextinityAdminButton: ButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminButton: ButtonProps;
+        DextinityAdminButton: ButtonProps;
     }
 
     interface Components {
-        CometAdminButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminButton"];
+        DextinityAdminButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/buttons/CopyToClipboardButton.tsx
+++ b/packages/admin/admin/src/common/buttons/CopyToClipboardButton.tsx
@@ -39,7 +39,7 @@ export const CopyToClipboardButton = (inProps: CopyToClipboardButtonProps) => {
         successIcon = <Accept />,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminCopyToClipboardButton" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminCopyToClipboardButton" });
 
     const [showSuccess, setShowSuccess] = useState<boolean>(false);
 
@@ -150,17 +150,17 @@ const SuccessButton = createComponentSlot(IconButton)<CopyToClipboardButtonClass
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminCopyToClipboardButton: CopyToClipboardButtonClassKey;
+        DextinityAdminCopyToClipboardButton: CopyToClipboardButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminCopyToClipboardButton: CopyToClipboardButtonProps;
+        DextinityAdminCopyToClipboardButton: CopyToClipboardButtonProps;
     }
 
     interface Components {
-        CometAdminCopyToClipboardButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminCopyToClipboardButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminCopyToClipboardButton"];
+        DextinityAdminCopyToClipboardButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminCopyToClipboardButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminCopyToClipboardButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/buttons/SaveButton.tsx
+++ b/packages/admin/admin/src/common/buttons/SaveButton.tsx
@@ -17,7 +17,7 @@ export function SaveButton(inProps: SaveButtonProps) {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminSaveButton",
+        name: "DextinityAdminSaveButton",
     });
 
     return (
@@ -34,17 +34,17 @@ const Root = createComponentSlot(FeedbackButton)<SaveButtonClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminSaveButton: SaveButtonClassKey;
+        DextinityAdminSaveButton: SaveButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminSaveButton: SaveButtonProps;
+        DextinityAdminSaveButton: SaveButtonProps;
     }
 
     interface Components {
-        CometAdminSaveButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminSaveButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminSaveButton"];
+        DextinityAdminSaveButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminSaveButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminSaveButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/buttons/cancel/CancelButton.tsx
+++ b/packages/admin/admin/src/common/buttons/cancel/CancelButton.tsx
@@ -14,7 +14,7 @@ export function CancelButton(inProps: CancelButtonProps) {
         children = <FormattedMessage {...messages.cancel} />,
         startIcon = <Clear />,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminCancelButton" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminCancelButton" });
 
     return (
         <Root variant="textDark" startIcon={startIcon} {...restProps}>
@@ -30,17 +30,17 @@ const Root = createComponentSlot(Button)<CancelButtonClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminCancelButton: CancelButtonClassKey;
+        DextinityAdminCancelButton: CancelButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminCancelButton: CancelButtonProps;
+        DextinityAdminCancelButton: CancelButtonProps;
     }
 
     interface Components {
-        CometAdminCancelButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminCancelButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminCancelButton"];
+        DextinityAdminCancelButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminCancelButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminCancelButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
+++ b/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
@@ -46,7 +46,7 @@ export interface ClearInputButtonProps extends ButtonBaseProps {
 export function ClearInputButton(inProps: ClearInputButtonProps) {
     const { icon = <Clear />, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminClearInputButton",
+        name: "DextinityAdminClearInputButton",
     });
     return (
         <Root tabIndex={-1} {...restProps}>
@@ -57,17 +57,17 @@ export function ClearInputButton(inProps: ClearInputButtonProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminClearInputButton: ClearInputButtonClassKey;
+        DextinityAdminClearInputButton: ClearInputButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminClearInputButton: ClearInputButtonProps;
+        DextinityAdminClearInputButton: ClearInputButtonProps;
     }
 
     interface Components {
-        CometAdminClearInputButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminClearInputButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminClearInputButton"];
+        DextinityAdminClearInputButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminClearInputButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminClearInputButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/buttons/delete/DeleteButton.tsx
+++ b/packages/admin/admin/src/common/buttons/delete/DeleteButton.tsx
@@ -15,7 +15,7 @@ export function DeleteButton(inProps: DeleteButtonProps) {
         children = <FormattedMessage {...messages.delete} />,
         startIcon = <Delete />,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminDeleteButton" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminDeleteButton" });
 
     return (
         <Root startIcon={startIcon} variant="destructive" {...restProps}>
@@ -31,17 +31,17 @@ const Root = createComponentSlot(Button)<DeleteButtonClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminDeleteButton: DeleteButtonClassKey;
+        DextinityAdminDeleteButton: DeleteButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminDeleteButton: DeleteButtonProps;
+        DextinityAdminDeleteButton: DeleteButtonProps;
     }
 
     interface Components {
-        CometAdminDeleteButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDeleteButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDeleteButton"];
+        DextinityAdminDeleteButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDeleteButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDeleteButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/buttons/feedback/FeedbackButton.tsx
+++ b/packages/admin/admin/src/common/buttons/feedback/FeedbackButton.tsx
@@ -64,7 +64,7 @@ export function FeedbackButton(inProps: FeedbackButtonProps) {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminFeedbackButton",
+        name: "DextinityAdminFeedbackButton",
     });
 
     const [displayState, setDisplayState] = useState<FeedbackButtonDisplayState>("idle");
@@ -172,17 +172,17 @@ export function FeedbackButton(inProps: FeedbackButtonProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFeedbackButton: FeedbackButtonClassKey;
+        DextinityAdminFeedbackButton: FeedbackButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFeedbackButton: FeedbackButtonProps;
+        DextinityAdminFeedbackButton: FeedbackButtonProps;
     }
 
     interface Components {
-        CometAdminFeedbackButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFeedbackButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFeedbackButton"];
+        DextinityAdminFeedbackButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFeedbackButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFeedbackButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/buttons/helpDialogButton/HelpDialogButton.tsx
+++ b/packages/admin/admin/src/common/buttons/helpDialogButton/HelpDialogButton.tsx
@@ -25,7 +25,7 @@ export const HelpDialogButton: FunctionComponent<HelpDialogButtonProps> = (inPro
         icon = <QuestionMark />,
         slotProps = {},
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminHelpDialogButton" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminHelpDialogButton" });
     const [showHelp, setShowHelp] = useState(false);
 
     return (
@@ -55,17 +55,17 @@ export const HelpDialogButton: FunctionComponent<HelpDialogButtonProps> = (inPro
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminHelpDialogButton: HelpDialogButtonProps;
+        DextinityAdminHelpDialogButton: HelpDialogButtonProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminHelpDialogButton: HelpDialogButtonClassKey;
+        DextinityAdminHelpDialogButton: HelpDialogButtonClassKey;
     }
 
     interface Components {
-        CometAdminHelpDialogButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminHelpDialogButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminHelpDialogButton"];
+        DextinityAdminHelpDialogButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminHelpDialogButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminHelpDialogButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
+++ b/packages/admin/admin/src/common/buttons/okay/OkayButton.tsx
@@ -15,7 +15,7 @@ export function OkayButton(inProps: OkayButtonProps) {
         children = <FormattedMessage {...messages.ok} />,
         startIcon = <Check />,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminOkayButton" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminOkayButton" });
 
     return (
         <Root startIcon={startIcon} {...restProps}>
@@ -31,17 +31,17 @@ const Root = createComponentSlot(Button)<OkayButtonClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminOkayButton: OkayButtonClassKey;
+        DextinityAdminOkayButton: OkayButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminOkayButton: OkayButtonProps;
+        DextinityAdminOkayButton: OkayButtonProps;
     }
 
     interface Components {
-        CometAdminOkayButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminOkayButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminOkayButton"];
+        DextinityAdminOkayButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminOkayButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminOkayButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/buttons/split/SplitButton.tsx
+++ b/packages/admin/admin/src/common/buttons/split/SplitButton.tsx
@@ -89,7 +89,7 @@ export function SplitButton(inProps: PropsWithChildren<SplitButtonProps>) {
         popoverProps,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminSplitButton" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminSplitButton" });
 
     const [showSelectButtonState, setShowSelectButtonState] = useState<boolean | undefined>(undefined);
 
@@ -186,12 +186,12 @@ export function SplitButton(inProps: PropsWithChildren<SplitButtonProps>) {
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminSplitButton: SplitButtonProps;
+        DextinityAdminSplitButton: SplitButtonProps;
     }
 
     interface Components {
-        CometAdminSplitButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminSplitButton"]>;
+        DextinityAdminSplitButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminSplitButton"]>;
         };
     }
 }

--- a/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/DataGridToolbar.tsx
@@ -13,7 +13,7 @@ type OwnerState = {
 };
 
 export const DataGridToolbar = (inProps: DataGridToolbarProps) => {
-    const props = useThemeProps({ props: inProps, name: "CometAdminDataGridToolbar" });
+    const props = useThemeProps({ props: inProps, name: "DextinityAdminDataGridToolbar" });
     const apiRef = useGridApiContext();
     const gridDensity = apiRef.current.state.density;
 
@@ -55,17 +55,17 @@ const Root = createComponentSlot(Toolbar)<DataGridToolbarClassKey, OwnerState>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminDataGridToolbar: DataGridToolbarClassKey;
+        DextinityAdminDataGridToolbar: DataGridToolbarClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminDataGridToolbar: DataGridToolbarProps;
+        DextinityAdminDataGridToolbar: DataGridToolbarProps;
     }
 
     interface Components {
-        CometAdminDataGridToolbar?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDataGridToolbar"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDataGridToolbar"];
+        DextinityAdminDataGridToolbar?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDataGridToolbar"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDataGridToolbar"];
         };
     }
 }

--- a/packages/admin/admin/src/common/toolbar/Toolbar.tsx
+++ b/packages/admin/admin/src/common/toolbar/Toolbar.tsx
@@ -138,7 +138,7 @@ export const Toolbar = (inProps: ToolbarProps) => {
         scopeIndicator,
         topBarActions,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminToolbar" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminToolbar" });
     const { headerHeight } = useContext(MasterLayoutContext);
 
     const ownerState: OwnerState = {
@@ -165,17 +165,17 @@ export const Toolbar = (inProps: ToolbarProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminToolbar: ToolbarClassKey;
+        DextinityAdminToolbar: ToolbarClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbar: ToolbarProps;
+        DextinityAdminToolbar: ToolbarProps;
     }
 
     interface Components {
-        CometAdminToolbar?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminToolbar"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminToolbar"];
+        DextinityAdminToolbar?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminToolbar"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminToolbar"];
         };
     }
 }

--- a/packages/admin/admin/src/common/toolbar/ToolbarBreadcrumbs.tsx
+++ b/packages/admin/admin/src/common/toolbar/ToolbarBreadcrumbs.tsx
@@ -47,7 +47,7 @@ export interface ToolbarBreadcrumbsProps
 }
 
 export const ToolbarBreadcrumbs = (inProps: ToolbarBreadcrumbsProps) => {
-    const { iconMapping = {}, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbarBreadcrumbs" });
+    const { iconMapping = {}, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminToolbarBreadcrumbs" });
     const {
         itemSeparator: itemSeparatorIcon = <ChevronRight />,
         openMobileMenu: openMobileMenuIcon = <ChevronDown />,
@@ -392,17 +392,17 @@ const MobileMenuItemNestingIndicator = createComponentSlot("div")<ToolbarBreadcr
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminToolbarBreadcrumbs: ToolbarBreadcrumbsClassKey;
+        DextinityAdminToolbarBreadcrumbs: ToolbarBreadcrumbsClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbarBreadcrumbs: ToolbarBreadcrumbsProps;
+        DextinityAdminToolbarBreadcrumbs: ToolbarBreadcrumbsProps;
     }
 
     interface Components {
-        CometAdminToolbarBreadcrumbs?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminToolbarBreadcrumbs"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminToolbarBreadcrumbs"];
+        DextinityAdminToolbarBreadcrumbs?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminToolbarBreadcrumbs"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminToolbarBreadcrumbs"];
         };
     }
 }

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActionButton.tsx
@@ -68,7 +68,7 @@ const StyledButton = createComponentSlot(Button)<ToolbarActionButtonClassKey, Ow
  * @deprecated Use `Button` from `@dextinity/admin` with the `responsive` prop instead.
  */
 export const ToolbarActionButton = (props: ToolbarActionButtonProps) => {
-    const { children, slotProps = {}, ...restProps } = useThemeProps({ props, name: "CometAdminToolbarActionButton" });
+    const { children, slotProps = {}, ...restProps } = useThemeProps({ props, name: "DextinityAdminToolbarActionButton" });
     const { iconButton: iconButtonProps, tooltip: tooltipProps, button: buttonProps } = slotProps;
 
     const windowSize = useWindowSize();
@@ -93,15 +93,15 @@ export const ToolbarActionButton = (props: ToolbarActionButtonProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminToolbarActionButton: ToolbarActionButtonProps;
+        DextinityAdminToolbarActionButton: ToolbarActionButtonProps;
     }
     interface ComponentNameToClassKey {
-        CometAdminToolbarActionButton: ToolbarActionButtonClassKey;
+        DextinityAdminToolbarActionButton: ToolbarActionButtonClassKey;
     }
     interface Components {
-        CometAdminToolbarActionButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminToolbarActionButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminToolbarActionButton"];
+        DextinityAdminToolbarActionButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminToolbarActionButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminToolbarActionButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/toolbar/actions/ToolbarActions.tsx
+++ b/packages/admin/admin/src/common/toolbar/actions/ToolbarActions.tsx
@@ -19,18 +19,18 @@ const Root = createComponentSlot("div")<ToolbarActionsClassKey>({
 );
 
 export const ToolbarActions = (inProps: PropsWithChildren<ThemedComponentBaseProps>) => {
-    const { children, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbarActions" });
+    const { children, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminToolbarActions" });
     return <Root {...restProps}>{children}</Root>;
 };
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminToolbarActions: ToolbarActionsClassKey;
+        DextinityAdminToolbarActions: ToolbarActionsClassKey;
     }
 
     interface Components {
-        CometAdminToolbarActions?: {
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminToolbarActions"];
+        DextinityAdminToolbarActions?: {
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminToolbarActions"];
         };
     }
 }

--- a/packages/admin/admin/src/common/toolbar/automatictitleitem/ToolbarAutomaticTitleItem.tsx
+++ b/packages/admin/admin/src/common/toolbar/automatictitleitem/ToolbarAutomaticTitleItem.tsx
@@ -25,7 +25,7 @@ const Root = createComponentSlot(ToolbarItem)<ToolbarAutomaticTitleItemClassKey>
 export type ToolbarAutomaticTitleItemClassKey = "root" | "typography";
 
 export const ToolbarAutomaticTitleItem = (inProps: ToolbarAutomaticTitleItemProps) => {
-    const { typographyProps = {}, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbarAutomaticTitleItem" });
+    const { typographyProps = {}, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminToolbarAutomaticTitleItem" });
     const stackApi = useStackApi();
 
     return (
@@ -39,16 +39,16 @@ export const ToolbarAutomaticTitleItem = (inProps: ToolbarAutomaticTitleItemProp
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminToolbarAutomaticTitleItem: ToolbarAutomaticTitleItemClassKey;
+        DextinityAdminToolbarAutomaticTitleItem: ToolbarAutomaticTitleItemClassKey;
     }
     interface ComponentsPropsList {
-        CometAdminToolbarAutomaticTitleItem: ToolbarAutomaticTitleItemProps;
+        DextinityAdminToolbarAutomaticTitleItem: ToolbarAutomaticTitleItemProps;
     }
 
     interface Components {
-        CometAdminToolbarAutomaticTitleItem?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminToolbarAutomaticTitleItem"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminToolbarAutomaticTitleItem"];
+        DextinityAdminToolbarAutomaticTitleItem?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminToolbarAutomaticTitleItem"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminToolbarAutomaticTitleItem"];
         };
     }
 }

--- a/packages/admin/admin/src/common/toolbar/backbutton/ToolbarBackButton.tsx
+++ b/packages/admin/admin/src/common/toolbar/backbutton/ToolbarBackButton.tsx
@@ -18,7 +18,7 @@ const Root = createComponentSlot("div")<ToolbarBackButtonClassKey>({
     flex: 0;
     display: flex;
 
-    .CometAdminToolbarItem-root {
+    .DextinityAdminToolbarItem-root {
         padding: 0;
     }
 `);
@@ -61,7 +61,7 @@ export const ToolbarBackButton = (inProps: ToolbarBackButtonProps) => {
         backIcon = <ArrowLeft sx={{ fontSize: 24 }} />,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminToolbarBackButton" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminToolbarBackButton" });
     const stackApi = useStackApi();
 
     if (!stackApi || stackApi.breadCrumbs.length <= 1) {
@@ -83,17 +83,17 @@ export const ToolbarBackButton = (inProps: ToolbarBackButtonProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminToolbarBackButton: ToolbarBackButtonClassKey;
+        DextinityAdminToolbarBackButton: ToolbarBackButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbarBackButton: ToolbarBackButtonProps;
+        DextinityAdminToolbarBackButton: ToolbarBackButtonProps;
     }
 
     interface Components {
-        CometAdminToolbarBackButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminToolbarBackButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminToolbarBackButton"];
+        DextinityAdminToolbarBackButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminToolbarBackButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminToolbarBackButton"];
         };
     }
 }

--- a/packages/admin/admin/src/common/toolbar/fillspace/ToolbarFillSpace.tsx
+++ b/packages/admin/admin/src/common/toolbar/fillspace/ToolbarFillSpace.tsx
@@ -22,23 +22,23 @@ const Root = createComponentSlot("div")<ToolbarFillSpaceClassKey>({
  * @deprecated Use `FillSpace` instead.
  */
 export const ToolbarFillSpace = (inProps: ToolbarFillSpaceProps) => {
-    const { children, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbarFillSpace" });
+    const { children, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminToolbarFillSpace" });
     return <Root {...restProps}>{children}</Root>;
 };
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminToolbarFillSpace: ToolbarFillSpaceClassKey;
+        DextinityAdminToolbarFillSpace: ToolbarFillSpaceClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbarFillSpace: ToolbarFillSpaceProps;
+        DextinityAdminToolbarFillSpace: ToolbarFillSpaceProps;
     }
 
     interface Components {
-        CometAdminToolbarFillSpace?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminToolbarFillSpace"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminToolbarFillSpace"];
+        DextinityAdminToolbarFillSpace?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminToolbarFillSpace"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminToolbarFillSpace"];
         };
     }
 }

--- a/packages/admin/admin/src/common/toolbar/item/ToolbarItem.tsx
+++ b/packages/admin/admin/src/common/toolbar/item/ToolbarItem.tsx
@@ -24,23 +24,23 @@ export interface ToolbarItemProps extends ThemedComponentBaseProps {
 }
 
 export const ToolbarItem = (inProps: ToolbarItemProps) => {
-    const { children, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbarItem" });
+    const { children, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminToolbarItem" });
     return <Root {...restProps}>{children}</Root>;
 };
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminToolbarItem: ToolbarItemClassKey;
+        DextinityAdminToolbarItem: ToolbarItemClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbarItem: ToolbarItemProps;
+        DextinityAdminToolbarItem: ToolbarItemProps;
     }
 
     interface Components {
-        CometAdminToolbarItem?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminToolbarItem"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminToolbarItem"];
+        DextinityAdminToolbarItem?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminToolbarItem"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminToolbarItem"];
         };
     }
 }

--- a/packages/admin/admin/src/common/toolbar/titleitem/ToolbarTitleItem.tsx
+++ b/packages/admin/admin/src/common/toolbar/titleitem/ToolbarTitleItem.tsx
@@ -32,7 +32,7 @@ const Typography = createComponentSlot(MuiTypography)<ToolbarTitleItemClassKey>(
 })();
 
 export const ToolbarTitleItem = (inProps: ToolbarTitleItemProps) => {
-    const { children, typographyProps = {}, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminToolbarTitleItem" });
+    const { children, typographyProps = {}, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminToolbarTitleItem" });
 
     return (
         <Root {...slotProps?.root} {...restProps}>
@@ -45,17 +45,17 @@ export const ToolbarTitleItem = (inProps: ToolbarTitleItemProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminToolbarTitleItem: ToolbarTitleItemClassKey;
+        DextinityAdminToolbarTitleItem: ToolbarTitleItemClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminToolbarTitleItem: ToolbarTitleItemProps;
+        DextinityAdminToolbarTitleItem: ToolbarTitleItemProps;
     }
 
     interface Components {
-        CometAdminToolbarTitleItem?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminToolbarTitleItem"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminToolbarTitleItem"];
+        DextinityAdminToolbarTitleItem?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminToolbarTitleItem"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminToolbarTitleItem"];
         };
     }
 }

--- a/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudContextMenu.tsx
@@ -79,7 +79,7 @@ export function CrudContextMenu<CopyData>(inProps: CrudContextMenuProps<CopyData
         ...restProp
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminCrudContextMenu",
+        name: "DextinityAdminCrudContextMenu",
     });
 
     const {
@@ -295,17 +295,17 @@ const DeleteDialog = createComponentSlot(CommonDeleteDialog)<CrudContextMenuClas
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminCrudContextMenu: CrudContextMenuProps<unknown>;
+        DextinityAdminCrudContextMenu: CrudContextMenuProps<unknown>;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminCrudContextMenu: CrudContextMenuClassKey;
+        DextinityAdminCrudContextMenu: CrudContextMenuClassKey;
     }
 
     interface Components {
-        CometAdminCrudContextMenu?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminCrudContextMenu"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminCrudContextMenu"];
+        DextinityAdminCrudContextMenu?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminCrudContextMenu"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminCrudContextMenu"];
         };
     }
 }

--- a/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
+++ b/packages/admin/admin/src/dataGrid/CrudMoreActionsMenu.tsx
@@ -233,17 +233,17 @@ export function CrudMoreActionsMenu({ slotProps, overallActions, selectiveAction
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminCrudMoreActionsMenu: CrudMoreActionsMenuProps;
+        DextinityAdminCrudMoreActionsMenu: CrudMoreActionsMenuProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminCrudMoreActionsMenu: CrudMoreActionsMenuClassKey;
+        DextinityAdminCrudMoreActionsMenu: CrudMoreActionsMenuClassKey;
     }
 
     interface Components {
-        CometAdminCrudMoreActionsMenu?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminCrudMoreActionsMenu"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminCrudMoreActionsMenu"];
+        DextinityAdminCrudMoreActionsMenu?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminCrudMoreActionsMenu"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminCrudMoreActionsMenu"];
         };
     }
 }

--- a/packages/admin/admin/src/dataGrid/DataGridPanel.tsx
+++ b/packages/admin/admin/src/dataGrid/DataGridPanel.tsx
@@ -93,7 +93,14 @@ const addFilterText = <FormattedMessage id="dataGrid.panel.addFilter" defaultMes
 let lastAddedFilterItemId = 0;
 
 export const DataGridPanel = (inProps: DataGridPanelProps) => {
-    const { children, open, slotProps, iconMapping = {}, onClose, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminDataGridPanel" });
+    const {
+        children,
+        open,
+        slotProps,
+        iconMapping = {},
+        onClose,
+        ...restProps
+    } = useThemeProps({ props: inProps, name: "DextinityAdminDataGridPanel" });
     const apiRef = useGridApiContext();
     const filterModel = useGridSelector(apiRef, gridFilterModelSelector);
     const filterableColumns = useGridSelector(apiRef, gridFilterableColumnDefinitionsSelector);
@@ -406,17 +413,17 @@ const ApplyButton = createComponentSlot(Button)<DataGridPanelClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminDataGridPanel: DataGridPanelProps;
+        DextinityAdminDataGridPanel: DataGridPanelProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminDataGridPanel: DataGridPanelClassKey;
+        DextinityAdminDataGridPanel: DataGridPanelClassKey;
     }
 
     interface Components {
-        CometAdminDataGridPanel?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDataGridPanel"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDataGridPanel"];
+        DextinityAdminDataGridPanel?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDataGridPanel"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDataGridPanel"];
         };
     }
 }

--- a/packages/admin/admin/src/dataGrid/GridCellContent.tsx
+++ b/packages/admin/admin/src/dataGrid/GridCellContent.tsx
@@ -27,7 +27,7 @@ type OwnerState = {
 export const GridCellContent = (inProps: GridCellContentProps) => {
     const { children, primaryText, secondaryText, slotProps, icon, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminGridCellContent",
+        name: "DextinityAdminGridCellContent",
     });
 
     const ownerState: OwnerState = {
@@ -121,17 +121,17 @@ const SecondaryText = createComponentSlot(Typography)<GridCellContentClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminGridCellContent: GridCellContentProps;
+        DextinityAdminGridCellContent: GridCellContentProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminGridCellContent: GridCellContentClassKey;
+        DextinityAdminGridCellContent: GridCellContentClassKey;
     }
 
     interface Components {
-        CometAdminGridCellContent?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminGridCellContent"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminGridCellContent"];
+        DextinityAdminGridCellContent?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminGridCellContent"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminGridCellContent"];
         };
     }
 }

--- a/packages/admin/admin/src/dataGrid/columnsManagement/DataGridColumnsManagement.tsx
+++ b/packages/admin/admin/src/dataGrid/columnsManagement/DataGridColumnsManagement.tsx
@@ -27,7 +27,7 @@ export type DataGridColumnsManagementProps = ThemedComponentBaseProps<{
 export type DataGridColumnsManagementClassKey = "root" | "body" | "list" | "listHeader" | "divider";
 
 export const DataGridColumnsManagement = (inProps: DataGridColumnsManagementProps) => {
-    const { sx, className, slotProps = {} } = useThemeProps({ props: inProps, name: "CometAdminDataGridColumnsManagement" });
+    const { sx, className, slotProps = {} } = useThemeProps({ props: inProps, name: "DextinityAdminDataGridColumnsManagement" });
 
     const apiRef = useGridApiContext<GridApiPro>();
     const columnVisibilityModel = useGridSelector(apiRef, gridColumnVisibilityModelSelector);
@@ -167,17 +167,17 @@ export const DataGridColumnsManagement = (inProps: DataGridColumnsManagementProp
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminDataGridColumnsManagement: DataGridColumnsManagementProps;
+        DextinityAdminDataGridColumnsManagement: DataGridColumnsManagementProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminDataGridColumnsManagement: DataGridColumnsManagementClassKey;
+        DextinityAdminDataGridColumnsManagement: DataGridColumnsManagementClassKey;
     }
 
     interface Components {
-        CometAdminDataGridColumnsManagement?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDataGridColumnsManagement"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDataGridColumnsManagement"];
+        DextinityAdminDataGridColumnsManagement?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDataGridColumnsManagement"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDataGridColumnsManagement"];
         };
     }
 }

--- a/packages/admin/admin/src/dataGrid/columnsManagement/DataGridColumnsManagementListItem.tsx
+++ b/packages/admin/admin/src/dataGrid/columnsManagement/DataGridColumnsManagementListItem.tsx
@@ -50,7 +50,7 @@ export const DataGridColumnsManagementListItem: FunctionComponent<DataGridColumn
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminDataGridColumnsManagementListItem",
+        name: "DextinityAdminDataGridColumnsManagementListItem",
     });
 
     const apiRef = useGridApiContext<GridApiPro>();
@@ -102,17 +102,17 @@ export const DataGridColumnsManagementListItem: FunctionComponent<DataGridColumn
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminDataGridColumnsManagementListItem: DataGridColumnsManagementListItemProps;
+        DextinityAdminDataGridColumnsManagementListItem: DataGridColumnsManagementListItemProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminDataGridColumnsManagementListItem: DataGridColumnsManagementListItemClassKey;
+        DextinityAdminDataGridColumnsManagementListItem: DataGridColumnsManagementListItemClassKey;
     }
 
     interface Components {
-        CometAdminDataGridColumnsManagementListItem?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDataGridColumnsManagementListItem"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDataGridColumnsManagementListItem"];
+        DextinityAdminDataGridColumnsManagementListItem?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDataGridColumnsManagementListItem"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDataGridColumnsManagementListItem"];
         };
     }
 }

--- a/packages/admin/admin/src/dataGrid/pagination/DataGridPagination.tsx
+++ b/packages/admin/admin/src/dataGrid/pagination/DataGridPagination.tsx
@@ -21,7 +21,7 @@ export const DataGridPagination: FunctionComponent<DataGridPaginationProps> = (i
         slotProps = {},
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminDataGridPagination",
+        name: "DextinityAdminDataGridPagination",
     });
 
     const apiRef = useGridApiContext();
@@ -83,17 +83,17 @@ export const DataGridPagination: FunctionComponent<DataGridPaginationProps> = (i
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminDataGridPagination: DataGridPaginationProps;
+        DextinityAdminDataGridPagination: DataGridPaginationProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminDataGridPagination: DataGridPaginationClassKey;
+        DextinityAdminDataGridPagination: DataGridPaginationClassKey;
     }
 
     interface Components {
-        CometAdminDataGridPagination?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDataGridPagination"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDataGridPagination"];
+        DextinityAdminDataGridPagination?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDataGridPagination"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDataGridPagination"];
         };
     }
 }

--- a/packages/admin/admin/src/dataGrid/pagination/paginationActions/DataGridPaginationActions.tsx
+++ b/packages/admin/admin/src/dataGrid/pagination/paginationActions/DataGridPaginationActions.tsx
@@ -53,7 +53,7 @@ export const DataGridPaginationActions: FunctionComponent<PropsWithChildren<Data
         slotProps = {},
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminDataGridPaginationActions",
+        name: "DextinityAdminDataGridPaginationActions",
     });
     const iconMapping = { ...defaultIconMapping, ...passedIconMapping };
 
@@ -99,17 +99,17 @@ export const DataGridPaginationActions: FunctionComponent<PropsWithChildren<Data
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminDataGridPaginationActions: DataGridPaginationActionsProps;
+        DextinityAdminDataGridPaginationActions: DataGridPaginationActionsProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminDataGridPaginationActions: DataGridPaginationActionsClassKey;
+        DextinityAdminDataGridPaginationActions: DataGridPaginationActionsClassKey;
     }
 
     interface Components {
-        CometAdminDataGridPaginationActions?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDataGridPaginationActions"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDataGridPaginationActions"];
+        DextinityAdminDataGridPaginationActions?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDataGridPaginationActions"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDataGridPaginationActions"];
         };
     }
 }

--- a/packages/admin/admin/src/dateTime/datePicker/DatePicker.tsx
+++ b/packages/admin/admin/src/dateTime/datePicker/DatePicker.tsx
@@ -69,7 +69,7 @@ export const DatePicker = (inProps: DatePickerProps) => {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminDatePicker",
+        name: "DextinityAdminDatePicker",
     });
     const [open, setOpen] = useState(false);
     const intl = useIntl();
@@ -171,17 +171,17 @@ const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<DatePi
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminDatePicker: DatePickerProps;
+        DextinityAdminDatePicker: DatePickerProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminDatePicker: DatePickerClassKey;
+        DextinityAdminDatePicker: DatePickerClassKey;
     }
 
     interface Components {
-        CometAdminDatePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDatePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDatePicker"];
+        DextinityAdminDatePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDatePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDatePicker"];
         };
     }
 }

--- a/packages/admin/admin/src/dateTime/dateRangePicker/DateRangePicker.tsx
+++ b/packages/admin/admin/src/dateTime/dateRangePicker/DateRangePicker.tsx
@@ -81,7 +81,7 @@ export const DateRangePicker = (inProps: DateRangePickerProps) => {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminFutureDateRangePicker",
+        name: "DextinityAdminFutureDateRangePicker",
     });
     const intl = useIntl();
 
@@ -198,17 +198,17 @@ const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<DateRa
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminDateRangePicker: DateRangePickerProps;
+        DextinityAdminDateRangePicker: DateRangePickerProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminDateRangePicker: DateRangePickerClassKey;
+        DextinityAdminDateRangePicker: DateRangePickerClassKey;
     }
 
     interface Components {
-        CometAdminDateRangePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDateRangePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDateRangePicker"];
+        DextinityAdminDateRangePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDateRangePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDateRangePicker"];
         };
     }
 }

--- a/packages/admin/admin/src/dateTime/dateTimePicker/DateTimePicker.tsx
+++ b/packages/admin/admin/src/dateTime/dateTimePicker/DateTimePicker.tsx
@@ -73,7 +73,7 @@ export const DateTimePicker = (inProps: DateTimePickerProps) => {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminDateTimePicker",
+        name: "DextinityAdminDateTimePicker",
     });
     const [open, setOpen] = useState(false);
     const intl = useIntl();
@@ -173,17 +173,17 @@ const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<DateTi
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminDateTimePicker: DateTimePickerProps;
+        DextinityAdminDateTimePicker: DateTimePickerProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminDateTimePicker: DateTimePickerClassKey;
+        DextinityAdminDateTimePicker: DateTimePickerClassKey;
     }
 
     interface Components {
-        CometAdminDateTimePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDateTimePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDateTimePicker"];
+        DextinityAdminDateTimePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDateTimePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDateTimePicker"];
         };
     }
 }

--- a/packages/admin/admin/src/dateTime/dateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/admin/admin/src/dateTime/dateTimeRangePicker/DateTimeRangePicker.tsx
@@ -77,7 +77,7 @@ export const DateTimeRangePicker = (inProps: DateTimeRangePickerProps) => {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminDateTimeRangePicker",
+        name: "DextinityAdminDateTimeRangePicker",
     });
     const intl = useIntl();
 
@@ -199,17 +199,17 @@ const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<DateTi
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminDateTimeRangePicker: DateTimeRangePickerProps;
+        DextinityAdminDateTimeRangePicker: DateTimeRangePickerProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminDateTimeRangePicker: DateTimeRangePickerClassKey;
+        DextinityAdminDateTimeRangePicker: DateTimeRangePickerClassKey;
     }
 
     interface Components {
-        CometAdminDateTimeRangePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminDateTimeRangePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminDateTimeRangePicker"];
+        DextinityAdminDateTimeRangePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminDateTimeRangePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminDateTimeRangePicker"];
         };
     }
 }

--- a/packages/admin/admin/src/dateTime/timePicker/TimePicker.tsx
+++ b/packages/admin/admin/src/dateTime/timePicker/TimePicker.tsx
@@ -69,7 +69,7 @@ export const TimePicker = (inProps: TimePickerProps) => {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminTimePicker",
+        name: "DextinityAdminTimePicker",
     });
     const [open, setOpen] = useState(false);
     const intl = useIntl();
@@ -170,17 +170,17 @@ const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<TimePi
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminTimePicker: TimePickerProps;
+        DextinityAdminTimePicker: TimePickerProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminTimePicker: TimePickerClassKey;
+        DextinityAdminTimePicker: TimePickerClassKey;
     }
 
     interface Components {
-        CometAdminTimePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminTimePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTimePicker"];
+        DextinityAdminTimePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminTimePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminTimePicker"];
         };
     }
 }

--- a/packages/admin/admin/src/dateTime/timeRangePicker/TimeRangePicker.tsx
+++ b/packages/admin/admin/src/dateTime/timeRangePicker/TimeRangePicker.tsx
@@ -81,7 +81,7 @@ export const TimeRangePicker = (inProps: TimeRangePickerProps) => {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminTimeRangePicker",
+        name: "DextinityAdminTimeRangePicker",
     });
     const intl = useIntl();
 
@@ -210,17 +210,17 @@ const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<TimeRa
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminTimeRangePicker: TimeRangePickerProps;
+        DextinityAdminTimeRangePicker: TimeRangePickerProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminTimeRangePicker: TimeRangePickerClassKey;
+        DextinityAdminTimeRangePicker: TimeRangePickerClassKey;
     }
 
     interface Components {
-        CometAdminTimeRangePicker?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminTimeRangePicker"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTimeRangePicker"];
+        DextinityAdminTimeRangePicker?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminTimeRangePicker"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminTimeRangePicker"];
         };
     }
 }

--- a/packages/admin/admin/src/error/errorboundary/ErrorBoundary.tsx
+++ b/packages/admin/admin/src/error/errorboundary/ErrorBoundary.tsx
@@ -139,7 +139,7 @@ const ExceptionStackTrace = createComponentSlot(Typography)<ErrorBoundaryClassKe
 })();
 
 export const ErrorBoundary = (inProps: ErrorBoundaryProps) => {
-    const props = useThemeProps({ props: inProps, name: "CometAdminErrorBoundary" });
+    const props = useThemeProps({ props: inProps, name: "DextinityAdminErrorBoundary" });
     const { onError } = useErrorHandler();
     return <CoreErrorBoundary {...props} onError={onError} />;
 };
@@ -216,17 +216,17 @@ class CoreErrorBoundary extends Component<CoreErrorBoundaryProps, IErrorBoundary
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminErrorBoundary: ErrorBoundaryClassKey;
+        DextinityAdminErrorBoundary: ErrorBoundaryClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminErrorBoundary: ErrorBoundaryProps;
+        DextinityAdminErrorBoundary: ErrorBoundaryProps;
     }
 
     interface Components {
-        CometAdminErrorBoundary?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminErrorBoundary"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminErrorBoundary"];
+        DextinityAdminErrorBoundary?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminErrorBoundary"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminErrorBoundary"];
         };
     }
 }

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -137,8 +137,8 @@ const InnerContainer = createComponentSlot("div")<FieldContainerClassKey, OwnerS
                 border-color: ${theme.palette.error.main};
             }
 
-            .CometAdminRte-root:not(:focus-within),
-            .CometAdminRte-root:hover:not(:focus-within) {
+            .DextinityAdminRte-root:not(:focus-within),
+            .DextinityAdminRte-root:hover:not(:focus-within) {
                 --comet-admin-rte-outer-border-color: ${theme.palette.error.main};
             }
         `}
@@ -153,8 +153,8 @@ const InnerContainer = createComponentSlot("div")<FieldContainerClassKey, OwnerS
                 border-color: ${theme.palette.warning.main};
             }
 
-            .CometAdminRte-root:not(:focus-within),
-            .CometAdminRte-root:hover:not(:focus-within) {
+            .DextinityAdminRte-root:not(:focus-within),
+            .DextinityAdminRte-root:hover:not(:focus-within) {
                 --comet-admin-rte-outer-border-color: ${theme.palette.warning.main};
             }
         `}
@@ -225,7 +225,7 @@ const InputContainer = createComponentSlot("div")<FieldContainerClassKey, OwnerS
             @container comet-admin-field-container-root (min-width: ${ownerState.forceVerticalContainerSize}px) {
                 min-height: 40px;
 
-                > .CometAdminFormFieldContainer-root {
+                > .DextinityAdminFormFieldContainer-root {
                     margin-bottom: 0;
                 }
             }
@@ -324,7 +324,7 @@ export const FieldContainer = (inProps: PropsWithChildren<FieldContainerProps>) 
         fieldMargin = "onlyIfNotLast",
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminFormFieldContainer" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminFormFieldContainer" });
     const fullWidth = passedFullWidth ?? variant === "horizontal";
 
     const hasError = !!error;
@@ -389,17 +389,17 @@ export const FieldContainer = (inProps: PropsWithChildren<FieldContainerProps>) 
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFormFieldContainer: FieldContainerClassKey;
+        DextinityAdminFormFieldContainer: FieldContainerClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFormFieldContainer: FieldContainerProps;
+        DextinityAdminFormFieldContainer: FieldContainerProps;
     }
 
     interface Components {
-        CometAdminFormFieldContainer?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFormFieldContainer"]>;
-            styleOverrides?: ComponentsOverrides["CometAdminFormFieldContainer"];
+        DextinityAdminFormFieldContainer?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFormFieldContainer"]>;
+            styleOverrides?: ComponentsOverrides["DextinityAdminFormFieldContainer"];
         };
     }
 }

--- a/packages/admin/admin/src/form/FinalFormFileSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormFileSelect.tsx
@@ -21,7 +21,7 @@ export function FinalFormFileSelect(inProps: FinalFormFileSelectProps) {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminFinalFormFileSelect",
+        name: "DextinityAdminFinalFormFileSelect",
     });
 
     const [tooManyFilesSelected, setTooManyFilesSelected] = useState(false);

--- a/packages/admin/admin/src/form/FinalFormRangeInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormRangeInput.tsx
@@ -103,7 +103,7 @@ export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
         slotProps,
         disabled,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminFinalFormRangeInput" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminFinalFormRangeInput" });
 
     const [internalMinInput, setInternalMinInput] = useState(fieldValue.min || undefined);
     const [internalMaxInput, setInternalMaxInput] = useState(fieldValue.max || undefined);
@@ -213,12 +213,12 @@ export function FinalFormRangeInput(inProps: FinalFormRangeInputProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFinalFormRangeInput: FinalFormRangeInputClassKey;
+        DextinityAdminFinalFormRangeInput: FinalFormRangeInputClassKey;
     }
 
     interface Components {
-        CometAdminFinalFormRangeInput?: {
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFinalFormRangeInput"];
+        DextinityAdminFinalFormRangeInput?: {
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFinalFormRangeInput"];
         };
     }
 }

--- a/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
+++ b/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
@@ -19,7 +19,7 @@ type FinalFormSearchTextFieldInternalProps = FieldRenderProps<string, HTMLInputE
  * @see {@link SearchField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
 export function FinalFormSearchTextField(inProps: FinalFormSearchTextFieldProps & FinalFormSearchTextFieldInternalProps) {
-    const { icon = <Search />, placeholder, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminFinalFormSearchTextField" });
+    const { icon = <Search />, placeholder, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminFinalFormSearchTextField" });
     const intl = useIntl();
 
     return (
@@ -38,12 +38,12 @@ export function FinalFormSearchTextField(inProps: FinalFormSearchTextFieldProps 
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminFinalFormSearchTextField: FinalFormSearchTextFieldProps;
+        DextinityAdminFinalFormSearchTextField: FinalFormSearchTextFieldProps;
     }
 
     interface Components {
-        CometAdminFinalFormSearchTextField?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFinalFormSearchTextField"]>;
+        DextinityAdminFinalFormSearchTextField?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFinalFormSearchTextField"]>;
         };
     }
 }

--- a/packages/admin/admin/src/form/FormSection.tsx
+++ b/packages/admin/admin/src/form/FormSection.tsx
@@ -29,7 +29,7 @@ export interface FormSectionProps
 export function FormSection(inProps: FormSectionProps) {
     const { children, title, disableMarginBottom, disableTypography, slotProps, infoTooltip, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminFormSection",
+        name: "DextinityAdminFormSection",
     });
 
     const ownerState: OwnerState = {
@@ -96,17 +96,17 @@ const Children = createComponentSlot("div")<FormSectionClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFormSection: FormSectionClassKey;
+        DextinityAdminFormSection: FormSectionClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFormSection: FormSectionProps;
+        DextinityAdminFormSection: FormSectionProps;
     }
 
     interface Components {
-        CometAdminFormSection?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFormSection"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFormSection"];
+        DextinityAdminFormSection?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFormSection"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFormSection"];
         };
     }
 }

--- a/packages/admin/admin/src/form/file/FileDropzone.tsx
+++ b/packages/admin/admin/src/form/file/FileDropzone.tsx
@@ -67,7 +67,7 @@ export const FileDropzone = (inProps: FileDropzoneProps) => {
         ...restDropzoneOptions
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminFileDropzone",
+        name: "DextinityAdminFileDropzone",
     });
     const { error: errorIcon = <Error color="error" />, select: selectIcon = <Select /> } = iconMapping;
     const [focused, setFocused] = useState(false);
@@ -243,17 +243,17 @@ const SelectFileButton = createComponentSlot(Button)<FileDropzoneClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFileDropzone: FileDropzoneClassKey;
+        DextinityAdminFileDropzone: FileDropzoneClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFileDropzone: FileDropzoneProps;
+        DextinityAdminFileDropzone: FileDropzoneProps;
     }
 
     interface Components {
-        CometAdminFileDropzone?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFileDropzone"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFileDropzone"];
+        DextinityAdminFileDropzone?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFileDropzone"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFileDropzone"];
         };
     }
 }

--- a/packages/admin/admin/src/form/file/FileSelect.tsx
+++ b/packages/admin/admin/src/form/file/FileSelect.tsx
@@ -78,7 +78,7 @@ export const FileSelect = <AdditionalValidFileValues = Record<string, unknown>,>
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminFileSelect",
+        name: "DextinityAdminFileSelect",
     });
 
     const { error: errorIcon = <ErrorIcon color="error" /> } = iconMapping;
@@ -219,7 +219,7 @@ const FileList = createComponentSlot("div")<FileSelectClassKey, OwnerState>({
             ${theme.breakpoints.up("md")} {
                 grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 
-                .CometAdminFormFieldContainer-horizontal & {
+                .DextinityAdminFormFieldContainer-horizontal & {
                     grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
                 }
             }
@@ -259,17 +259,17 @@ const ErrorMessage = createComponentSlot(Typography)<FileSelectClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFileSelect: FileSelectClassKey;
+        DextinityAdminFileSelect: FileSelectClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFileSelect: FileSelectProps;
+        DextinityAdminFileSelect: FileSelectProps;
     }
 
     interface Components {
-        CometAdminFileSelect?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFileSelect"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFileSelect"];
+        DextinityAdminFileSelect?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFileSelect"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFileSelect"];
         };
     }
 }

--- a/packages/admin/admin/src/form/file/FileSelectListItem.tsx
+++ b/packages/admin/admin/src/form/file/FileSelectListItem.tsx
@@ -85,7 +85,7 @@ export const FileSelectListItem = (inProps: FileSelectListItemProps) => {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminFileSelectListItem",
+        name: "DextinityAdminFileSelectListItem",
     });
     const fileNameRef = useRef<HTMLDivElement>(null);
     const fileNameIsOverflowing = useElementIsOverflowing(fileNameRef);
@@ -212,11 +212,11 @@ const Root = createComponentSlot("div")<FileSelectListItemClassKey, OwnerState>(
         &:hover {
             background-color: ${theme.palette.grey[100]};
 
-            .CometAdminFileSelectListItem-fileSize {
+            .DextinityAdminFileSelectListItem-fileSize {
                 background-color: ${theme.palette.grey[200]};
             }
 
-            .CometAdminFileSelectListItem-iconButton {
+            .DextinityAdminFileSelectListItem-iconButton {
                 color: ${theme.palette.grey[900]};
             }
         }
@@ -452,17 +452,17 @@ const IconButton = createComponentSlot(MuiIconButton)<FileSelectListItemClassKey
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFileSelectListItem: FileSelectListItemClassKey;
+        DextinityAdminFileSelectListItem: FileSelectListItemClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFileSelectListItem: FileSelectListItemProps;
+        DextinityAdminFileSelectListItem: FileSelectListItemProps;
     }
 
     interface Components {
-        CometAdminFileSelectListItem?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFileSelectListItem"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFileSelectListItem"];
+        DextinityAdminFileSelectListItem?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFileSelectListItem"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFileSelectListItem"];
         };
     }
 }

--- a/packages/admin/admin/src/fullPageAlert/FullPageAlert.tsx
+++ b/packages/admin/admin/src/fullPageAlert/FullPageAlert.tsx
@@ -103,7 +103,7 @@ export const FullPageAlert: FunctionComponent<FullPageAlertProps> = (inProps) =>
         sx,
         className,
         slotProps = {},
-    } = useThemeProps({ props: inProps, name: "CometAdminFullPageAlert" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminFullPageAlert" });
 
     const iconMapping = { ...defaultIconMapping, ...passedIconMapping };
     const titleMapping = { ...defaultTitleMapping, ...passedTitleMapping };
@@ -151,17 +151,17 @@ export const FullPageAlert: FunctionComponent<FullPageAlertProps> = (inProps) =>
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminFullPageAlert: FullPageAlertProps;
+        DextinityAdminFullPageAlert: FullPageAlertProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminFullPageAlert: FullPageAlertClassKey;
+        DextinityAdminFullPageAlert: FullPageAlertClassKey;
     }
 
     interface Components {
-        CometAdminFullPageAlert?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFullPageAlert"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFullPageAlert"];
+        DextinityAdminFullPageAlert?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFullPageAlert"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFullPageAlert"];
         };
     }
 }

--- a/packages/admin/admin/src/helpers/createComponentSlot.tsx
+++ b/packages/admin/admin/src/helpers/createComponentSlot.tsx
@@ -9,7 +9,7 @@ import {
 import type { CSSProperties } from "@mui/material/styles";
 import { type ComponentProps, type ElementType, forwardRef, type JSX } from "react";
 
-const classNamePrefix = "CometAdmin";
+const classNamePrefix = "DextinityAdmin";
 
 type Options<ClassKey extends string, OwnerState extends object | undefined> = {
     componentName: string;

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -318,7 +318,7 @@ export { Tab, Tabs, type TabsClassKey, type TabsProps } from "./tabs/Tabs";
 export { TabScrollButton, type TabScrollButtonClassKey, type TabScrollButtonProps } from "./tabs/TabScrollButton";
 export { breakpointsOptions, breakpointValues } from "./theme/breakpointsOptions";
 export { errorPalette, greyPalette, infoPalette, primaryPalette, successPalette, warningPalette } from "./theme/colors";
-export { createCometTheme } from "./theme/createCometTheme";
+export { createDextinityTheme } from "./theme/createDextinityTheme";
 export { paletteOptions } from "./theme/paletteOptions";
 export { shadows } from "./theme/shadows";
 export { createTypographyOptions } from "./theme/typographyOptions";

--- a/packages/admin/admin/src/inlineAlert/InlineAlert.tsx
+++ b/packages/admin/admin/src/inlineAlert/InlineAlert.tsx
@@ -104,7 +104,7 @@ export const InlineAlert: FunctionComponent<InlineAlertProps> = (inProps) => {
         sx,
         className,
         slotProps = {},
-    } = useThemeProps({ props: inProps, name: "CometAdminInlineAlert" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminInlineAlert" });
 
     const iconMapping = { ...defaultIconMapping, ...passedIconMapping };
     const titleMapping = { ...defaultTitleMapping, ...passedTitleMapping };
@@ -130,17 +130,17 @@ export const InlineAlert: FunctionComponent<InlineAlertProps> = (inProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminInlineAlert: InlineAlertProps;
+        DextinityAdminInlineAlert: InlineAlertProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminInlineAlert: InlineAlertClassKey;
+        DextinityAdminInlineAlert: InlineAlertClassKey;
     }
 
     interface Components {
-        CometAdminInlineAlert?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminInlineAlert"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminInlineAlert"];
+        DextinityAdminInlineAlert?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminInlineAlert"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminInlineAlert"];
         };
     }
 }

--- a/packages/admin/admin/src/inputWithPopper/InputWithPopper.tsx
+++ b/packages/admin/admin/src/inputWithPopper/InputWithPopper.tsx
@@ -48,7 +48,7 @@ export const InputWithPopper = (inProps: InputWithPopperProps) => {
         inputRef: inputRefProp,
         slotProps,
         ...inputBaseProps
-    } = useThemeProps({ props: inProps, name: "CometAdminInputWithPopper" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminInputWithPopper" });
     const { Transition = Grow, ...inputBaseComponents } = components;
 
     const rootRef = useRef<HTMLDivElement>(null);

--- a/packages/admin/admin/src/mui/MasterLayout.tsx
+++ b/packages/admin/admin/src/mui/MasterLayout.tsx
@@ -69,7 +69,7 @@ export function MasterLayout(inProps: MasterLayoutProps) {
         headerHeight = 60,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminMasterLayout" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminMasterLayout" });
 
     const [open, setOpen] = useStoredState("main-navigation-open", openMenuByDefault);
     const [drawerVariant, setDrawerVariant] = useState<"permanent" | "temporary">("permanent");
@@ -137,17 +137,17 @@ export function MasterLayout(inProps: MasterLayoutProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminMasterLayout: MasterLayoutClassKey;
+        DextinityAdminMasterLayout: MasterLayoutClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminMasterLayout: MasterLayoutProps;
+        DextinityAdminMasterLayout: MasterLayoutProps;
     }
 
     interface Components {
-        CometAdminMasterLayout?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminMasterLayout"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminMasterLayout"];
+        DextinityAdminMasterLayout?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminMasterLayout"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminMasterLayout"];
         };
     }
 }

--- a/packages/admin/admin/src/mui/mainNavigation/CollapsibleItem.styles.ts
+++ b/packages/admin/admin/src/mui/mainNavigation/CollapsibleItem.styles.ts
@@ -59,12 +59,12 @@ export const CollapsibleItemMainNavigationItem = createComponentSlot(MainNavigat
 
         ${ownerState.childSelected &&
         css`
-            .CometAdminMainNavigationItem-text,
-            .CometAdminMainNavigationItem-icon {
+            .DextinityAdminMainNavigationItem-text,
+            .DextinityAdminMainNavigationItem-icon {
                 color: ${theme.palette.primary.main};
             }
 
-            .CometAdminMainNavigationItem-primary {
+            .DextinityAdminMainNavigationItem-primary {
                 ${(ownerState.level === 2 || ownerState.level === 3) &&
                 css`
                     font-weight: 600;

--- a/packages/admin/admin/src/mui/mainNavigation/CollapsibleItem.tsx
+++ b/packages/admin/admin/src/mui/mainNavigation/CollapsibleItem.tsx
@@ -52,7 +52,7 @@ export const MainNavigationCollapsibleItem = (inProps: MainNavigationCollapsible
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminMainNavigationCollapsibleItem",
+        name: "DextinityAdminMainNavigationCollapsibleItem",
     });
 
     const {
@@ -234,17 +234,17 @@ export const MainNavigationCollapsibleItem = (inProps: MainNavigationCollapsible
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminMainNavigationCollapsibleItem: MainNavigationCollapsibleItemClassKey;
+        DextinityAdminMainNavigationCollapsibleItem: MainNavigationCollapsibleItemClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminMainNavigationCollapsibleItem: MainNavigationCollapsibleItemProps;
+        DextinityAdminMainNavigationCollapsibleItem: MainNavigationCollapsibleItemProps;
     }
 
     interface Components {
-        CometAdminMainNavigationCollapsibleItem?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminMainNavigationCollapsibleItem"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminMainNavigationCollapsibleItem"];
+        DextinityAdminMainNavigationCollapsibleItem?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminMainNavigationCollapsibleItem"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminMainNavigationCollapsibleItem"];
         };
     }
 }

--- a/packages/admin/admin/src/mui/mainNavigation/Item.tsx
+++ b/packages/admin/admin/src/mui/mainNavigation/Item.tsx
@@ -52,7 +52,7 @@ export const MainNavigationItem = (inProps: MainNavigationItemProps) => {
         isCollapsibleOpen,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminMainNavigationItem" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminMainNavigationItem" });
 
     const { drawerVariant } = useMainNavigation();
 
@@ -99,17 +99,17 @@ export const MainNavigationItem = (inProps: MainNavigationItemProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminMainNavigationItem: MainNavigationItemProps;
+        DextinityAdminMainNavigationItem: MainNavigationItemProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminMainNavigationItem: MainNavigationItemClassKey;
+        DextinityAdminMainNavigationItem: MainNavigationItemClassKey;
     }
 
     interface Components {
-        CometAdminMainNavigationItem?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminMainNavigationItem"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminMainNavigationItem"];
+        DextinityAdminMainNavigationItem?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminMainNavigationItem"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminMainNavigationItem"];
         };
     }
 }

--- a/packages/admin/admin/src/mui/mainNavigation/ItemGroup.tsx
+++ b/packages/admin/admin/src/mui/mainNavigation/ItemGroup.tsx
@@ -106,7 +106,7 @@ export interface MainNavigationItemGroupProps
 export const MainNavigationItemGroup = (inProps: MainNavigationItemGroupProps) => {
     const { title, shortTitle, helperIcon, children, isMenuOpen, slotProps, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminMainNavigationItemGroup",
+        name: "DextinityAdminMainNavigationItemGroup",
     });
 
     const intl = useIntl();
@@ -176,17 +176,17 @@ export const MainNavigationItemGroup = (inProps: MainNavigationItemGroupProps) =
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminMainNavigationItemGroup: MainNavigationItemGroupProps;
+        DextinityAdminMainNavigationItemGroup: MainNavigationItemGroupProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminMainNavigationItemGroup: MainNavigationItemGroupClassKey;
+        DextinityAdminMainNavigationItemGroup: MainNavigationItemGroupClassKey;
     }
 
     interface Components {
-        CometAdminMainNavigationItemGroup?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminMainNavigationItemGroup"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminMainNavigationItemGroup"];
+        DextinityAdminMainNavigationItemGroup?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminMainNavigationItemGroup"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminMainNavigationItemGroup"];
         };
     }
 }

--- a/packages/admin/admin/src/mui/mainNavigation/MainNavigation.styles.ts
+++ b/packages/admin/admin/src/mui/mainNavigation/MainNavigation.styles.ts
@@ -33,7 +33,7 @@ const getSharedStyles = (theme: Theme, headerHeight: number) => css`
     height: calc(100% - ${headerHeight}px);
     top: ${headerHeight}px;
 
-    .CometAdminMainNavigationItemGroup-root + .CometAdminMainNavigationItem-root {
+    .DextinityAdminMainNavigationItemGroup-root + .DextinityAdminMainNavigationItem-root {
         margin-top: ${theme.spacing(8)};
     }
 `;

--- a/packages/admin/admin/src/mui/mainNavigation/MainNavigation.tsx
+++ b/packages/admin/admin/src/mui/mainNavigation/MainNavigation.tsx
@@ -32,7 +32,7 @@ export const MainNavigation = (inProps: MainNavigationProps) => {
         variant = "permanent",
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminMainNavigation" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminMainNavigation" });
     const history = useHistory();
     const { open, toggleOpen, setOpen, setDrawerVariant, drawerVariant } = useMainNavigation();
     const initialRender = useRef(true);
@@ -128,17 +128,17 @@ export const MainNavigation = (inProps: MainNavigationProps) => {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminMainNavigation: MainNavigationClassKey;
+        DextinityAdminMainNavigation: MainNavigationClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminMainNavigation: MainNavigationProps;
+        DextinityAdminMainNavigation: MainNavigationProps;
     }
 
     interface Components {
-        CometAdminMainNavigation?: {
-            defaultProps?: ComponentsPropsList["CometAdminMainNavigation"];
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminMainNavigation"];
+        DextinityAdminMainNavigation?: {
+            defaultProps?: ComponentsPropsList["DextinityAdminMainNavigation"];
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminMainNavigation"];
         };
     }
 }

--- a/packages/admin/admin/src/router/ConfirmationDialog.tsx
+++ b/packages/admin/admin/src/router/ConfirmationDialog.tsx
@@ -125,7 +125,7 @@ export function RouterConfirmationDialog(inProps: RouterConfirmationDialogProps)
         showSaveButton = false,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminRouterConfirmationDialog" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminRouterConfirmationDialog" });
 
     return (
         <StyledDialog open={isOpen} onClose={() => handleClose(PromptAction.Cancel)} maxWidth="sm" {...slotProps?.root} {...restProps}>
@@ -162,12 +162,12 @@ export function RouterConfirmationDialog(inProps: RouterConfirmationDialogProps)
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminRouterConfirmationDialog: RouterConfirmationDialogClassKey;
+        DextinityAdminRouterConfirmationDialog: RouterConfirmationDialogClassKey;
     }
 
     interface Components {
-        CometAdminRouterConfirmationDialog?: {
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminRouterConfirmationDialog"];
+        DextinityAdminRouterConfirmationDialog?: {
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminRouterConfirmationDialog"];
         };
     }
 }

--- a/packages/admin/admin/src/section/SectionHeadline.tsx
+++ b/packages/admin/admin/src/section/SectionHeadline.tsx
@@ -44,7 +44,7 @@ export function SectionHeadline(inProps: SectionHeadlineProps) {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminSectionHeadline",
+        name: "DextinityAdminSectionHeadline",
     });
 
     const { tooltip: tooltipIcon = <Info sx={{ fontSize: "inherit" }} /> } = iconMapping;
@@ -151,17 +151,17 @@ const StyledDivider = createComponentSlot(Divider)<SectionHeadlineClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminSectionHeadline: SectionHeadlineClassKey;
+        DextinityAdminSectionHeadline: SectionHeadlineClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminSectionHeadline: SectionHeadlineProps;
+        DextinityAdminSectionHeadline: SectionHeadlineProps;
     }
 
     interface Components {
-        CometAdminSectionHeadline?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminSectionHeadline"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminSectionHeadline"];
+        DextinityAdminSectionHeadline?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminSectionHeadline"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminSectionHeadline"];
         };
     }
 }

--- a/packages/admin/admin/src/stack/backbutton/StackBackButton.tsx
+++ b/packages/admin/admin/src/stack/backbutton/StackBackButton.tsx
@@ -11,7 +11,11 @@ export type StackBackButtonClassKey = ButtonClassKey;
 export type StackBackButtonProps = ButtonProps;
 
 export function StackBackButton(inProps: StackBackButtonProps) {
-    const { startIcon = <ArrowLeft />, variant = "textDark", ...restProps } = useThemeProps({ props: inProps, name: "CometAdminStackBackButton" });
+    const {
+        startIcon = <ArrowLeft />,
+        variant = "textDark",
+        ...restProps
+    } = useThemeProps({ props: inProps, name: "DextinityAdminStackBackButton" });
 
     return (
         <StackApiContext.Consumer>
@@ -39,17 +43,17 @@ const Root = createComponentSlot(Button)<StackBackButtonClassKey>({
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminStackBackButton: StackBackButtonClassKey;
+        DextinityAdminStackBackButton: StackBackButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminStackBackButton: StackBackButtonProps;
+        DextinityAdminStackBackButton: StackBackButtonProps;
     }
 
     interface Components {
-        CometAdminStackBackButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminStackBackButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminStackBackButton"];
+        DextinityAdminStackBackButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminStackBackButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminStackBackButton"];
         };
     }
 }

--- a/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
+++ b/packages/admin/admin/src/stack/breadcrumbs/StackBreadcrumbs.tsx
@@ -91,7 +91,12 @@ export interface StackBreadcrumbsProps
 }
 
 export function StackBreadcrumbs(inProps: StackBreadcrumbsProps) {
-    const { separator, overflowLinkText = ". . .", slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminStackBreadcrumbs" });
+    const {
+        separator,
+        overflowLinkText = ". . .",
+        slotProps,
+        ...restProps
+    } = useThemeProps({ props: inProps, name: "DextinityAdminStackBreadcrumbs" });
     const stackApi = useStackApi();
     const { palette } = useTheme();
     const breadcrumbsRef = useRef<HTMLDivElement>(null);
@@ -140,17 +145,17 @@ export function StackBreadcrumbs(inProps: StackBreadcrumbsProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminStackBreadcrumbs: StackBreadcrumbsClassKey;
+        DextinityAdminStackBreadcrumbs: StackBreadcrumbsClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminStackBreadcrumbs: StackBreadcrumbsProps;
+        DextinityAdminStackBreadcrumbs: StackBreadcrumbsProps;
     }
 
     interface Components {
-        CometAdminStackBreadcrumbs?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminStackBreadcrumbs"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminStackBreadcrumbs"];
+        DextinityAdminStackBreadcrumbs?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminStackBreadcrumbs"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminStackBreadcrumbs"];
         };
     }
 }

--- a/packages/admin/admin/src/table/TableBodyRow.tsx
+++ b/packages/admin/admin/src/table/TableBodyRow.tsx
@@ -36,7 +36,7 @@ export interface TableBodyRowProps
  * @deprecated Use MUI X Data Grid in combination with `useDataGridRemote` instead.
  */
 export function TableBodyRow(inProps: TableBodyRowProps) {
-    const { title, children, index, hideTableHead, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminTableBodyRow" });
+    const { title, children, index, hideTableHead, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminTableBodyRow" });
 
     const ownerState: OwnerState = {
         isOdd: ((index || 0) + (hideTableHead ? 1 : 0)) % 2 === 1,
@@ -51,17 +51,17 @@ export function TableBodyRow(inProps: TableBodyRowProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminTableBodyRow: TableBodyRowClassKey;
+        DextinityAdminTableBodyRow: TableBodyRowClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminTableBodyRow: TableBodyRowProps;
+        DextinityAdminTableBodyRow: TableBodyRowProps;
     }
 
     interface Components {
-        CometAdminTableBodyRow?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminTableBodyRow"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTableBodyRow"];
+        DextinityAdminTableBodyRow?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminTableBodyRow"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminTableBodyRow"];
         };
     }
 }

--- a/packages/admin/admin/src/table/TableDndOrder.tsx
+++ b/packages/admin/admin/src/table/TableDndOrder.tsx
@@ -176,7 +176,7 @@ export function TableDndOrder<TRow extends IRow>(inProps: TableDndOrderProps<TRo
         dragHandleIcon = <DragHandle />,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminTableDndOrder" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminTableDndOrder" });
 
     const renderHeadTableRow = useCallback<NonNullable<ITableProps<TRow>["renderHeadTableRow"]>>((ownProps) => {
         return (
@@ -203,17 +203,17 @@ export function TableDndOrder<TRow extends IRow>(inProps: TableDndOrderProps<TRo
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminTableDndOrder: TableDndOrderProps<IRow>;
+        DextinityAdminTableDndOrder: TableDndOrderProps<IRow>;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminTableDndOrder: TableDndOrderClassKey;
+        DextinityAdminTableDndOrder: TableDndOrderClassKey;
     }
 
     interface Components {
-        CometAdminTableDndOrder?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminTableDndOrder"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTableDndOrder"];
+        DextinityAdminTableDndOrder?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminTableDndOrder"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminTableDndOrder"];
         };
     }
 }

--- a/packages/admin/admin/src/table/TableQuery.tsx
+++ b/packages/admin/admin/src/table/TableQuery.tsx
@@ -82,7 +82,7 @@ export interface TableQueryProps
  * @deprecated Use MUI X Data Grid in combination with `useDataGridRemote` instead.
  */
 export function TableQuery(inProps: TableQueryProps) {
-    const { loading, error, children, api, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "CometAdminTableQuery" });
+    const { loading, error, children, api, slotProps, ...restProps } = useThemeProps({ props: inProps, name: "DextinityAdminTableQuery" });
 
     return (
         <TableQueryContext.Provider
@@ -118,17 +118,17 @@ export function TableQuery(inProps: TableQueryProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentsPropsList {
-        CometAdminTableQuery: TableQueryProps;
+        DextinityAdminTableQuery: TableQueryProps;
     }
 
     interface ComponentNameToClassKey {
-        CometAdminTableQuery: TableQueryClassKey;
+        DextinityAdminTableQuery: TableQueryClassKey;
     }
 
     interface Components {
-        CometAdminTableQuery?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminTableQuery"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTableQuery"];
+        DextinityAdminTableQuery?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminTableQuery"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminTableQuery"];
         };
     }
 }

--- a/packages/admin/admin/src/table/filterbar/FilterBar.tsx
+++ b/packages/admin/admin/src/table/filterbar/FilterBar.tsx
@@ -13,7 +13,7 @@ const Root = createComponentSlot("div")<FilterBarClassKey>({
     componentName: "FilterBar",
     slotName: "root",
 })(css`
-    .CometAdminFormFieldContainer-root {
+    .DextinityAdminFormFieldContainer-root {
         margin-bottom: 0;
     }
 `);
@@ -43,7 +43,7 @@ export interface FilterBarProps
 export function FilterBar(inProps: FilterBarProps) {
     const { children, slotProps, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminFilterBar",
+        name: "DextinityAdminFilterBar",
     });
 
     return (
@@ -55,17 +55,17 @@ export function FilterBar(inProps: FilterBarProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFilterBar: FilterBarClassKey;
+        DextinityAdminFilterBar: FilterBarClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFilterBar: FilterBarProps;
+        DextinityAdminFilterBar: FilterBarProps;
     }
 
     interface Components {
-        CometAdminFilterBar?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFilterBar"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFilterBar"];
+        DextinityAdminFilterBar?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFilterBar"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFilterBar"];
         };
     }
 }

--- a/packages/admin/admin/src/table/filterbar/filterBarActiveFilterBadge/FilterBarActiveFilterBadge.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarActiveFilterBadge/FilterBarActiveFilterBadge.tsx
@@ -43,7 +43,7 @@ export interface FilterBarActiveFilterBadgeProps
 export function FilterBarActiveFilterBadge(inProps: FilterBarActiveFilterBadgeProps) {
     const { countValue, slotProps, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminFilterBarActiveFilterBadge",
+        name: "DextinityAdminFilterBarActiveFilterBadge",
     });
     if (countValue > 0) {
         return (
@@ -60,17 +60,17 @@ export function FilterBarActiveFilterBadge(inProps: FilterBarActiveFilterBadgePr
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFilterBarActiveFilterBadge: FilterBarActiveFilterBadgeClassKey;
+        DextinityAdminFilterBarActiveFilterBadge: FilterBarActiveFilterBadgeClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFilterBarActiveFilterBadge: FilterBarActiveFilterBadgeProps;
+        DextinityAdminFilterBarActiveFilterBadge: FilterBarActiveFilterBadgeProps;
     }
 
     interface Components {
-        CometAdminFilterBarActiveFilterBadge?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFilterBarActiveFilterBadge"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFilterBarActiveFilterBadge"];
+        DextinityAdminFilterBarActiveFilterBadge?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFilterBarActiveFilterBadge"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFilterBarActiveFilterBadge"];
         };
     }
 }

--- a/packages/admin/admin/src/table/filterbar/filterBarButton/FilterBarButton.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarButton/FilterBarButton.tsx
@@ -97,7 +97,7 @@ export function FilterBarButton(inProps: FilterBarButtonProps) {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminFilterBarButton",
+        name: "DextinityAdminFilterBarButton",
     });
 
     const hasDirtyFields = !!(numberDirtyFields && numberDirtyFields > 0);
@@ -119,17 +119,17 @@ export function FilterBarButton(inProps: FilterBarButtonProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFilterBarButton: FilterBarButtonClassKey;
+        DextinityAdminFilterBarButton: FilterBarButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFilterBarButton: FilterBarButtonProps;
+        DextinityAdminFilterBarButton: FilterBarButtonProps;
     }
 
     interface Components {
-        CometAdminFilterBarButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFilterBarButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFilterBarButton"];
+        DextinityAdminFilterBarButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFilterBarButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFilterBarButton"];
         };
     }
 }

--- a/packages/admin/admin/src/table/filterbar/filterBarMoreFilters/FilterBarMoreFilters.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarMoreFilters/FilterBarMoreFilters.tsx
@@ -52,7 +52,7 @@ export function FilterBarMoreFilters(inProps: PropsWithChildren<FilterBarMoreFil
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminFilterBarMoreFilters",
+        name: "DextinityAdminFilterBarMoreFilters",
     });
     const [hasExtended, setHasExtended] = useState(false);
 
@@ -71,17 +71,17 @@ export function FilterBarMoreFilters(inProps: PropsWithChildren<FilterBarMoreFil
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFilterBarMoreFilters: FilterBarMoreFiltersClassKey;
+        DextinityAdminFilterBarMoreFilters: FilterBarMoreFiltersClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFilterBarMoreFilters: FilterBarMoreFiltersProps;
+        DextinityAdminFilterBarMoreFilters: FilterBarMoreFiltersProps;
     }
 
     interface Components {
-        CometAdminFilterBarMoreFilters?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFilterBarMoreFilters"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFilterBarMoreFilters"];
+        DextinityAdminFilterBarMoreFilters?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFilterBarMoreFilters"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFilterBarMoreFilters"];
         };
     }
 }

--- a/packages/admin/admin/src/table/filterbar/filterBarPopoverFilter/FilterBarPopoverFilter.tsx
+++ b/packages/admin/admin/src/table/filterbar/filterBarPopoverFilter/FilterBarPopoverFilter.tsx
@@ -44,7 +44,7 @@ const PopoverContentContainer = createComponentSlot("div")<FilterBarPopoverFilte
 })(css`
     min-width: 300px;
 
-    .CometAdminFormFieldContainer-root {
+    .DextinityAdminFormFieldContainer-root {
         box-sizing: border-box;
         padding: 20px;
         margin-bottom: 0;
@@ -104,7 +104,7 @@ export function FilterBarPopoverFilter(inProps: PropsWithChildren<FilterBarPopov
         filterBarButtonProps,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminFilterBarPopoverFilter" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminFilterBarPopoverFilter" });
 
     const outerForm = useForm();
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -209,17 +209,17 @@ export function FilterBarPopoverFilter(inProps: PropsWithChildren<FilterBarPopov
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminFilterBarPopoverFilter: FilterBarPopoverFilterClassKey;
+        DextinityAdminFilterBarPopoverFilter: FilterBarPopoverFilterClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminFilterBarPopoverFilter: FilterBarPopoverFilterProps;
+        DextinityAdminFilterBarPopoverFilter: FilterBarPopoverFilterProps;
     }
 
     interface Components {
-        CometAdminFilterBarPopoverFilter?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminFilterBarPopoverFilter"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFilterBarPopoverFilter"];
+        DextinityAdminFilterBarPopoverFilter?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminFilterBarPopoverFilter"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminFilterBarPopoverFilter"];
         };
     }
 }

--- a/packages/admin/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/admin/src/tabs/RouterTabs.tsx
@@ -72,7 +72,7 @@ export function RouterTabs(inProps: Props) {
         tabsProps: { ScrollButtonComponent = TabScrollButton, ...tabsProps } = {},
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminRouterTabs" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminRouterTabs" });
 
     const history = useHistory();
     const subRoutePrefix = useSubRoutePrefix();
@@ -181,12 +181,12 @@ export function RouterTabs(inProps: Props) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminRouterTabs: RouterTabsClassKey;
+        DextinityAdminRouterTabs: RouterTabsClassKey;
     }
 
     interface Components {
-        CometAdminRouterTabs?: {
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminRouterTabs"];
+        DextinityAdminRouterTabs?: {
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminRouterTabs"];
         };
     }
 }

--- a/packages/admin/admin/src/tabs/TabScrollButton.tsx
+++ b/packages/admin/admin/src/tabs/TabScrollButton.tsx
@@ -40,7 +40,7 @@ export interface TabScrollButtonProps extends ButtonBaseProps {
 export function TabScrollButton(inProps: TabScrollButtonProps) {
     const { orientation, direction, ...restProps } = useThemeProps({
         props: inProps,
-        name: "CometAdminTabScrollButton",
+        name: "DextinityAdminTabScrollButton",
     });
 
     const ownerState: OwnerState = {
@@ -56,17 +56,17 @@ export function TabScrollButton(inProps: TabScrollButtonProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminTabScrollButton: TabScrollButtonClassKey;
+        DextinityAdminTabScrollButton: TabScrollButtonClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminTabScrollButton: TabScrollButtonProps;
+        DextinityAdminTabScrollButton: TabScrollButtonProps;
     }
 
     interface Components {
-        CometAdminTabScrollButton?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminTabScrollButton"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTabScrollButton"];
+        DextinityAdminTabScrollButton?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminTabScrollButton"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminTabScrollButton"];
         };
     }
 }

--- a/packages/admin/admin/src/tabs/Tabs.tsx
+++ b/packages/admin/admin/src/tabs/Tabs.tsx
@@ -79,7 +79,7 @@ export function Tabs(inProps: TabsProps) {
         ScrollButtonComponent = TabScrollButton,
         slotProps,
         ...restProps
-    } = useThemeProps({ props: inProps, name: "CometAdminTabs" });
+    } = useThemeProps({ props: inProps, name: "DextinityAdminTabs" });
 
     let value: ITabsState["value"];
     let setValue: ITabsState["setValue"];
@@ -150,17 +150,17 @@ export function Tabs(inProps: TabsProps) {
 
 declare module "@mui/material/styles" {
     interface ComponentNameToClassKey {
-        CometAdminTabs: TabsClassKey;
+        DextinityAdminTabs: TabsClassKey;
     }
 
     interface ComponentsPropsList {
-        CometAdminTabs: TabsProps;
+        DextinityAdminTabs: TabsProps;
     }
 
     interface Components {
-        CometAdminTabs?: {
-            defaultProps?: Partial<ComponentsPropsList["CometAdminTabs"]>;
-            styleOverrides?: ComponentsOverrides<Theme>["CometAdminTabs"];
+        DextinityAdminTabs?: {
+            defaultProps?: Partial<ComponentsPropsList["DextinityAdminTabs"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["DextinityAdminTabs"];
         };
     }
 }

--- a/packages/admin/admin/src/theme/componentsTheme/MuiPickersInputBase.ts
+++ b/packages/admin/admin/src/theme/componentsTheme/MuiPickersInputBase.ts
@@ -59,11 +59,11 @@ export const getMuiPickersInputBase = (
                 },
             },
 
-            [`.CometAdminClearInputAdornment-root.${inputAdornmentClasses.positionStart}`]: {
+            [`.DextinityAdminClearInputAdornment-root.${inputAdornmentClasses.positionStart}`]: {
                 marginLeft: spacing(-2),
             },
 
-            [`.CometAdminClearInputAdornment-root.${inputAdornmentClasses.positionEnd}`]: {
+            [`.DextinityAdminClearInputAdornment-root.${inputAdornmentClasses.positionEnd}`]: {
                 marginRight: spacing(-2),
             },
         },

--- a/packages/admin/admin/src/theme/createDextinityTheme.ts
+++ b/packages/admin/admin/src/theme/createDextinityTheme.ts
@@ -2,13 +2,13 @@ import { createTheme, type Theme, type ThemeOptions } from "@mui/material";
 import { createBreakpoints } from "@mui/system";
 import { deepmerge } from "@mui/utils";
 
-import { breakpointsOptions as cometBreakpointsOptions } from "./breakpointsOptions";
+import { breakpointsOptions as dextinityBreakpointsOptions } from "./breakpointsOptions";
 import { getComponentsTheme } from "./componentsTheme/getComponentsTheme";
-import { paletteOptions as cometPaletteOptions } from "./paletteOptions";
+import { paletteOptions as dextinityPaletteOptions } from "./paletteOptions";
 import { shadows } from "./shadows";
 import { createTypographyOptions } from "./typographyOptions";
 
-export const createCometTheme = (
+export const createDextinityTheme = (
     {
         palette: passedPaletteOptions = {},
         typography: passedTypographyOptions = {},
@@ -20,16 +20,16 @@ export const createCometTheme = (
     }: ThemeOptions | undefined = {},
     ...args: object[]
 ): Theme => {
-    const breakpointsOptions = deepmerge(cometBreakpointsOptions, passedBreakpointsOptions);
+    const breakpointsOptions = deepmerge(dextinityBreakpointsOptions, passedBreakpointsOptions);
     const breakpoints = createBreakpoints(breakpointsOptions);
 
-    const paletteOptions = deepmerge(cometPaletteOptions, passedPaletteOptions);
+    const paletteOptions = deepmerge(dextinityPaletteOptions, passedPaletteOptions);
     const { palette } = createTheme({ palette: paletteOptions });
 
     const passedTypographyOptionsObject = typeof passedTypographyOptions === "function" ? passedTypographyOptions(palette) : passedTypographyOptions;
     const typographyOptions = deepmerge(createTypographyOptions(breakpoints), passedTypographyOptionsObject);
 
-    const cometThemeOptionsBeforeAddingComponents = {
+    const dextinityThemeOptionsBeforeAddingComponents = {
         spacing: passedSpacingOptions,
         palette: {
             ...paletteOptions,
@@ -47,14 +47,14 @@ export const createCometTheme = (
         breakpoints: breakpointsOptions,
     } satisfies ThemeOptions;
 
-    const combinedThemeOptionsBeforeAddingComponents = deepmerge(cometThemeOptionsBeforeAddingComponents, restPassedOptions);
+    const combinedThemeOptionsBeforeAddingComponents = deepmerge(dextinityThemeOptionsBeforeAddingComponents, restPassedOptions);
     const themeBeforeAddingComponents = createTheme(combinedThemeOptionsBeforeAddingComponents);
 
-    const cometThemeOptions = {
-        ...cometThemeOptionsBeforeAddingComponents,
+    const dextinityThemeOptions = {
+        ...dextinityThemeOptionsBeforeAddingComponents,
         components: getComponentsTheme(passedComponentsOptions, themeBeforeAddingComponents),
     } satisfies ThemeOptions;
 
-    const themeOptions = deepmerge(cometThemeOptions, restPassedOptions);
+    const themeOptions = deepmerge(dextinityThemeOptions, restPassedOptions);
     return createTheme(themeOptions, ...args);
 };

--- a/packages/admin/cms-admin/.storybook/decorators/ThemeProvider.decorator.tsx
+++ b/packages/admin/cms-admin/.storybook/decorators/ThemeProvider.decorator.tsx
@@ -1,4 +1,4 @@
-import { createCometTheme, MuiThemeProvider } from "@dextinity/admin";
+import { createDextinityTheme, MuiThemeProvider } from "@dextinity/admin";
 import { createTheme as createMuiTheme, CssBaseline } from "@mui/material";
 import { type Decorator } from "@storybook/react-vite";
 
@@ -9,7 +9,7 @@ export enum ThemeOption {
 
 export const ThemeProviderDecorator: Decorator = (fn, context) => {
     const { theme: selectedTheme } = context.globals;
-    const theme = selectedTheme === ThemeOption.Mui ? createMuiTheme() : createCometTheme();
+    const theme = selectedTheme === ThemeOption.Mui ? createMuiTheme() : createDextinityTheme();
     return (
         <MuiThemeProvider theme={theme}>
             <CssBaseline />

--- a/packages/admin/cms-admin/.storybook/decorators/ThemeProvider.decorator.tsx
+++ b/packages/admin/cms-admin/.storybook/decorators/ThemeProvider.decorator.tsx
@@ -3,7 +3,7 @@ import { createTheme as createMuiTheme, CssBaseline } from "@mui/material";
 import { type Decorator } from "@storybook/react-vite";
 
 export enum ThemeOption {
-    Comet = "comet",
+    Dextinity = "dextinity",
     Mui = "mui",
 }
 

--- a/packages/admin/cms-admin/.storybook/preview.ts
+++ b/packages/admin/cms-admin/.storybook/preview.ts
@@ -22,7 +22,7 @@ export const globalTypes: GlobalTypes = {
             title: "Theme",
             icon: "paintbrush",
             items: [
-                { value: ThemeOption.Comet, right: "🟩", title: "Comet Theme" },
+                { value: ThemeOption.Dextinity, right: "🟩", title: "Dextinity Theme" },
                 { value: ThemeOption.Mui, right: "🟦", title: "Mui Theme" },
             ],
             dynamicTitle: true,

--- a/packages/admin/cms-admin/src/blocks/common/AdminTabsTabContent.tsx
+++ b/packages/admin/cms-admin/src/blocks/common/AdminTabsTabContent.tsx
@@ -25,7 +25,7 @@ const Content = styled("div")`
     margin-top: ${({ theme }) => theme.spacing(4)};
     margin-bottom: ${({ theme }) => theme.spacing(4)};
 
-    & > .CometAdminStackBreadcrumbs-root:first-of-type {
+    & > .DextinityAdminStackBreadcrumbs-root:first-of-type {
         margin-top: -${({ theme }) => theme.spacing(4)};
     }
 `;

--- a/packages/admin/cms-admin/src/blocks/common/BlockAdminComponentRoot.tsx
+++ b/packages/admin/cms-admin/src/blocks/common/BlockAdminComponentRoot.tsx
@@ -30,7 +30,7 @@ const BlockAdminComponentRoot = (props: PropsWithChildren<Props>) => {
 export { BlockAdminComponentRoot };
 
 const ChildrenContainer = styled("div")`
-    .CometAdminRte-root > .CometAdminRteToolbar-root {
+    .DextinityAdminRte-root > .DextinityAdminRteToolbar-root {
         top: 70px;
     }
 `;

--- a/packages/admin/cms-admin/src/blocks/table/CellValue.tsx
+++ b/packages/admin/cms-admin/src/blocks/table/CellValue.tsx
@@ -52,11 +52,11 @@ const RteContentWrapper = styled("div")(({ theme }) => ({
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(1),
 
-    ".CometAdminRteBlockElement-root:first-child, .MuiTypography-root:first-child": {
+    ".DextinityAdminRteBlockElement-root:first-child, .MuiTypography-root:first-child": {
         marginTop: 0,
     },
 
-    ".CometAdminRteBlockElement-root:last-child, .MuiTypography-root:last-child": {
+    ".DextinityAdminRteBlockElement-root:last-child, .MuiTypography-root:last-child": {
         marginBottom: 0,
     },
 }));

--- a/skills/comet-core-admin-component-authoring/SKILL.md
+++ b/skills/comet-core-admin-component-authoring/SKILL.md
@@ -64,7 +64,7 @@ Each item names a rule and why it matters; the doc has the exact syntax for each
    mismatch types that slot's `slotProps` against the wrong component.
 
 5. **Props are read through `useThemeProps`, never the raw `inProps`, with the name
-   prefixed `CometAdmin`.** This merges the theme's `defaultProps` with the passed props —
+   prefixed `DextinityAdmin`.** This merges the theme's `defaultProps` with the passed props —
    skip it and `defaultProps` customization is dead.
 
 6. **`slotProps?.<slot>` is spread into each slot, and `restProps` (carrying `sx` and
@@ -82,11 +82,11 @@ Each item names a rule and why it matters; the doc has the exact syntax for each
    icon is for. Destructure with an `Icon` suffix and a default, so the component works
    with no mapping but every icon can be replaced.
 
-10. **The component is registered in MUI's theme types** — the `CometAdmin<Name>` key added
+10. **The component is registered in MUI's theme types** — the `DextinityAdmin<Name>` key added
     to `ComponentsPropsList`, `ComponentNameToClassKey`, and `Components` (with
     `defaultProps?: Partial<...>` and `styleOverrides`). Without this, consumers get no type
     safety on their overrides.
 
-Two final checks that catch the most frequent review findings: the `CometAdmin<Name>` name
+Two final checks that catch the most frequent review findings: the `DextinityAdmin<Name>` name
 is identical in `useThemeProps` and in all three theme-type interfaces, and the package
 type-checks (`tsc`) — the theme-type augmentation is the usual failure point.

--- a/storybook/.storybook/decorators/ThemeProvider.decorator.tsx
+++ b/storybook/.storybook/decorators/ThemeProvider.decorator.tsx
@@ -3,7 +3,7 @@ import { createTheme as createMuiTheme, CssBaseline } from "@mui/material";
 import type { Decorator } from "@storybook/react-vite";
 
 export enum ThemeOption {
-    Comet = "comet",
+    Dextinity = "dextinity",
     Mui = "mui",
 }
 

--- a/storybook/.storybook/decorators/ThemeProvider.decorator.tsx
+++ b/storybook/.storybook/decorators/ThemeProvider.decorator.tsx
@@ -1,4 +1,4 @@
-import { createCometTheme, MuiThemeProvider } from "@dextinity/admin";
+import { createDextinityTheme, MuiThemeProvider } from "@dextinity/admin";
 import { createTheme as createMuiTheme, CssBaseline } from "@mui/material";
 import type { Decorator } from "@storybook/react-vite";
 
@@ -9,7 +9,7 @@ export enum ThemeOption {
 
 export const ThemeProviderDecorator: Decorator = (fn, context) => {
     const { theme: selectedTheme } = context.globals;
-    const theme = selectedTheme === ThemeOption.Mui ? createMuiTheme() : createCometTheme();
+    const theme = selectedTheme === ThemeOption.Mui ? createMuiTheme() : createDextinityTheme();
     return (
         <MuiThemeProvider theme={theme}>
             <CssBaseline />

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -21,7 +21,7 @@ export const globalTypes: GlobalTypes = {
             title: "Theme",
             icon: "paintbrush",
             items: [
-                { value: ThemeOption.Comet, right: "🟩", title: "Comet Theme" },
+                { value: ThemeOption.Dextinity, right: "🟩", title: "Dextinity Theme" },
                 { value: ThemeOption.Mui, right: "🟦", title: "Mui Theme" },
             ],
             dynamicTitle: true,

--- a/storybook/src/docs/form/Layout.mdx
+++ b/storybook/src/docs/form/Layout.mdx
@@ -75,12 +75,12 @@ If you want to use the horizontal layout on an individual [Field](?path=/docs/do
 </FieldContainer>
 ```
 
-To use the horizontal layout throughout your application, set it as the default value in your theme, on `CometAdminFormFieldContainer`.
+To use the horizontal layout throughout your application, set it as the default value in your theme, on `DextinityAdminFormFieldContainer`.
 
 ```ts
-const theme = createCometTheme({
+const theme = createDextinityTheme({
     components: {
-        CometAdminFormFieldContainer: {
+        DextinityAdminFormFieldContainer: {
             defaultProps: {
                 variant: "horizontal",
             },

--- a/storybook/src/docs/form/Layout.stories.tsx
+++ b/storybook/src/docs/form/Layout.stories.tsx
@@ -2,7 +2,7 @@ import {
     Button,
     CancelButton,
     CheckboxField,
-    createCometTheme,
+    createDextinityTheme,
     Field,
     FieldContainer,
     FinalFormInput,
@@ -277,9 +277,9 @@ export const GridLayout = {
 
 export const HorizontalFields = {
     render: () => {
-        const theme = createCometTheme({
+        const theme = createDextinityTheme({
             components: {
-                CometAdminFormFieldContainer: {
+                DextinityAdminFormFieldContainer: {
                     defaultProps: {
                         variant: "horizontal",
                     },


### PR DESCRIPTION
Rebrands the theme (`createCometTheme`, `CometAdmin*` prefixes) to Dextinity.

https://claude.ai/code/session_017Mvz58xURKTdtTV36UQdW8