### PR TITLE
docs: Add CometValidationException documentation

### DIFF
--- a/docs/docs/2-core-concepts/10-validation/index.md
+++ b/docs/docs/2-core-concepts/10-validation/index.md
@@ -52,11 +52,11 @@ The `@IsOptional()` decorator from `class-validator` allows both `undefined` and
 
 Use `@IsUndefinable()` or `@IsNullable()` to be more specific about which values are allowed:
 
-| Decorator | Allows `undefined` | Allows `null` |
-| --- | :---: | :---: |
-| `@IsOptional()` | ✅ | ✅ |
-| `@IsUndefinable()` | ✅ | ❌ |
-| `@IsNullable()` | ❌ | ✅ |
+| Decorator          | Allows `undefined` | Allows `null` |
+| ------------------ | :----------------: | :-----------: |
+| `@IsOptional()`    |         ✅         |      ✅       |
+| `@IsUndefinable()` |         ✅         |      ❌       |
+| `@IsNullable()`    |         ❌         |      ✅       |
 
 ## PartialType
 
@@ -71,3 +71,65 @@ import { CreateProductInput } from "./create-product.input";
 
 export class UpdateProductInput extends PartialType(CreateProductInput) {}
 ```
+
+## CometValidationException
+
+`CometValidationException` is the exception COMET DXP raises when validation fails. It extends `CometException`, the base class for business-logic errors that should be reported back to the client as a `400 Bad Request` rather than logged as a server error. In addition to a message, it carries the list of `ValidationError`s produced by [class-validator](https://github.com/typestack/class-validator):
+
+```ts
+class CometValidationException extends CometException {
+    constructor(
+        message: string,
+        readonly errors?: ValidationError[],
+    );
+}
+```
+
+### Automatic validation errors
+
+DTO validation failures are turned into a `CometValidationException` by `ValidationExceptionFactory`. Wire it up as the `exceptionFactory` of a NestJS `ValidationPipe` so that every rejected DTO produces a `CometValidationException` instead of the default `BadRequestException`:
+
+```ts
+// main.ts
+import { ExceptionFilter, ValidationExceptionFactory } from "@comet/cms-api";
+import { ValidationPipe } from "@nestjs/common";
+
+app.useGlobalFilters(new ExceptionFilter(config.debug));
+app.useGlobalPipes(
+    new ValidationPipe({
+        exceptionFactory: ValidationExceptionFactory,
+        transform: true,
+        forbidNonWhitelisted: true,
+        whitelist: true,
+    }),
+);
+```
+
+For dynamically typed args (for example a scope or an input whose type is only known at runtime), use `DynamicDtoValidationPipe` from `@comet/cms-api`, which is a `ValidationPipe` preconfigured with `ValidationExceptionFactory`.
+
+### Throwing it manually
+
+Throw a `CometValidationException` from a resolver or service for validation rules that can't be expressed with decorators — for example a uniqueness check that requires a database lookup:
+
+```ts
+import { CometValidationException } from "@comet/cms-api";
+
+if (!(await this.redirectService.isRedirectSourceAvailable(input.source, scope))) {
+    throw new CometValidationException("Validation failed");
+}
+```
+
+### Error response
+
+The `ExceptionFilter` catches every `CometException` and converts it into a `400 Bad Request`. For a `CometValidationException`, the collected `ValidationError`s are exposed under `validationErrors`:
+
+```json
+{
+    "statusCode": 400,
+    "message": "Validation failed",
+    "error": "CometValidationException",
+    "validationErrors": [{ "property": "source" }]
+}
+```
+
+The same shape is returned for both GraphQL and REST requests. Register the `ExceptionFilter` globally (see the `main.ts` example above) so these exceptions are translated consistently across the API.


### PR DESCRIPTION
## Summary
Added comprehensive documentation for `CometValidationException` to the validation guide, including usage patterns, configuration examples, and error response formats.

## Changes
- **Table formatting**: Improved markdown table alignment for better readability in the decorator comparison table
- **New section**: Added "CometValidationException" documentation covering:
  - Class definition and inheritance from `CometException`
  - Automatic validation error handling via `ValidationExceptionFactory` and `ValidationPipe` configuration
  - `DynamicDtoValidationPipe` for dynamically typed arguments
  - Manual exception throwing for custom validation rules (e.g., database uniqueness checks)
  - Error response format with `validationErrors` field for both GraphQL and REST APIs
  - Example code snippets for `main.ts` setup and resolver usage

## Details
The documentation explains how validation failures are automatically converted to `CometValidationException` instances and how developers can throw these exceptions manually for validation rules that cannot be expressed with decorators. It also clarifies the consistent error response format across GraphQL and REST endpoints when using the `ExceptionFilter`.

https://claude.ai/code/session_01WQBAUJ5vGmef58dspRSAVD