### PR TITLE
Rebrand CSS variables to Dextinity

### DIFF
--- a/packages/admin/admin-rte/src/core/Controls/Toolbar/Toolbar.styles.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/Toolbar/Toolbar.styles.tsx
@@ -15,7 +15,7 @@ export const Root = createComponentSlot("div")<RteToolbarClassKey>({
         z-index: 2;
         display: flex;
         flex-wrap: wrap;
-        border-top: 1px solid var(--comet-admin-rte-outer-border-color);
+        border-top: 1px solid var(--dextinity-admin-rte-outer-border-color);
         background-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors?.toolbarBackground};
         padding-left: 6px;
         padding-right: 6px;

--- a/packages/admin/admin-rte/src/core/Rte.tsx
+++ b/packages/admin/admin-rte/src/core/Rte.tsx
@@ -348,18 +348,18 @@ const Root = createComponentSlot("div")<RteClassKey, OwnerState>({
     },
 })(
     ({ theme }) => css`
-        --comet-admin-rte-outer-border-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors.border};
-        border: 1px solid var(--comet-admin-rte-outer-border-color);
+        --dextinity-admin-rte-outer-border-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors.border};
+        border: 1px solid var(--dextinity-admin-rte-outer-border-color);
         border-top-width: 0; // To prevent the top border from being hidden, when to toolbar is sticky, the top border must be handled by the Toolbar itself
         background-color: #fff;
         border-radius: 2px;
 
         &:hover {
-            --comet-admin-rte-outer-border-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors.outerBorderOnHover};
+            --dextinity-admin-rte-outer-border-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors.outerBorderOnHover};
         }
 
         &:focus-within {
-            --comet-admin-rte-outer-border-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors.outerBorderOnFocus};
+            --dextinity-admin-rte-outer-border-color: ${getRteTheme(theme.components?.DextinityAdminRte?.defaultProps).colors.outerBorderOnFocus};
         }
     `,
 );

