### PR TITLE
Update Comet import aliases

### DIFF
--- a/demo/site/src/util/recursivelyLoadBlockData.ts
+++ b/demo/site/src/util/recursivelyLoadBlockData.ts
@@ -1,4 +1,4 @@
-import { type BlockLoader, type BlockLoaderDependencies, recursivelyLoadBlockData as cometRecursivelyLoadBlockData } from "@dextinity/site-nextjs";
+import { type BlockLoader, type BlockLoaderDependencies, recursivelyLoadBlockData as baseRecursivelyLoadBlockData } from "@dextinity/site-nextjs";
 import type { AllBlockNames } from "@src/blocks.generated";
 import { loader as pageTreeIndexLoader } from "@src/common/blocks/PageTreeIndexBlock.loader";
 import { loader as newsDetailLoader } from "@src/news/blocks/NewsDetailBlock.loader";
@@ -23,5 +23,5 @@ const blockLoaders: Partial<Record<AllBlockNames, BlockLoader>> = {
 //small wrapper for @dextinity/site-nextjs recursivelyLoadBlockData that injects blockMeta from block-meta.json
 export async function recursivelyLoadBlockData(options: { blockType: string; blockData: unknown } & BlockLoaderDependencies) {
     const blocksMeta = await import("../../block-meta.json"); //dynamic import to avoid this json in client bundle
-    return cometRecursivelyLoadBlockData({ ...options, blocksMeta: blocksMeta.default, loaders: blockLoaders });
+    return baseRecursivelyLoadBlockData({ ...options, blocksMeta: blocksMeta.default, loaders: blockLoaders });
 }

--- a/packages/admin/admin/src/common/buttons/feedback/FeedbackButton.tsx
+++ b/packages/admin/admin/src/common/buttons/feedback/FeedbackButton.tsx
@@ -6,7 +6,7 @@ import { FormattedMessage } from "react-intl";
 
 import { createComponentSlot } from "../../../helpers/createComponentSlot";
 import type { ThemedComponentBaseProps } from "../../../helpers/ThemedComponentBaseProps";
-import { Tooltip as CometTooltip } from "../../Tooltip";
+import { Tooltip as BaseTooltip } from "../../Tooltip";
 import { Button, type ButtonClassKey, type ButtonProps } from "../Button";
 
 export type FeedbackButtonClassKey = "idle" | "loading" | "success" | "error" | "tooltip" | ButtonClassKey;
@@ -26,7 +26,7 @@ const Root = createComponentSlot(Button)<FeedbackButtonClassKey, OwnerState>({
     },
 })();
 
