### PR TITLE
Rebrand local storage cookie API to Dextinity

### DIFF
--- a/docs/docs/4-guides/2-working-with-cookies/index.md
+++ b/docs/docs/4-guides/2-working-with-cookies/index.md
@@ -33,18 +33,18 @@ For local development and other environments that do not embed the project's coo
 
 #### Debugging using the dev tools console
 
-The localStorage cookie api can be accessed via the dev tools console with `window.cometLocalStorageCookieApi`.
+The localStorage cookie api can be accessed via the dev tools console with `window.dextinityLocalStorageCookieApi`.
 
 ##### Open Cookie Settings
 
 ```js
-window.cometLocalStorageCookieApi.openCookieSettings();
+window.dextinityLocalStorageCookieApi.openCookieSettings();
 ```
 
 ##### View the currently consented cookies
 
 ```js
-window.cometLocalStorageCookieApi.consentedCookies;
+window.dextinityLocalStorageCookieApi.consentedCookies;
 ```
 
 ## Using the `<CookieSafe />` component

--- a/packages/site/site-react/src/cookies/useLocalStorageCookieApi.ts
+++ b/packages/site/site-react/src/cookies/useLocalStorageCookieApi.ts
@@ -4,11 +4,11 @@ import { useLocalStorage } from "usehooks-ts";
 
 import type { CookieApi, CookieApiHook } from "./CookieApiContext";
 
-const localStorageCookieApiKey = "comet-dev-cookie-api-consented-cookies";
+const localStorageCookieApiKey = "dextinity-dev-cookie-api-consented-cookies";
 
 declare global {
     interface Window {
-        cometLocalStorageCookieApi: CookieApi;
+        dextinityLocalStorageCookieApi: CookieApi;
     }
 }
 
@@ -33,7 +33,7 @@ export const useLocalStorageCookieApi: CookieApiHook = () => {
 
         const simulateLoadingTimeout = setTimeout(() => {
             setInitialized(true);
-            window.cometLocalStorageCookieApi = {
+            window.dextinityLocalStorageCookieApi = {
                 initialized: true,
                 consentedCookies,
                 openCookieSettings: openCookieSettings,


### PR DESCRIPTION
Changes the local storage key and window property of `useLocalStorageCookieApi` to Dextinity.

https://claude.ai/code/session_015kNXN27RM96KGiq6Gc3DKm