--- a/packages/admin/admin/src/common/Loading.tsx
+++ b/packages/admin/admin/src/common/Loading.tsx
@@ -12,7 +12,7 @@ export const Loading = ({ behavior = "auto", fontSize, sx, ...svgIconsProps }: L
     const offsetTop = rootRef.current?.offsetTop || 0;
 
     return (
-        <Root ref={rootRef} style={{ "--comet-admin-loading-offset-top": `${offsetTop}px` } as CSSProperties} behavior={behavior}>
+        <Root ref={rootRef} style={{ "--dextinity-admin-loading-offset-top": `${offsetTop}px` } as CSSProperties} behavior={behavior}>
             <LoadingContainer behavior={behavior}>
                 <BallTriangle sx={{ fontSize: fontSize ?? 40, ...sx }} {...svgIconsProps} />
             </LoadingContainer>
@@ -40,7 +40,7 @@ const Root = styled("div")<Required<Pick<LoadingProps, "behavior">>>`
 
         if (behavior === "fillPageHeight") {
             return css`
-                height: calc(100vh - var(--comet-admin-loading-offset-top));
+                height: calc(100vh - var(--dextinity-admin-loading-offset-top));
             `;
         }
     }}

--- a/packages/admin/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/admin/src/form/FieldContainer.tsx
@@ -86,7 +86,7 @@ const Root = createComponentSlot(FormControl)<FieldContainerClassKey, OwnerState
         ownerState.variant === "horizontal" &&
         css`
             container-type: inline-size;
-            container-name: comet-admin-field-container-root;
+            container-name: dextinity-admin-field-container-root;
         `}
 
         ${ownerState.fieldMargin !== "never" &&
@@ -119,7 +119,7 @@ const InnerContainer = createComponentSlot("div")<FieldContainerClassKey, OwnerS
     ({ theme, ownerState }) => css`
         ${ownerState.variant === "horizontal" &&
         css`
-            @container comet-admin-field-container-root (min-width: ${ownerState.forceVerticalContainerSize}px) {
+            @container dextinity-admin-field-container-root (min-width: ${ownerState.forceVerticalContainerSize}px) {
                 display: flex;
                 flex-direction: row;
                 max-width: 944px;
@@ -139,7 +139,7 @@ const InnerContainer = createComponentSlot("div")<FieldContainerClassKey, OwnerS
 
             .DextinityAdminRte-root:not(:focus-within),
             .DextinityAdminRte-root:hover:not(:focus-within) {
-                --comet-admin-rte-outer-border-color: ${theme.palette.error.main};
+                --dextinity-admin-rte-outer-border-color: ${theme.palette.error.main};
             }
         `}
 
@@ -155,7 +155,7 @@ const InnerContainer = createComponentSlot("div")<FieldContainerClassKey, OwnerS
 
             .DextinityAdminRte-root:not(:focus-within),
             .DextinityAdminRte-root:hover:not(:focus-within) {
-                --comet-admin-rte-outer-border-color: ${theme.palette.warning.main};
+                --dextinity-admin-rte-outer-border-color: ${theme.palette.warning.main};
             }
         `}
     `,
@@ -172,7 +172,7 @@ const Label = createComponentSlot(FormLabel)<FieldContainerClassKey, OwnerState>
 
             ${ownerState.variant === "horizontal" &&
             css`
-                @container comet-admin-field-container-root (min-width: ${ownerState.forceVerticalContainerSize}px) {
+                @container dextinity-admin-field-container-root (min-width: ${ownerState.forceVerticalContainerSize}px) {
                     display: block;
                 }
             `}
@@ -180,7 +180,7 @@ const Label = createComponentSlot(FormLabel)<FieldContainerClassKey, OwnerState>
 
         ${ownerState.variant === "horizontal" &&
         css`
-            @container comet-admin-field-container-root (min-width: ${ownerState.forceVerticalContainerSize}px) {
+            @container dextinity-admin-field-container-root (min-width: ${ownerState.forceVerticalContainerSize}px) {
                 width: calc(100% / 3);
                 flex-shrink: 0;
                 flex-grow: 0;
@@ -213,7 +213,7 @@ const InputContainer = createComponentSlot("div")<FieldContainerClassKey, OwnerS
         ${ownerState.variant === "horizontal" &&
         ownerState.fullWidth &&
         css`
-            @container comet-admin-field-container-root (min-width: ${ownerState.forceVerticalContainerSize}px) {
+            @container dextinity-admin-field-container-root (min-width: ${ownerState.forceVerticalContainerSize}px) {
                 flex-grow: 1;
                 /* Overrides the flex default (min-width: auto), which would prevent the item from shrinking below its content width and cause layout overflow. */
                 min-width: 0;
@@ -222,7 +222,7 @@ const InputContainer = createComponentSlot("div")<FieldContainerClassKey, OwnerS
 
         ${ownerState.variant === "horizontal" &&
         css`
-            @container comet-admin-field-container-root (min-width: ${ownerState.forceVerticalContainerSize}px) {
+            @container dextinity-admin-field-container-root (min-width: ${ownerState.forceVerticalContainerSize}px) {
                 min-height: 40px;
 
                 > .DextinityAdminFormFieldContainer-root {

--- a/packages/admin/admin/src/mui/MasterLayout.tsx
+++ b/packages/admin/admin/src/mui/MasterLayout.tsx
@@ -39,8 +39,8 @@ const ContentWrapper = createComponentSlot("div")<MasterLayoutClassKey>({
     slotName: "contentWrapper",
 })(css`
     flex-grow: 1;
-    padding-top: var(--comet-admin-master-layout-content-top-spacing);
-    width: calc(100% - var(--comet-admin-master-layout-menu-width));
+    padding-top: var(--dextinity-admin-master-layout-content-top-spacing);
+    width: calc(100% - var(--dextinity-admin-master-layout-menu-width));
 `);
 
 export interface MasterLayoutProps
@@ -122,8 +122,8 @@ export function MasterLayout(inProps: MasterLayoutProps) {
                         {...slotProps?.contentWrapper}
                         style={
                             {
-                                "--comet-admin-master-layout-content-top-spacing": `${headerHeight}px`,
-                                "--comet-admin-master-layout-menu-width": `${menuWidth}px`,
+                                "--dextinity-admin-master-layout-content-top-spacing": `${headerHeight}px`,
+                                "--dextinity-admin-master-layout-menu-width": `${menuWidth}px`,
                             } as CSSProperties
                         }
                     >

--- a/packages/admin/cms-admin/src/builds/PublisherPage.tsx
+++ b/packages/admin/cms-admin/src/builds/PublisherPage.tsx
@@ -29,7 +29,7 @@ const buildsQuery = gql`
 
 const DataGridContainer = styled("div")`
     width: 100%;
-    height: calc(100vh - var(--comet-admin-master-layout-content-top-spacing));
+    height: calc(100vh - var(--dextinity-admin-master-layout-content-top-spacing));
 `;
 
 export function PublisherPage() {


### PR DESCRIPTION
Addresses https://github.com/vivid-planet/comet/pull/6086#discussion_r3689008417: rename the `--comet-admin-*` CSS variables to Dextinity. Additionally, rename the `comet-admin-field-container-root` container name.

https://claude.ai/code/session_017Mvz58xURKTdtTV36UQdW8