### PR TITLE
mail-react: Fix inline links rendering blue in Outlook on Windows

### DIFF
--- a/.changeset/fix-outlook-inline-link-color.md
+++ b/.changeset/fix-outlook-inline-link-color.md
@@ -1,0 +1,9 @@
+---
+"@comet/mail-react": patch
+---
+
+Fix inline links losing their color in Outlook on Windows
+
+`HtmlInlineLink` rendered blue in Outlook on Windows instead of matching the text around it, unless the theme set a base text color. The base text theme now defines one, so links match without any configuration.
+
+As a result, a text color set through the `MjmlMailRoot` `attributes` slot no longer applies — set it on `theme.text` or on a text variant instead.

--- a/packages/mail-react/src/components/inlineLink/__tests__/HtmlInlineLink.test.tsx
+++ b/packages/mail-react/src/components/inlineLink/__tests__/HtmlInlineLink.test.tsx
@@ -1,0 +1,65 @@
+import { MjmlColumn } from "@faire/mjml-react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { renderMailHtml } from "../../../server/renderMailHtml.js";
+import { createTheme } from "../../../theme/createTheme.js";
+import { ThemeProvider } from "../../../theme/ThemeProvider.js";
+import { MjmlMailRoot } from "../../mailRoot/MjmlMailRoot.js";
+import { MjmlSection } from "../../section/MjmlSection.js";
+import { HtmlText } from "../../text/HtmlText.js";
+import { MjmlText } from "../../text/MjmlText.js";
+import { HtmlInlineLink } from "../HtmlInlineLink.js";
+
+function getInlineLinkColor(html: string): string | undefined {
+    const style = /<a[^>]*\sstyle="([^"]*)"/.exec(html)?.[1];
+
+    if (style === undefined) {
+        throw new Error(`Rendered markup contains no styled anchor: ${html}`);
+    }
+
+    const colorDeclaration = style
+        .split(";")
+        .map((declaration) => declaration.trim())
+        .find((declaration) => declaration.startsWith("color:"));
+
+    return colorDeclaration?.slice("color:".length).trim();
+}
+
+// Outlook's Word renderer discards `inherit`, so a theme that sets no color of its own must still
+// leave the anchor with a color that renderer can resolve.
+describe("HtmlInlineLink", () => {
+    it("writes a resolvable color inside HtmlText", () => {
+        const html = renderToStaticMarkup(
+            <ThemeProvider theme={createTheme()}>
+                <HtmlText element="div">
+                    Visit <HtmlInlineLink href="https://example.com">our website</HtmlInlineLink>
+                </HtmlText>
+            </ThemeProvider>,
+        );
+
+        const color = getInlineLinkColor(html);
+
+        expect(color).toBeDefined();
+        expect(color).not.toBe("inherit");
+    });
+
+    it("writes a resolvable color inside MjmlText", () => {
+        const { html } = renderMailHtml(
+            <MjmlMailRoot theme={createTheme()}>
+                <MjmlSection>
+                    <MjmlColumn>
+                        <MjmlText>
+                            Visit <HtmlInlineLink href="https://example.com">our website</HtmlInlineLink>
+                        </MjmlText>
+                    </MjmlColumn>
+                </MjmlSection>
+            </MjmlMailRoot>,
+        );
+
+        const color = getInlineLinkColor(html);
+
+        expect(color).toBeDefined();
+        expect(color).not.toBe("inherit");
+    });
+});

--- a/packages/mail-react/src/theme/defaultTheme.ts
+++ b/packages/mail-react/src/theme/defaultTheme.ts
@@ -17,6 +17,7 @@ export const defaultTheme: Theme = {
         fontSize: "16px",
         lineHeight: "20px",
         bottomSpacing: "16px",
+        color: "#000000",
     },
     divider: defaultDividerStyles,
     button: defaultButtonStyles,


### PR DESCRIPTION
An inline link falls back to `inherit` when the theme has no color to publish, and Word-based Outlook discards that keyword, leaving its own blue hyperlink style in place. The base text theme defined no color, so that was the default rendering.

- **Text color set through the mail root's `attributes` slot stops applying.**
  An explicit MJML attribute outranks that slot, and font family, size and line height already behaved this way; keeping the slot usable for color alone would let a link's color drift from its surrounding text.