### PR TITLE
Rebrand Comet cookies to Dextinity

### DIFF
--- a/docs/docs/3-features-modules/2-preview/how-site-preview-works.md
+++ b/docs/docs/3-features-modules/2-preview/how-site-preview-works.md
@@ -68,7 +68,7 @@ export async function GET(request: NextRequest) {
 
 1. Reads the `jwt` query parameter.
 2. Verifies the JWT signature using `SITE_PREVIEW_SECRET`.
-3. Stores the preview parameters (scope, preview data, user ID) in an `HttpOnly` cookie named `__comet_site_preview` as a new, longer-lived JWT (valid for 1 day).
+3. Stores the preview parameters (scope, preview data, user ID) in an `HttpOnly` cookie named `__dextinity_site_preview` as a new, longer-lived JWT (valid for 1 day).
 4. Enables [Next.js Draft Mode](https://nextjs.org/docs/app/building-your-application/configuring/draft-mode).
 5. Redirects to the `path` contained in the JWT.
 
@@ -92,7 +92,7 @@ export async function getSiteConfigForHost(host: string) {
 }
 ```
 
-`previewParams()` reads and verifies the `__comet_site_preview` cookie and returns the `{ scope, previewData }` stored during the handshake. This is how a single preview domain can serve previews for multiple sites/scopes without any URL-based routing.
+`previewParams()` reads and verifies the `__dextinity_site_preview` cookie and returns the `{ scope, previewData }` stored during the handshake. This is how a single preview domain can serve previews for multiple sites/scopes without any URL-based routing.
 
 ### 5. Site Renders in Preview Mode
 
@@ -130,7 +130,7 @@ Admin opens iframe:
   ▼
 Site /site-preview route (sitePreviewRoute)
   │  Verifies JWT
-  │  Sets __comet_site_preview cookie { scope, previewData, userId } — valid 1 day
+  │  Sets __dextinity_site_preview cookie { scope, previewData, userId } — valid 1 day
   │  Enables Next.js Draft Mode
   │  Redirects to <path>
   ▼
@@ -144,7 +144,7 @@ Editor sees unpublished / invisible content in the iframe
 
 ## Security Considerations
 
-- The initial JWT is valid for only **10 seconds** to limit the window for replay attacks. The `__comet_site_preview` cookie JWT is valid for **1 day**, matching the editor's working session.
+- The initial JWT is valid for only **10 seconds** to limit the window for replay attacks. The `__dextinity_site_preview` cookie JWT is valid for **1 day**, matching the editor's working session.
 - The cookie is `HttpOnly` and `SameSite=Lax` to prevent access from JavaScript and limit CSRF exposure.
 - The `/site-preview` route validates that the redirect path is a relative path (starts with `/` and not `//`) to prevent open redirect vulnerabilities.
 - The `SITE_PREVIEW_SECRET` must be kept confidential and should be a strong random value. It is shared between the API and the site.

--- a/packages/admin/cms-admin/src/userPermissions/user/ImpersonationButtons.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/ImpersonationButtons.tsx
@@ -7,7 +7,7 @@ import { useCurrentUser, useUserPermissionCheck } from "../hooks/currentUser";
 
 export const StopImpersonationButton = (buttonProps: ButtonProps) => {
     const stopImpersonation = async () => {
-        Cookies.remove("comet-impersonate-user-id");
+        Cookies.remove("dextinity-impersonate-user-id");
         location.href = "/";
     };
 
@@ -22,7 +22,7 @@ export const StartImpersonationButton = ({ userId }: { userId: string }) => {
     const currentUser = useCurrentUser();
     const isAllowed = useUserPermissionCheck();
     const startImpersonation = async () => {
-        Cookies.set("comet-impersonate-user-id", userId);
+        Cookies.set("dextinity-impersonate-user-id", userId);
         location.href = "/";
     };
 

--- a/packages/admin/cms-admin/src/userPermissions/utils/handleImpersonation.ts
+++ b/packages/admin/cms-admin/src/userPermissions/utils/handleImpersonation.ts
@@ -1,11 +1,11 @@
 import Cookies from "js-cookie";
 
 export const startImpersonation = async (userId: string) => {
-    Cookies.set("comet-impersonate-user-id", userId);
+    Cookies.set("dextinity-impersonate-user-id", userId);
     location.href = "/";
 };
 
 export const stopImpersonation = async () => {
-    Cookies.remove("comet-impersonate-user-id");
+    Cookies.remove("dextinity-impersonate-user-id");
     location.href = "/";
 };

--- a/packages/api/cms-api/src/auth/services/site-preview.auth-service.spec.ts
+++ b/packages/api/cms-api/src/auth/services/site-preview.auth-service.spec.ts
@@ -6,7 +6,7 @@ import { createSitePreviewAuthService, type SitePreviewAuthServiceConfig } from 
 
 describe("createSitePreviewAuthService", () => {
     const instantianteService = (config: SitePreviewAuthServiceConfig) => new (createSitePreviewAuthService(config))();
-    const mockRequest = (cookieValue: string) => vi.fn().mockReturnValue({ cookies: { __comet_site_preview: cookieValue } })();
+    const mockRequest = (cookieValue: string) => vi.fn().mockReturnValue({ cookies: { __dextinity_site_preview: cookieValue } })();
     const authenticationError = expect.objectContaining({ authenticationError: expect.any(String) });
 
     it("throws Error on empty secret", async () => {

--- a/packages/api/cms-api/src/auth/services/site-preview.auth-service.ts
+++ b/packages/api/cms-api/src/auth/services/site-preview.auth-service.ts
@@ -16,7 +16,7 @@ export function createSitePreviewAuthService({ sitePreviewSecret }: SitePreviewA
                 throw new Error("secret must not be empty");
             }
 
-            const cookieValue = request.cookies["__comet_site_preview"];
+            const cookieValue = request.cookies["__dextinity_site_preview"];
             if (!cookieValue) {
                 return SKIP_AUTH_SERVICE;
             }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -229,11 +229,11 @@ export class UserPermissionsService {
     }
 
     async getImpersonatedUser(authenticatedUser: User, request: Request): Promise<User | undefined> {
-        if (request?.cookies["comet-impersonate-user-id"]) {
+        if (request?.cookies["dextinity-impersonate-user-id"]) {
             const permissions = await this.getPermissions(authenticatedUser);
             if (permissions.find((permission) => permission.permission === "impersonation")) {
                 try {
-                    const user = await this.findUserOrThrow(request.cookies["comet-impersonate-user-id"]);
+                    const user = await this.findUserOrThrow(request.cookies["dextinity-impersonate-user-id"]);
                     if (
                         await AbstractAccessControlService.isEqualOrMorePermissions(
                             await this.getPermissionsAndContentScopes(authenticatedUser),

--- a/packages/site/site-nextjs/src/sitePreview/previewUtils.ts
+++ b/packages/site/site-nextjs/src/sitePreview/previewUtils.ts
@@ -40,7 +40,7 @@ export async function setSitePreviewParams(payload: SitePreviewParams) {
         .setProtectedHeader({ alg: "HS256" })
         .setExpirationTime("1 day")
         .sign(new TextEncoder().encode(process.env.SITE_PREVIEW_SECRET));
-    (await cookies()).set("__comet_site_preview", jwt, { httpOnly: true, sameSite: "lax" });
+    (await cookies()).set("__dextinity_site_preview", jwt, { httpOnly: true, sameSite: "lax" });
     (await draftMode()).enable();
 }
 
@@ -64,7 +64,7 @@ export async function previewParams(options: { skipDraftModeCheck: boolean } = {
         }
     }
 
-    const cookie = (await cookies()).get("__comet_site_preview");
+    const cookie = (await cookies()).get("__dextinity_site_preview");
     if (cookie) {
         return verifyJwt<PreviewParams>(cookie.value);
     }


### PR DESCRIPTION
Rebrands the Comet cookies (`__comet_site_preview`, `comet-impersonate-user-id`) to Dextinity.

https://claude.ai/code/session_01MwHM5NDS3J4dZiwrWu2i4x