### PR TITLE
mail-react: Render rich-text lists as a table

### DIFF
--- a/.changeset/render-rich-text-lists-as-a-table.md
+++ b/.changeset/render-rich-text-lists-as-a-table.md
@@ -1,0 +1,8 @@
+---
+"@comet/mail-react": patch
+---
+
+Fix inconsistent spacing of rich-text lists across email clients by rendering each list as a table instead of `<ul>` / `<ol>`
+
+- `richTextBlock__listItem` is now a `<tr>` instead of an `<li>`, so margin and padding set on it no longer apply. Every row but the last carries `richTextBlock__listItem--itemSpacing`, with the spacing on its cells.
+- List cells restate the text styles inline, so a rule targeting list text needs `!important`. The cells carry `richTextBlock__listItemMarker` and `richTextBlock__listItemText`, and the table carries a modifier naming its text variant, such as `richTextBlock__list--variantBody`.

--- a/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
@@ -111,7 +111,7 @@ The `blockTypes` option maps the application's draft block types to the styling 
 
 The factory works without any configuration: `createRichTextBlock()` renders every draft block with the base `theme.text` styles, as do block types missing from `blockTypes`. This makes the block usable before any text variants exist in the theme.
 
-Style values in `blockTypes` don't support responsive values — define a theme variant for responsive styling, or set a `className` and register responsive CSS via `registerStyles`.
+Style values in `blockTypes` don't support responsive values — define a theme variant for responsive styling, or set a `className` and register responsive CSS via `registerStyles`. For a list block type, such a rule has to target `.<className> .richTextBlock__listItemText`, because the list's cells carry their own font styles.
 
 ### Link types
 