-const Tooltip = createComponentSlot(CometTooltip)<FeedbackButtonClassKey>({
+const Tooltip = createComponentSlot(BaseTooltip)<FeedbackButtonClassKey>({
     componentName: "FeedbackButton",
     slotName: "tooltip",
 })();
@@ -34,7 +34,7 @@ const Tooltip = createComponentSlot(CometTooltip)<FeedbackButtonClassKey>({
 export interface FeedbackButtonProps
     extends ThemedComponentBaseProps<{
             root: typeof Button;
-            tooltip: typeof CometTooltip;
+            tooltip: typeof BaseTooltip;
         }>,
         Omit<ButtonProps, "slotProps"> {
     onClick?: () => void | Promise<void>;

--- a/packages/admin/admin/src/common/buttons/helpDialogButton/HelpDialogButton.sc.ts
+++ b/packages/admin/admin/src/common/buttons/helpDialogButton/HelpDialogButton.sc.ts
@@ -1,7 +1,7 @@
 import { DialogContent as MuiDialogContent, IconButton } from "@mui/material";
 
 import { createComponentSlot } from "../../../helpers/createComponentSlot";
-import { Dialog as CometDialog } from "../../Dialog";
+import { Dialog as BaseDialog } from "../../Dialog";
 import type { HelpDialogButtonClassKey } from "./HelpDialogButton";
 
 export const Button = createComponentSlot(IconButton)<HelpDialogButtonClassKey>({
@@ -9,7 +9,7 @@ export const Button = createComponentSlot(IconButton)<HelpDialogButtonClassKey>(
     slotName: "button",
 })();
 
-export const Dialog = createComponentSlot(CometDialog)<HelpDialogButtonClassKey>({
+export const Dialog = createComponentSlot(BaseDialog)<HelpDialogButtonClassKey>({
     componentName: "HelpDialogButton",
     slotName: "dialog",
 })();

--- a/packages/admin/admin/src/dateTime/datePicker/DatePicker.tsx
+++ b/packages/admin/admin/src/dateTime/datePicker/DatePicker.tsx
@@ -4,7 +4,7 @@ import { DatePicker as MuiDatePicker, type DatePickerProps as MuiDatePickerProps
 import { type ReactNode, useState } from "react";
 import { useIntl } from "react-intl";
 
-import { ClearInputAdornment as CometClearInputAdornment } from "../../common/ClearInputAdornment";
+import { ClearInputAdornment as BaseClearInputAdornment } from "../../common/ClearInputAdornment";
 import { OpenPickerAdornment } from "../../common/OpenPickerAdornment";
 import { ReadOnlyAdornment } from "../../common/ReadOnlyAdornment";
 import { createComponentSlot } from "../../helpers/createComponentSlot";
@@ -15,7 +15,7 @@ export type DatePickerClassKey = "root" | "clearInputAdornment" | "readOnlyAdorn
 
 export type DatePickerProps = ThemedComponentBaseProps<{
     root: typeof MuiDatePicker;
-    clearInputAdornment: typeof CometClearInputAdornment;
+    clearInputAdornment: typeof BaseClearInputAdornment;
     readOnlyAdornment: typeof ReadOnlyAdornment;
     openPickerAdornment: typeof OpenPickerAdornment;
 }> & {
@@ -164,7 +164,7 @@ const Root = createComponentSlot(MuiDatePicker)<DatePickerClassKey>({
     }
 `);
 
-const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<DatePickerClassKey>({
+const ClearInputAdornment = createComponentSlot(BaseClearInputAdornment)<DatePickerClassKey>({
     componentName: "DatePicker",
     slotName: "clearInputAdornment",
 })();

--- a/packages/admin/admin/src/dateTime/dateRangePicker/DateRangePicker.tsx
+++ b/packages/admin/admin/src/dateTime/dateRangePicker/DateRangePicker.tsx
@@ -4,7 +4,7 @@ import type { DateRangePickerProps as MuiDateRangePickerProps } from "@mui/x-dat
 import { type ComponentType, lazy, type ReactNode, Suspense, useState } from "react";
 import { useIntl } from "react-intl";
 
-import { ClearInputAdornment as CometClearInputAdornment } from "../../common/ClearInputAdornment";
+import { ClearInputAdornment as BaseClearInputAdornment } from "../../common/ClearInputAdornment";
 import { OpenPickerAdornment } from "../../common/OpenPickerAdornment";
 import { ReadOnlyAdornment } from "../../common/ReadOnlyAdornment";
 import { createComponentSlot } from "../../helpers/createComponentSlot";
@@ -23,7 +23,7 @@ export type DateRangePickerClassKey = "root" | "clearInputAdornment" | "readOnly
 
 export type DateRangePickerProps = ThemedComponentBaseProps<{
     root: ComponentType<MuiDateRangePickerProps>;
-    clearInputAdornment: typeof CometClearInputAdornment;
+    clearInputAdornment: typeof BaseClearInputAdornment;
     readOnlyAdornment: typeof ReadOnlyAdornment;
     openPickerAdornment: typeof OpenPickerAdornment;
 }> & {
@@ -191,7 +191,7 @@ const LazyRoot = lazy(async () => {
     };
 });
 
-const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<DateRangePickerClassKey>({
+const ClearInputAdornment = createComponentSlot(BaseClearInputAdornment)<DateRangePickerClassKey>({
     componentName: "DateRangePicker",
     slotName: "clearInputAdornment",
 })();

--- a/packages/admin/admin/src/dateTime/dateTimePicker/DateTimePicker.tsx
+++ b/packages/admin/admin/src/dateTime/dateTimePicker/DateTimePicker.tsx
@@ -8,7 +8,7 @@ import {
 import { type ReactNode, useState } from "react";
 import { useIntl } from "react-intl";
 
-import { ClearInputAdornment as CometClearInputAdornment } from "../../common/ClearInputAdornment";
+import { ClearInputAdornment as BaseClearInputAdornment } from "../../common/ClearInputAdornment";
 import { OpenPickerAdornment } from "../../common/OpenPickerAdornment";
 import { ReadOnlyAdornment } from "../../common/ReadOnlyAdornment";
 import { createComponentSlot } from "../../helpers/createComponentSlot";
@@ -19,7 +19,7 @@ export type DateTimePickerClassKey = "root" | "clearInputAdornment" | "readOnlyA
 
 export type DateTimePickerProps = ThemedComponentBaseProps<{
     root: typeof MuiDateTimePicker;
-    clearInputAdornment: typeof CometClearInputAdornment;
+    clearInputAdornment: typeof BaseClearInputAdornment;
     readOnlyAdornment: typeof ReadOnlyAdornment;
     openPickerAdornment: typeof OpenPickerAdornment;
 }> & {
@@ -166,7 +166,7 @@ const Root = createComponentSlot(MuiDateTimePicker)<DateTimePickerClassKey>({
     }
 `);
 
-const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<DateTimePickerClassKey>({
+const ClearInputAdornment = createComponentSlot(BaseClearInputAdornment)<DateTimePickerClassKey>({
     componentName: "DateTimePicker",
     slotName: "clearInputAdornment",
 })();

--- a/packages/admin/admin/src/dateTime/dateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/admin/admin/src/dateTime/dateTimeRangePicker/DateTimeRangePicker.tsx
@@ -4,7 +4,7 @@ import type { DateTimeRangePickerProps as MuiDateTimeRangePickerProps } from "@m
 import { type ComponentType, lazy, type ReactNode, Suspense, useState } from "react";
 import { useIntl } from "react-intl";
 
-import { ClearInputAdornment as CometClearInputAdornment } from "../../common/ClearInputAdornment";
+import { ClearInputAdornment as BaseClearInputAdornment } from "../../common/ClearInputAdornment";
 import { OpenPickerAdornment } from "../../common/OpenPickerAdornment";
 import { ReadOnlyAdornment } from "../../common/ReadOnlyAdornment";
 import { createComponentSlot } from "../../helpers/createComponentSlot";
@@ -23,7 +23,7 @@ export type DateTimeRangePickerClassKey = "root" | "clearInputAdornment" | "read
 
 export type DateTimeRangePickerProps = ThemedComponentBaseProps<{
     root: ComponentType<MuiDateTimeRangePickerProps>;
-    clearInputAdornment: typeof CometClearInputAdornment;
+    clearInputAdornment: typeof BaseClearInputAdornment;
     readOnlyAdornment: typeof ReadOnlyAdornment;
     openPickerAdornment: typeof OpenPickerAdornment;
 }> & {
@@ -192,7 +192,7 @@ const LazyRoot = lazy(async () => {
     };
 });
 
-const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<DateTimeRangePickerClassKey>({
+const ClearInputAdornment = createComponentSlot(BaseClearInputAdornment)<DateTimeRangePickerClassKey>({
     componentName: "DateTimeRangePicker",
     slotName: "clearInputAdornment",
 })();

--- a/packages/admin/admin/src/dateTime/timePicker/TimePicker.tsx
+++ b/packages/admin/admin/src/dateTime/timePicker/TimePicker.tsx
@@ -4,7 +4,7 @@ import { pickersInputBaseClasses, TimePicker as MuiTimePicker, type TimePickerPr
 import { type ReactNode, useState } from "react";
 import { useIntl } from "react-intl";
 
-import { ClearInputAdornment as CometClearInputAdornment } from "../../common/ClearInputAdornment";
+import { ClearInputAdornment as BaseClearInputAdornment } from "../../common/ClearInputAdornment";
 import { OpenPickerAdornment } from "../../common/OpenPickerAdornment";
 import { ReadOnlyAdornment } from "../../common/ReadOnlyAdornment";
 import { createComponentSlot } from "../../helpers/createComponentSlot";
@@ -15,7 +15,7 @@ export type TimePickerClassKey = "root" | "clearInputAdornment" | "readOnlyAdorn
 
 export type TimePickerProps = ThemedComponentBaseProps<{
     root: typeof MuiTimePicker;
-    clearInputAdornment: typeof CometClearInputAdornment;
+    clearInputAdornment: typeof BaseClearInputAdornment;
     readOnlyAdornment: typeof ReadOnlyAdornment;
     openPickerAdornment: typeof OpenPickerAdornment;
 }> & {
@@ -163,7 +163,7 @@ const Root = createComponentSlot(MuiTimePicker)<TimePickerClassKey>({
     }
 `);
 
-const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<TimePickerClassKey>({
+const ClearInputAdornment = createComponentSlot(BaseClearInputAdornment)<TimePickerClassKey>({
     componentName: "TimePicker",
     slotName: "clearInputAdornment",
 })();

--- a/packages/admin/admin/src/dateTime/timeRangePicker/TimeRangePicker.tsx
+++ b/packages/admin/admin/src/dateTime/timeRangePicker/TimeRangePicker.tsx
@@ -4,7 +4,7 @@ import type { TimeRangePickerProps as MuiTimeRangePickerProps } from "@mui/x-dat
 import { type ComponentType, lazy, type ReactNode, Suspense, useState } from "react";
 import { useIntl } from "react-intl";
 
-import { ClearInputAdornment as CometClearInputAdornment } from "../../common/ClearInputAdornment";
+import { ClearInputAdornment as BaseClearInputAdornment } from "../../common/ClearInputAdornment";
 import { OpenPickerAdornment } from "../../common/OpenPickerAdornment";
 import { ReadOnlyAdornment } from "../../common/ReadOnlyAdornment";
 import { createComponentSlot } from "../../helpers/createComponentSlot";
@@ -23,7 +23,7 @@ export type TimeRangePickerClassKey = "root" | "clearInputAdornment" | "readOnly
 
 export type TimeRangePickerProps = ThemedComponentBaseProps<{
     root: ComponentType<MuiTimeRangePickerProps>;
-    clearInputAdornment: typeof CometClearInputAdornment;
+    clearInputAdornment: typeof BaseClearInputAdornment;
     readOnlyAdornment: typeof ReadOnlyAdornment;
     openPickerAdornment: typeof OpenPickerAdornment;
 }> & {
@@ -203,7 +203,7 @@ const LazyRoot = lazy(async () => {
     };
 });
 
-const ClearInputAdornment = createComponentSlot(CometClearInputAdornment)<TimeRangePickerClassKey>({
+const ClearInputAdornment = createComponentSlot(BaseClearInputAdornment)<TimeRangePickerClassKey>({
     componentName: "TimeRangePicker",
     slotName: "clearInputAdornment",
 })();

--- a/packages/admin/admin/src/mui/mainNavigation/CollapsibleItem.tsx
+++ b/packages/admin/admin/src/mui/mainNavigation/CollapsibleItem.tsx
@@ -13,7 +13,7 @@ import {
     Root,
 } from "./CollapsibleItem.styles";
 import { useMainNavigation } from "./Context";
-import type { MainNavigationItem as CometMainNavigationItem, MainNavigationItemLevel, MainNavigationItemProps } from "./Item";
+import type { MainNavigationItem, MainNavigationItemLevel, MainNavigationItemProps } from "./Item";
 import type { MainNavigationItemRouterLinkProps } from "./ItemRouterLink";
 
 export type MainNavigationChild = ReactElement<MainNavigationCollapsibleItemProps | MainNavigationItemRouterLinkProps | MainNavigationItemProps>;
@@ -22,7 +22,7 @@ export interface MainNavigationCollapsibleItemProps
     extends Omit<MainNavigationItemProps, "slotProps">,
         ThemedComponentBaseProps<{
             root: "div";
-            mainNavigationItem: typeof CometMainNavigationItem;
+            mainNavigationItem: typeof MainNavigationItem;
             itemTitle: typeof Typography;
             collapsibleIndicator: "div";
         }> {

--- a/packages/admin/cms-admin/src/warnings/warningsConfig.ts
+++ b/packages/admin/cms-admin/src/warnings/warningsConfig.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import { useDextinityConfig } from "../config/DextinityConfigContext";
-import { warningMessages as cometWarningMessages } from "./warningMessages";
+import { warningMessages as baseWarningMessages } from "./warningMessages";
 
 export interface WarningsConfig {
     messages: Record<string, ReactNode>;
@@ -10,5 +10,5 @@ export interface WarningsConfig {
 export function useWarningsConfig(): WarningsConfig {
     const dextinityConfig = useDextinityConfig();
 
-    return { ...dextinityConfig.warnings, messages: { ...dextinityConfig.warnings?.messages, ...cometWarningMessages } };
+    return { ...dextinityConfig.warnings, messages: { ...dextinityConfig.warnings?.messages, ...baseWarningMessages } };
 }

--- a/skills/dextinity-block/references/block-loader.md
+++ b/skills/dextinity-block/references/block-loader.md
@@ -297,7 +297,7 @@ Register the loader in the project's `recursivelyLoadBlockData.ts` wrapper (typi
 2. Add an entry to the `blockLoaders` record, keyed by the **block type name** (the name string passed to `createBlock` in the API, without the `Block` suffix in the key).
 
 ```ts
-import { type BlockLoader, type BlockLoaderDependencies, recursivelyLoadBlockData as cometRecursivelyLoadBlockData } from "@dextinity/site-nextjs";
+import { type BlockLoader, type BlockLoaderDependencies, recursivelyLoadBlockData as baseRecursivelyLoadBlockData } from "@dextinity/site-nextjs";
 import { type AllBlockNames } from "@src/blocks.generated";
 import { loader as myEntityLoader } from "@src/path/to/blocks/MyEntityBlock.loader";
 


### PR DESCRIPTION
There are multiple Comet import aliases throughout the codebase, for instance, `import { Tooltip as CometTooltip } from "../../Tooltip";`. Change to `Base*` to remove the Comet references.

https://claude.ai/code/session_01QCZJANJRkWgvwGDAzxmpG8