### PR TITLE
Rebrand iframe messages to Dextinity

### DIFF
--- a/packages/admin/cms-admin/src/blocks/iframebridge/IFrameBridge.tsx
+++ b/packages/admin/cms-admin/src/blocks/iframebridge/IFrameBridge.tsx
@@ -76,7 +76,7 @@ export const IFrameBridgeProvider = ({ children, onReceiveMessage }: PropsWithCh
     const _onReceiveMessage = useCallback(
         (message: IFrameMessage) => {
             onReceiveMessage?.(message);
-            switch (message.cometType) {
+            switch (message.dextinityType) {
                 case IFrameMessageType.Ready:
                     setIFrameReady(true);
                     break;
@@ -97,7 +97,7 @@ export const IFrameBridgeProvider = ({ children, onReceiveMessage }: PropsWithCh
                 const message = JSON.parse(event.data);
                 // Check if message is an iframe message from us -> there are more messaging from e.g webpack,etc.
                 // eslint-disable-next-line no-prototype-builtins
-                if (message.hasOwnProperty("cometType")) {
+                if (message.hasOwnProperty("dextinityType")) {
                     _onReceiveMessage(message as IFrameMessage);
                 }
             } catch {
@@ -114,7 +114,7 @@ export const IFrameBridgeProvider = ({ children, onReceiveMessage }: PropsWithCh
 
     const sendSelectComponent = useCallback(
         (adminRoute: string) => {
-            const message: IAdminSelectComponentMessage = { cometType: AdminMessageType.SelectComponent, data: { adminRoute } };
+            const message: IAdminSelectComponentMessage = { dextinityType: AdminMessageType.SelectComponent, data: { adminRoute } };
             sendMessage(message);
         },
         [sendMessage],
@@ -129,7 +129,7 @@ export const IFrameBridgeProvider = ({ children, onReceiveMessage }: PropsWithCh
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             sendBlockState: (blockState: any) => {
                                 const message: IAdminBlockMessage = {
-                                    cometType: AdminMessageType.Block,
+                                    dextinityType: AdminMessageType.Block,
                                     data: {
                                         block: blockState, // @TODO: refactor block to blockState
                                     },
@@ -138,7 +138,7 @@ export const IFrameBridgeProvider = ({ children, onReceiveMessage }: PropsWithCh
                             },
                             sendShowOnlyVisible: (showOnlyVisible: boolean) => {
                                 const message: IAdminShowOnlyVisibleMessage = {
-                                    cometType: AdminMessageType.ShowOnlyVisible,
+                                    dextinityType: AdminMessageType.ShowOnlyVisible,
                                     data: {
                                         showOnlyVisible,
                                     },
@@ -150,19 +150,19 @@ export const IFrameBridgeProvider = ({ children, onReceiveMessage }: PropsWithCh
                             sendSelectComponent,
                             hoveredSiteRoute: hoveredSiteRoute,
                             sendHoverComponent: (adminRoute) => {
-                                const message: IAdminHoverComponentMessage = { cometType: AdminMessageType.HoverComponent, data: { adminRoute } };
+                                const message: IAdminHoverComponentMessage = { dextinityType: AdminMessageType.HoverComponent, data: { adminRoute } };
                                 sendMessage(message);
                             },
                             sendContentScopeJwt: (contentScopeJwt) => {
                                 const message: IAdminContentScopeMessage = {
-                                    cometType: AdminMessageType.ContentScope,
+                                    dextinityType: AdminMessageType.ContentScope,
                                     data: { contentScopeJwt },
                                 };
                                 sendMessage(message);
                             },
                             sendGraphQLApiUrl: (graphQLApiUrl) => {
                                 const message: IAdminGraphQLApiUrlMessage = {
-                                    cometType: AdminMessageType.GraphQLApiUrl,
+                                    dextinityType: AdminMessageType.GraphQLApiUrl,
                                     data: { graphQLApiUrl },
                                 };
                                 sendMessage(message);

--- a/packages/admin/cms-admin/src/blocks/iframebridge/IFrameMessage.ts
+++ b/packages/admin/cms-admin/src/blocks/iframebridge/IFrameMessage.ts
@@ -22,7 +22,7 @@ export enum IFrameMessageType {
  * The `IReadyIFrameMessage` message is sent from the site to the admin when the iFrame is ready to receive messages.
  */
 export interface IReadyIFrameMessage {
-    cometType: IFrameMessageType.Ready;
+    dextinityType: IFrameMessageType.Ready;
 }
 
 /**
@@ -31,7 +31,7 @@ export interface IReadyIFrameMessage {
  * The admin interface will then try to navigate to the corresponding block's admin interface.
  */
 export interface IFrameSelectComponentMessage {
-    cometType: IFrameMessageType.SelectComponent;
+    dextinityType: IFrameMessageType.SelectComponent;
     data: {
         adminRoute: string;
     };
@@ -41,7 +41,7 @@ export interface IFrameSelectComponentMessage {
  * @deprecated Use SitePreviewIFrameOpenLinkMessage instead
  */
 interface IFrameOpenLinkMessage {
-    cometType: IFrameMessageType.OpenLink;
+    dextinityType: IFrameMessageType.OpenLink;
     data: {
         link: ExternalLinkBlockData;
     };
@@ -51,7 +51,7 @@ interface IFrameOpenLinkMessage {
  * @deprecated Use SitePreviewIFrameLocationMessage instead
  */
 export interface IFrameLocationMessage {
-    cometType: IFrameMessageType.SitePreviewLocation;
+    dextinityType: IFrameMessageType.SitePreviewLocation;
     data: Pick<Location, "search" | "pathname">;
 }
 
@@ -59,7 +59,7 @@ export interface IFrameLocationMessage {
  * The `IFrameHoverComponentMessage` is sent from the site to the admin, when a component is hovered in the iFrame and should be highlighted in the admin interface.
  */
 interface IFrameHoverComponentMessage {
-    cometType: IFrameMessageType.HoverComponent;
+    dextinityType: IFrameMessageType.HoverComponent;
     data: {
         route: string | null;
     };
@@ -86,7 +86,7 @@ export enum AdminMessageType {
  * The `IAdminBlockMessage` is sent from the admin to the site, whih block should be displayed in the iFrame.
  */
 export interface IAdminBlockMessage {
-    cometType: AdminMessageType.Block;
+    dextinityType: AdminMessageType.Block;
     data: {
         block: unknown;
     };
@@ -96,7 +96,7 @@ export interface IAdminBlockMessage {
  * The `IAdminShowOnlyVisibleMessage` is sent from the admin to the site, when the "Show only visible" checkbox is toggled.
  */
 export interface IAdminShowOnlyVisibleMessage {
-    cometType: AdminMessageType.ShowOnlyVisible;
+    dextinityType: AdminMessageType.ShowOnlyVisible;
     data: {
         showOnlyVisible: boolean;
     };
@@ -106,7 +106,7 @@ export interface IAdminShowOnlyVisibleMessage {
  * The `IAdminSelectComponentMessage` is sent from the admin to the site, when a component is selected in the admin interface.
  */
 export interface IAdminSelectComponentMessage {
-    cometType: AdminMessageType.SelectComponent;
+    dextinityType: AdminMessageType.SelectComponent;
     data: {
         adminRoute: string;
     };
@@ -116,7 +116,7 @@ export interface IAdminSelectComponentMessage {
  * The `IAdminHoverComponentMessage` is sent from the admin to the site, when a component is hovered in the admin interface.
  */
 export interface IAdminHoverComponentMessage {
-    cometType: AdminMessageType.HoverComponent;
+    dextinityType: AdminMessageType.HoverComponent;
     data: {
         adminRoute: string | null;
     };
@@ -126,7 +126,7 @@ export interface IAdminHoverComponentMessage {
  * The `IAdminContentScopeMessage` is sent from the admin to the site, when the content scope is changed in the admin interface.
  */
 export interface IAdminContentScopeMessage {
-    cometType: AdminMessageType.ContentScope;
+    dextinityType: AdminMessageType.ContentScope;
     data: {
         contentScopeJwt: string;
     };
@@ -136,7 +136,7 @@ export interface IAdminContentScopeMessage {
  * The `IAdminGraphQLApiUrlMessage` is sent from the admin to the site.
  */
 export interface IAdminGraphQLApiUrlMessage {
-    cometType: AdminMessageType.GraphQLApiUrl;
+    dextinityType: AdminMessageType.GraphQLApiUrl;
     data: {
         graphQLApiUrl: string;
     };

--- a/packages/admin/cms-admin/src/preview/site/SitePreview.tsx
+++ b/packages/admin/cms-admin/src/preview/site/SitePreview.tsx
@@ -109,7 +109,7 @@ function SitePreview({ resolvePath, logo = <CometColor sx={{ fontSize: 32 }} /> 
     const siteLink = `${siteConfig.url}${sitePath}`;
 
     useSitePreviewIFrameBridge((message) => {
-        switch (message.cometType) {
+        switch (message.dextinityType) {
             case SitePreviewIFrameMessageType.OpenLink:
                 setLinkToOpen(message.data.link);
                 break;

--- a/packages/admin/cms-admin/src/preview/site/iframebridge/SitePreviewIFrameMessage.ts
+++ b/packages/admin/cms-admin/src/preview/site/iframebridge/SitePreviewIFrameMessage.ts
@@ -9,14 +9,14 @@ export enum SitePreviewIFrameMessageType {
 }
 
 interface SitePreviewIFrameOpenLinkMessage {
-    cometType: SitePreviewIFrameMessageType.OpenLink;
+    dextinityType: SitePreviewIFrameMessageType.OpenLink;
     data: {
         link: ExternalLinkBlockData;
     };
 }
 
 export interface SitePrevewIFrameLocationMessage {
-    cometType: SitePreviewIFrameMessageType.SitePreviewLocation;
+    dextinityType: SitePreviewIFrameMessageType.SitePreviewLocation;
     data: Pick<Location, "search" | "pathname">;
 }
 

--- a/packages/admin/cms-admin/src/preview/site/iframebridge/useSitePreviewIFrameBridge.ts
+++ b/packages/admin/cms-admin/src/preview/site/iframebridge/useSitePreviewIFrameBridge.ts
@@ -14,8 +14,9 @@ export function useSitePreviewIFrameBridge(onReceiveMessage: (message: SitePrevi
             // Check if message is an iframe message from us -> there are more messaging from e.g webpack,etc.
             if (
                 message &&
-                Object.prototype.hasOwnProperty.call(message, "cometType") &&
-                (message.cometType == SitePreviewIFrameMessageType.OpenLink || message.cometType == SitePreviewIFrameMessageType.SitePreviewLocation)
+                Object.prototype.hasOwnProperty.call(message, "dextinityType") &&
+                (message.dextinityType == SitePreviewIFrameMessageType.OpenLink ||
+                    message.dextinityType == SitePreviewIFrameMessageType.SitePreviewLocation)
             ) {
                 onReceiveMessage(message as SitePreviewIFrameMessage);
             }

--- a/packages/site/site-nextjs/src/sitePreview/SitePreviewProvider.tsx
+++ b/packages/site/site-nextjs/src/sitePreview/SitePreviewProvider.tsx
@@ -15,7 +15,7 @@ const SitePreview = ({ children }: PropsWithChildren) => {
     useEffect(() => {
         function sendUpstreamMessage() {
             const message: SitePreviewIFrameLocationMessage = {
-                cometType: SitePreviewIFrameMessageType.SitePreviewLocation,
+                dextinityType: SitePreviewIFrameMessageType.SitePreviewLocation,
                 data: { search: searchParams.toString(), pathname },
             };
             sendSitePreviewIFrameMessage(message);

--- a/packages/site/site-react/src/blocks/ExternalLinkBlock.tsx
+++ b/packages/site/site-react/src/blocks/ExternalLinkBlock.tsx
@@ -27,7 +27,7 @@ export function ExternalLinkBlock({
             if (preview.previewType === "SitePreview") {
                 // send link to admin to handle external link
                 sendSitePreviewIFrameMessage({
-                    cometType: SitePreviewIFrameMessageType.OpenLink,
+                    dextinityType: SitePreviewIFrameMessageType.OpenLink,
                     data: { link: { openInNewWindow, targetUrl, noFollow } },
                 });
             }

--- a/packages/site/site-react/src/iframebridge/IFrameBridge.tsx
+++ b/packages/site/site-react/src/iframebridge/IFrameBridge.tsx
@@ -211,7 +211,7 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
 
     const onReceiveMessage = useCallback(
         (message: AdminMessage) => {
-            switch (message.cometType) {
+            switch (message.dextinityType) {
                 case AdminMessageType.Block:
                     setBlock(message.data.block);
                     break;
@@ -252,7 +252,7 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
                 const message = JSON.parse(e.data);
                 // Check if message is an iframe message from us -> there are more messaging from e.g webpack,etc.
                 // eslint-disable-next-line no-prototype-builtins
-                if (message.hasOwnProperty("cometType")) {
+                if (message.hasOwnProperty("dextinityType")) {
                     onReceiveMessage(message as AdminMessage);
                 }
             } catch {
@@ -262,7 +262,7 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
 
         window.addEventListener("message", handleMessage, false);
 
-        sendMessage({ cometType: IFrameMessageType.Ready });
+        sendMessage({ dextinityType: IFrameMessageType.Ready });
 
         return () => {
             window.removeEventListener("message", handleMessage, false);
@@ -293,10 +293,10 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
             hoveredAdminRoute,
             sendSelectComponent: (adminRoute: string) => {
                 setSelectedAdminRoute(adminRoute);
-                sendMessage({ cometType: IFrameMessageType.SelectComponent, data: { adminRoute } });
+                sendMessage({ dextinityType: IFrameMessageType.SelectComponent, data: { adminRoute } });
             },
             sendHoverComponent: (route: string | null) => {
-                sendMessage({ cometType: IFrameMessageType.HoverComponent, data: { route } });
+                sendMessage({ dextinityType: IFrameMessageType.HoverComponent, data: { route } });
             },
             sendMessage,
             contentScope,

--- a/packages/site/site-react/src/iframebridge/IFrameMessage.ts
+++ b/packages/site/site-react/src/iframebridge/IFrameMessage.ts
@@ -21,7 +21,7 @@ export enum IFrameMessageType {
  * The `IReadyIFrameMessage` message is sent from the site to the admin when the iFrame is ready to receive messages.
  */
 export interface IReadyIFrameMessage {
-    cometType: IFrameMessageType.Ready;
+    dextinityType: IFrameMessageType.Ready;
 }
 
 /**
@@ -30,7 +30,7 @@ export interface IReadyIFrameMessage {
  * The admin interface will then try to navigate to the corresponding block's admin interface.
  */
 export interface IFrameSelectComponentMessage {
-    cometType: IFrameMessageType.SelectComponent;
+    dextinityType: IFrameMessageType.SelectComponent;
     data: {
         adminRoute: string;
     };
@@ -40,7 +40,7 @@ export interface IFrameSelectComponentMessage {
  * @deprecated Use SitePreviewIFrameOpenLinkMessage instead
  */
 export interface IFrameOpenLinkMessage {
-    cometType: IFrameMessageType.OpenLink;
+    dextinityType: IFrameMessageType.OpenLink;
     data: {
         link: ExternalLinkBlockData;
     };
@@ -50,7 +50,7 @@ export interface IFrameOpenLinkMessage {
  * @deprecated Use SitePreviewIFrameLocationMessage instead
  */
 export interface IFrameLocationMessage {
-    cometType: IFrameMessageType.SitePreviewLocation;
+    dextinityType: IFrameMessageType.SitePreviewLocation;
     data: Pick<Location, "search" | "pathname">;
 }
 
@@ -58,7 +58,7 @@ export interface IFrameLocationMessage {
  * The `IFrameHoverComponentMessage` is sent from the site to the admin, when a component is hovered in the iFrame and should be highlighted in the admin interface.
  */
 export interface IFrameHoverComponentMessage {
-    cometType: IFrameMessageType.HoverComponent;
+    dextinityType: IFrameMessageType.HoverComponent;
     data: {
         route: string | null;
     };
@@ -85,7 +85,7 @@ export enum AdminMessageType {
  * The `IAdminBlockMessage` is sent from the admin to the site, whih block should be displayed in the iFrame.
  */
 interface IAdminBlockMessage {
-    cometType: AdminMessageType.Block;
+    dextinityType: AdminMessageType.Block;
     data: {
         block: unknown;
     };
@@ -95,7 +95,7 @@ interface IAdminBlockMessage {
  * The `IAdminShowOnlyVisibleMessage` is sent from the admin to the site, when the "Show only visible" checkbox is toggled.
  */
 export interface IAdminShowOnlyVisibleMessage {
-    cometType: AdminMessageType.ShowOnlyVisible;
+    dextinityType: AdminMessageType.ShowOnlyVisible;
     data: {
         showOnlyVisible: boolean;
     };
@@ -105,7 +105,7 @@ export interface IAdminShowOnlyVisibleMessage {
  * The `IAdminSelectComponentMessage` is sent from the admin to the site, when a component is selected in the admin interface.
  */
 interface IAdminSelectComponentMessage {
-    cometType: AdminMessageType.SelectComponent;
+    dextinityType: AdminMessageType.SelectComponent;
     data: {
         adminRoute: string;
     };
@@ -115,7 +115,7 @@ interface IAdminSelectComponentMessage {
  * The `IAdminHoverComponentMessage` is sent from the admin to the site, when a component is hovered in the admin interface.
  */
 export interface IAdminHoverComponentMessage {
-    cometType: AdminMessageType.HoverComponent;
+    dextinityType: AdminMessageType.HoverComponent;
     data: {
         adminRoute: string | null;
     };
@@ -125,7 +125,7 @@ export interface IAdminHoverComponentMessage {
  * The `IAdminContentScopeMessage` is sent from the admin to the site, when the content scope is changed in the admin interface.
  */
 export interface IAdminContentScopeMessage {
-    cometType: AdminMessageType.ContentScope;
+    dextinityType: AdminMessageType.ContentScope;
     data: {
         contentScopeJwt: string;
     };
@@ -135,7 +135,7 @@ export interface IAdminContentScopeMessage {
  * The `IAdminGraphQLApiUrlMessage` is sent from the admin to the site.
  */
 export interface IAdminGraphQLApiUrlMessage {
-    cometType: AdminMessageType.GraphQLApiUrl;
+    dextinityType: AdminMessageType.GraphQLApiUrl;
     data: {
         graphQLApiUrl: string;
     };

--- a/packages/site/site-react/src/sitePreview/iframebridge/SitePreviewIFrameMessage.ts
+++ b/packages/site/site-react/src/sitePreview/iframebridge/SitePreviewIFrameMessage.ts
@@ -10,14 +10,14 @@ export enum SitePreviewIFrameMessageType {
 }
 
 interface SitePreviewIFrameOpenLinkMessage {
-    cometType: SitePreviewIFrameMessageType.OpenLink;
+    dextinityType: SitePreviewIFrameMessageType.OpenLink;
     data: {
         link: ExternalLinkBlockData;
     };
 }
 
 export interface SitePreviewIFrameLocationMessage {
-    cometType: SitePreviewIFrameMessageType.SitePreviewLocation;
+    dextinityType: SitePreviewIFrameMessageType.SitePreviewLocation;
     data: Pick<Location, "search" | "pathname">;
 }
 


### PR DESCRIPTION
Rename the `cometType` property to `dextinityType` for all iframe messages. I considered dropping the prefix, but decided against it as there may be other messages (see the check [here](https://github.com/vivid-planet/comet/blob/0c6b7be5fdc9783dc5bb9e5bee4185f30527b00b/packages/admin/cms-admin/src/preview/site/iframebridge/useSitePreviewIFrameBridge.ts#L14-L20)).

https://claude.ai/code/session_01RbD4ufAWqRj5uXUtTCLdSn