@@ -182,7 +182,7 @@ export const {
 ### Rendering behavior
 
 - Each draft block renders as its own text component; spacing between blocks comes from the theme's `bottomSpacing`, and the last block gets none.
-- List items render flat as `<ul>` / `<ol>` inside one text component per list; nesting by draft depth isn't supported.
+- Each list renders as a table inside one text component, with a row per item, a marker cell and a text cell — the indent and the marker gap are cell padding, which is the only spacing Outlook on Windows applies reliably. List items render flat; nesting by draft depth isn't supported.
 - Headings are styled text, not semantic `<h1>` elements, matching the text components' design.
 - Empty draft blocks are skipped; when the data contains no text at all, the block renders nothing.
-- Rendered elements carry `richTextBlock__text`, `richTextBlock__list`, `richTextBlock__listItem`, and `richTextBlock__link` class names for targeting with [registerStyles](./2-components-and-theme.md).
+- Rendered elements carry `richTextBlock__text`, `richTextBlock__list`, `richTextBlock__listItem`, `richTextBlock__listItemMarker`, `richTextBlock__listItemText`, and `richTextBlock__link` class names for targeting with [registerStyles](./2-components-and-theme.md). The list table also carries a modifier naming the text variant its items render with, such as `richTextBlock__list--variantBody`, and its rows carry `richTextBlock__listItem--itemSpacing`, or `richTextBlock__listItem--blockSpacing` on the last row when spacing follows the list. Its cells restate the text styles inline, so a rule targeting list text needs `!important`.

--- a/packages/mail-react/src/blocks/richText/RichTextList.tsx
+++ b/packages/mail-react/src/blocks/richText/RichTextList.tsx
@@ -1,0 +1,114 @@
+import clsx from "clsx";
+import type { CSSProperties, ReactNode } from "react";
+
+import { useOutlookTextStyle } from "../../components/text/OutlookTextStyleContext.js";
+import { generateResponsiveTextCss } from "../../components/text/textStyles.js";
+import { registerStyles } from "../../styles/registerStyles.js";
+import { getDefaultOrUndefined } from "../../theme/responsiveValue.js";
+import { useOptionalTheme } from "../../theme/ThemeProvider.js";
+import type { TextVariantStyles, Theme, ThemeText, VariantName } from "../../theme/themeTypes.js";
+
+const listIndent = 8;
+const markerGap = 12;
+const itemSpacing = 8;
+
+const unorderedMarker = "•";
+
+// Variant names come from the consumer, so the `variant` prefix keeps them apart from the package's own modifiers.
+function variantModifier(variantName: string): string {
+    return `richTextBlock__list--variant${variantName.charAt(0).toUpperCase()}${variantName.slice(1)}`;
+}
+
+interface RichTextListItem {
+    key: string;
+    content: ReactNode;
+}
+
+interface RichTextListProps {
+    ordered?: boolean;
+    variant?: VariantName;
+    /** When true, the variant's spacing below the block applies below the last item. */
+    bottomSpacing?: boolean;
+    items: RichTextListItem[];
+}
+
+/** Renders one draft-js list as a table, because cell padding is the only list indent Outlook applies reliably. */
+export function RichTextList({ ordered, variant, bottomSpacing, items }: RichTextListProps): ReactNode {
+    const theme = useOptionalTheme();
+    const outlookTextStyle = useOutlookTextStyle();
+
+    const themeText: ThemeText = theme?.text ?? {};
+    const { defaultVariant, variants, ...baseTextStyles } = themeText;
+    const activeVariant = variant ?? defaultVariant;
+    const variantStyles = activeVariant ? variants?.[activeVariant] : undefined;
+    const mergedStyles: TextVariantStyles = { ...baseTextStyles, ...variantStyles };
+
+    // The HTML parser can move a raw-HTML block's text element out of the table, so spacing set
+    // there would not apply to the list. The last row carries it instead.
+    const blockSpacing = bottomSpacing ? getDefaultOrUndefined(mergedStyles.bottomSpacing) : undefined;
+
+    // The cells cannot inherit the text styles: once the parser has moved the text element away,
+    // the nearest ancestor with a font size is MJML's column, whose font size is zero.
+    const fontStyle: CSSProperties = {
+        ...outlookTextStyle,
+        ...(outlookTextStyle?.lineHeight !== undefined && { msoLineHeightRule: "exactly" }),
+    };
+
+    return (
+        <table
+            role="presentation"
+            cellPadding={0}
+            cellSpacing={0}
+            border={0}
+            width="100%"
+            className={clsx("richTextBlock__list", activeVariant && variantModifier(activeVariant))}
+            style={{ borderCollapse: "collapse" }}
+        >
+            <tbody>
+                {items.map((item, index) => {
+                    const isLastItem = index === items.length - 1;
+                    const spacingBelow = isLastItem ? blockSpacing : itemSpacing;
+                    const cellStyle: CSSProperties = { ...fontStyle, ...(spacingBelow !== undefined && { paddingBottom: spacingBelow }) };
+
+                    return (
+                        <tr
+                            key={item.key}
+                            className={clsx(
+                                "richTextBlock__listItem",
+                                !isLastItem && "richTextBlock__listItem--itemSpacing",
+                                isLastItem && blockSpacing !== undefined && "richTextBlock__listItem--blockSpacing",
+                            )}
+                        >
+                            <td
+                                className="richTextBlock__listItemMarker"
+                                align={ordered ? "right" : "left"}
+                                valign="top"
+                                style={{
+                                    ...cellStyle,
+                                    paddingLeft: listIndent,
+                                    paddingRight: markerGap,
+                                    whiteSpace: "nowrap", // The full-width text cell squeezes this column, so markers such as `10.` must stay on one line.
+                                }}
+                            >
+                                {ordered ? `${index + 1}.` : unorderedMarker}
+                            </td>
+                            <td className="richTextBlock__listItemText" width="100%" valign="top" style={cellStyle}>
+                                {item.content}
+                            </td>
+                        </tr>
+                    );
+                })}
+            </tbody>
+        </table>
+    );
+}
+
+export function generateRichTextListStyles(theme: Theme): string {
+    return generateResponsiveTextCss(theme, {
+        styleSelector: (variantName) =>
+            `.${variantModifier(variantName)} .richTextBlock__listItemMarker, .${variantModifier(variantName)} .richTextBlock__listItemText`,
+        spacingSelector: (variantName) => `.${variantModifier(variantName)} .richTextBlock__listItem--blockSpacing > td`,
+    });
+}
+
+registerStyles(generateRichTextListStyles);

--- a/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { MjmlSection } from "../../../components/section/MjmlSection.js";
 import { createTheme } from "../../../theme/createTheme.js";
 import { createRichTextBlock } from "../createRichTextBlock.js";
-import { exampleBlockData, headlinesOnlyBlockData, highlightBlockData } from "./exampleBlockData.js";
+import { exampleBlockData, headlinesOnlyBlockData, highlightBlockData, listVarietyBlockData } from "./exampleBlockData.js";
 
 const { HtmlRichTextBlock } = createRichTextBlock();
 
@@ -34,6 +34,31 @@ export const Default: Story = {
             <MjmlColumn>
                 <MjmlRaw>
                     <HtmlRichTextBlock data={exampleBlockData} />
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+const listVarietyTheme = createTheme({
+    text: {
+        defaultVariant: "body",
+        variants: {
+            body: { fontSize: { default: "16px", mobile: "14px" }, lineHeight: { default: "24px", mobile: "20px" }, bottomSpacing: "16px" },
+        },
+    },
+});
+
+/** Lists render as a table, not as `<ul>` / `<ol>`, so their spacing is consistent across email clients. */
+export const ListVariety: Story = {
+    parameters: {
+        theme: listVarietyTheme,
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <HtmlRichTextBlock data={listVarietyBlockData} />
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>

--- a/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { MjmlSection } from "../../../components/section/MjmlSection.js";
 import { createTheme } from "../../../theme/createTheme.js";
 import { createRichTextBlock } from "../createRichTextBlock.js";
-import { exampleBlockData, headlinesOnlyBlockData, highlightBlockData } from "./exampleBlockData.js";
+import { exampleBlockData, headlinesOnlyBlockData, highlightBlockData, listVarietyBlockData } from "./exampleBlockData.js";
 
 const { MjmlRichTextBlock } = createRichTextBlock();
 
@@ -67,6 +67,29 @@ export const WithVariants: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlVariantsRichTextBlock data={exampleBlockData} />
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+const listVarietyTheme = createTheme({
+    text: {
+        defaultVariant: "body",
+        variants: {
+            body: { fontSize: { default: "16px", mobile: "14px" }, lineHeight: { default: "24px", mobile: "20px" }, bottomSpacing: "16px" },
+        },
+    },
+});
+
+/** Lists render as a table, not as `<ul>` / `<ol>`, so their spacing is consistent across email clients. */
+export const ListVariety: Story = {
+    parameters: {
+        theme: listVarietyTheme,
+    },
+    render: () => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRichTextBlock data={listVarietyBlockData} />
             </MjmlColumn>
         </MjmlSection>
     ),

--- a/packages/mail-react/src/blocks/richText/__stories__/exampleBlockData.ts
+++ b/packages/mail-react/src/blocks/richText/__stories__/exampleBlockData.ts
@@ -159,6 +159,116 @@ export const highlightBlockData: RichTextBlockData = {
     },
 };
 
+const orderedItemsPastTen = [
+    "Ordered item one",
+    "Ordered item two",
+    "Ordered item three",
+    "Ordered item four",
+    "Ordered item five",
+    "Ordered item six",
+    "Ordered item seven",
+    "Ordered item eight",
+    "Ordered item nine",
+    "Ordered item ten — the marker column widens here, and every item's text keeps the same left edge",
+    "Ordered item eleven",
+].map((text, index) => ({
+    key: `ov${String(index)}`,
+    text,
+    type: "ordered-list-item",
+    depth: 0,
+    inlineStyleRanges: [],
+    entityRanges: [],
+    data: {},
+}));
+
+export const listVarietyBlockData: RichTextBlockData = {
+    draftContent: {
+        blocks: [
+            {
+                key: "lv1",
+                text: "A paragraph above the first list, so the list has a block before it.",
+                type: "paragraph-standard",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "lv2",
+                text: "Short item",
+                type: "unordered-list-item",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "lv3",
+                text: "A long item that keeps going for long enough to wrap onto a second line, which is the only way to see whether the marker stays level with the item's first line.",
+                type: "unordered-list-item",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "lv4",
+                text: "This item is long enough to wrap onto a second line in the email body, then it breaks the line here\nand ends with a link that follows the break.",
+                type: "unordered-list-item",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [{ offset: 114, length: 6, key: 0 }],
+                data: {},
+            },
+            ...orderedItemsPastTen,
+            {
+                key: "lv8",
+                text: "A paragraph between the lists, so the lists above sit in the middle of the document.",
+                type: "paragraph-standard",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "lv9",
+                text: "A final list, first item",
+                type: "unordered-list-item",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+            {
+                key: "lv10",
+                text: "A final list, last item — the document ends here",
+                type: "unordered-list-item",
+                depth: 0,
+                inlineStyleRanges: [],
+                entityRanges: [],
+                data: {},
+            },
+        ],
+        entityMap: {
+            "0": {
+                type: "LINK",
+                mutability: "MUTABLE",
+                data: {
+                    attachedBlocks: [],
+                    block: {
+                        type: "external",
+                        props: {
+                            targetUrl: "https://example.com",
+                            openInNewWindow: false,
+                        },
+                    },
+                    activeType: "external",
+                },
+            },
+        },
+    },
+};
+
 export const headlinesOnlyBlockData: RichTextBlockData = {
     draftContent: {
         blocks: [

--- a/packages/mail-react/src/blocks/richText/__tests__/createRichTextBlock.test.tsx
+++ b/packages/mail-react/src/blocks/richText/__tests__/createRichTextBlock.test.tsx
@@ -303,26 +303,89 @@ describe("createRichTextBlock — links", () => {
 describe("createRichTextBlock — lists", () => {
     const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock();
 
-    it("groups consecutive unordered list items into one list within one text component", () => {
-        const data = createBlockData([
-            createDraftBlock({ key: "a", text: "Item one", type: "unordered-list-item" }),
-            createDraftBlock({ key: "b", text: "Item two", type: "unordered-list-item" }),
-        ]);
+    function createListBlocks(type: "unordered-list-item" | "ordered-list-item", texts: string[]) {
+        return texts.map((text, index) => createDraftBlock({ key: `${type}-${String(index)}`, text, type }));
+    }
+
+    it("renders consecutive items as one table, one row per item", () => {
+        const data = createBlockData(createListBlocks("unordered-list-item", ["Item one", "Item two"]));
         const markup = renderWithTheme(<MjmlRichTextBlock data={data} />);
 
         expect(markup.match(/<mj-text/g)).toHaveLength(1);
-        expect(markup.match(/<ul/g)).toHaveLength(1);
-        expect(markup.match(/<li/g)).toHaveLength(2);
+        expect(markup.match(/<tr/g)).toHaveLength(2);
+        expect(markup.match(/richTextBlock__listItemMarker/g)).toHaveLength(2);
+        expect(markup.match(/richTextBlock__listItemText/g)).toHaveLength(2);
     });
 
-    it("renders ordered list items as an ol with element class names", () => {
+    it("spaces the items through their rows, and puts the block's bottom spacing below the last one", () => {
         const data = createBlockData([
-            createDraftBlock({ key: "a", text: "Item one", type: "ordered-list-item" }),
-            createDraftBlock({ key: "b", text: "Item two", type: "ordered-list-item" }),
+            ...createListBlocks("unordered-list-item", ["Item one", "Item two", "Item three"]),
+            createDraftBlock({ key: "p", text: "A closing paragraph" }),
+        ]);
+        const rows = renderWithTheme(<HtmlRichTextBlock data={data} />).split("<tr");
+
+        expect(rows[1]).toContain("richTextBlock__listItem--itemSpacing");
+        expect(rows[1]).toMatch(/padding-bottom:\d+px/);
+        expect(rows[3]).not.toContain("richTextBlock__listItem--itemSpacing");
+        expect(rows[3]).toContain("richTextBlock__listItem--blockSpacing");
+        expect(rows[3]).toMatch(/padding-bottom:\d+px/);
+        expect(rows[0]).not.toContain("htmlText--bottomSpacing");
+    });
+
+    it("keeps an item's inline markup inside its text cell", () => {
+        const data = createBlockData(
+            [
+                createDraftBlock({
+                    key: "a",
+                    text: "line one\nour website",
+                    type: "unordered-list-item",
+                    entityRanges: [{ offset: 9, length: 11, key: 0 }],
+                }),
+            ],
+            { "0": { type: "LINK", mutability: "MUTABLE", data: { block: { type: "external", props: { targetUrl: "https://example.com" } } } } },
+        );
+        const markup = renderWithTheme(<HtmlRichTextBlock data={data} />);
+        const textCell = /<td[^>]*richTextBlock__listItemText[^>]*>.*?<\/td>/s.exec(markup)?.[0];
+
+        expect(textCell).toContain("line one<br/>");
+        expect(textCell).toContain('href="https://example.com"');
+    });
+
+    it("numbers ordered items, restarting after an interrupting paragraph", () => {
+        const data = createBlockData([
+            ...createListBlocks("ordered-list-item", ["First list, item one", "First list, item two"]),
+            createDraftBlock({ key: "p", text: "An interrupting paragraph" }),
+            createDraftBlock({ key: "second", text: "Second list, item one", type: "ordered-list-item" }),
         ]);
         const markup = renderWithTheme(<HtmlRichTextBlock data={data} />);
 
-        expect(markup.match(/<ol class="richTextBlock__list"/g)).toHaveLength(1);
-        expect(markup.match(/<li class="richTextBlock__listItem"/g)).toHaveLength(2);
+        expect(markup.match(/>1\.</g)).toHaveLength(2);
+        expect(markup.match(/>2\.</g)).toHaveLength(1);
+    });
+
+    // Both cells need the styles because the nearest ancestor with a font size can be MJML's column, at zero.
+    it("copies the surrounding text styles onto both cells of an item", () => {
+        const data = createBlockData(createListBlocks("unordered-list-item", ["Item one"]));
+        const markup = renderWithTheme(<MjmlRichTextBlock data={data} />);
+
+        expect(markup.match(/font-family:/g)).toHaveLength(2);
+        expect(markup).toContain("mso-line-height-rule:exactly");
+    });
+
+    it("renders the items unstyled when no theme is set", () => {
+        const data = createBlockData(createListBlocks("unordered-list-item", ["Item one"]));
+        const markup = renderToStaticMarkup(<MjmlRichTextBlock data={data} />);
+
+        expect(markup).toContain("Item one");
+        expect(markup).not.toContain("font-family");
+    });
+
+    it("adds the variant modifier for the variant its items render with", () => {
+        const { HtmlRichTextBlock: HtmlVariantRichTextBlock } = createRichTextBlock({ blockTypes: { "unordered-list-item": { variant: "body" } } });
+        const themeWithDefaultVariant = createTheme({ text: { defaultVariant: "body", variants: { body: { fontSize: "16px" } } } });
+        const data = createBlockData(createListBlocks("unordered-list-item", ["Item one"]));
+
+        expect(renderWithTheme(<HtmlVariantRichTextBlock data={data} />, themeWithVariants)).toContain("richTextBlock__list--variantBody");
+        expect(renderWithTheme(<HtmlRichTextBlock data={data} />, themeWithDefaultVariant)).toContain("richTextBlock__list--variantBody");
     });
 });

--- a/packages/mail-react/src/blocks/richText/__tests__/richTextListStyles.test.ts
+++ b/packages/mail-react/src/blocks/richText/__tests__/richTextListStyles.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { createTheme } from "../../../theme/createTheme.js";
+import { generateRichTextListStyles } from "../RichTextList.js";
+
+describe("generateRichTextListStyles", () => {
+    it("restates a variant's breakpoint overrides on both cells, and its bottom spacing on the last row", () => {
+        const theme = createTheme({
+            text: {
+                variants: { body: { fontSize: { default: "16px", mobile: "14px" }, bottomSpacing: { default: "16px", mobile: "12px" } } },
+            },
+        });
+        const styles = generateRichTextListStyles(theme);
+
+        expect(styles).toContain(".richTextBlock__list--variantBody .richTextBlock__listItemMarker");
+        expect(styles).toContain(".richTextBlock__list--variantBody .richTextBlock__listItemText");
+        expect(styles).toContain("font-size: 14px !important");
+        expect(styles).toContain(".richTextBlock__list--variantBody .richTextBlock__listItem--blockSpacing > td");
+        expect(styles).toContain("padding-bottom: 12px !important");
+    });
+});

--- a/packages/mail-react/src/blocks/richText/createRichTextRenderers.tsx
+++ b/packages/mail-react/src/blocks/richText/createRichTextRenderers.tsx
@@ -3,6 +3,7 @@ import type { Renderers, TextBlockRenderFn } from "redraft";
 
 import { HtmlInlineLink } from "../../components/inlineLink/HtmlInlineLink.js";
 import type { RichTextBlockTypeProps, RichTextInlineRenderer, RichTextLinkHrefResolver } from "./common.js";
+import { RichTextList } from "./RichTextList.js";
 
 export type BlockTextProps = PropsWithChildren<
     RichTextBlockTypeProps & {
@@ -88,21 +89,23 @@ function createTextBlockRenderFn({ blockTextComponent: BlockText, blockTypeProps
 }
 
 function createListBlockRenderFn({
-    listElement: ListElement,
+    ordered,
     blockTextComponent: BlockText,
     blockTypeProps,
     lastBlockKey,
-}: CreateBlockRenderFnOptions & { listElement: "ul" | "ol" }): TextBlockRenderFn {
+}: CreateBlockRenderFnOptions & { ordered: boolean }): TextBlockRenderFn {
     return (children, { keys }) => (
-        <BlockText key={keys.join("-")} bottomSpacing={!keys.includes(lastBlockKey)} {...blockTypeProps}>
-            {/* Vertical margins are removed so the spacing between blocks comes from the theme's bottomSpacing alone. */}
-            <ListElement className="richTextBlock__list" style={{ marginTop: 0, marginBottom: 0 }}>
-                {children.map((child, index) => (
-                    <li key={keys[index]} className="richTextBlock__listItem">
-                        {renderWithLineBreaks(child)}
-                    </li>
-                ))}
-            </ListElement>
+        <BlockText
+            key={keys.join("-")}
+            bottomSpacing={false} // The list holds this space itself — applying it here too would double it.
+            {...blockTypeProps}
+        >
+            <RichTextList
+                ordered={ordered}
+                variant={blockTypeProps.variant}
+                bottomSpacing={!keys.includes(lastBlockKey)}
+                items={children.map((child, index) => ({ key: keys[index], content: renderWithLineBreaks(child) }))}
+            />
         </BlockText>
     );
 }
@@ -137,7 +140,7 @@ export function createRichTextRenderers({
 
     for (const listBlockType of listBlockTypes) {
         blocks[listBlockType] = createListBlockRenderFn({
-            listElement: listBlockType === "unordered-list-item" ? "ul" : "ol",
+            ordered: listBlockType === "ordered-list-item",
             blockTextComponent,
             blockTypeProps: blockTypes[listBlockType] ?? {},
             lastBlockKey,

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -410,6 +410,8 @@ Key behaviors:
     );
     ```
 
+    For a list block type, target `.<className> .richTextBlock__listItemText` instead of `> div` — the list's cells carry their own font styles, which outrank a rule on the block's element.
+
 - **Multiple configurations per app.** Each factory call is independent — rename the destructured components per use case:
 
     ```tsx
@@ -444,9 +446,9 @@ Key behaviors:
     });
     ```
 
-- **Lists** render flat (`<ul>` / `<ol>` inside one text component per list); nesting by draft depth isn't supported.
+- **Lists** render as a table inside one text component, with a row per item, a marker cell and a text cell — the indent and the marker gap are cell padding, which is the only spacing Outlook on Windows applies reliably. Items render flat; nesting by draft depth isn't supported.
 - Spacing between blocks comes from the theme's `bottomSpacing` (the last block gets none); headings are styled text, not semantic `<h1>` elements.
-- Rendered elements carry `richTextBlock__text`, `richTextBlock__list`, `richTextBlock__listItem`, and `richTextBlock__link` class names for targeting with `registerStyles`.
+- Rendered elements carry `richTextBlock__text`, `richTextBlock__list`, `richTextBlock__listItem`, `richTextBlock__listItemMarker`, `richTextBlock__listItemText`, and `richTextBlock__link` class names for targeting with `registerStyles`. The list table also carries a modifier naming the text variant its items render with, such as `richTextBlock__list--variantBody`, and its rows carry `richTextBlock__listItem--itemSpacing`, or `richTextBlock__listItem--blockSpacing` on the last row when spacing follows the list. Its cells restate the text styles inline, so a rule targeting list text needs `!important`.
 
 ---
 


### PR DESCRIPTION
Lists took whatever indentation the email client applied, and neither that indent nor the gap after the marker can be set reliably on a list element.
Table cell padding holds across clients.

- **List cells set their own font styles instead of inheriting them.**
  The nearest ancestor with a font size can be MJML's column wrapper, which sets it to zero.
- **The distances are constants, not theme tokens.**
  A follow-up pull request will implement theme support.
- **This stays a patch, accepting that CSS written against the old list markup breaks.**
  Currently we rarely or never use rich-text lists in mails, so such rules are unlikely to exist.

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13349