### PR TITLE
mail-react: Fix the examples and guidance for raw content in a column

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/1-email-basics.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/1-email-basics.md
@@ -42,21 +42,21 @@ When you need to drop into raw HTML outside of a text context — for example, t
 
 ### Start Raw Content Inside a Column With `<tr>`
 
-`mj-column` wraps every child in its own `<tr><td>` — except `MjmlRaw` content, which goes straight into the column's table unwrapped. A `<table>`, `<div>`, or `<img>` in that position breaks the surrounding layout: the section or column after it renders outside its wrapper or group, and MJML reports no error. Open with a `<tr>` and put your markup in a `<td>`, zeroing that cell's `padding`, `font-size`, and `line-height` so it adds no height of its own:
+`mj-column` wraps every child in its own `<tr><td>` — except `MjmlRaw` content, which goes straight into the column's table unwrapped. A `<table>`, `<div>`, or `<img>` in that position ends up outside the column's table instead, and MJML reports no error. This covers the `Html*` components. Open with a `<tr>` and put your markup in a `<td>`:
 
 ```tsx
 <MjmlColumn>
     <MjmlRaw>
         <tr>
-            <td style={{ padding: 0, fontSize: 0, lineHeight: 0, msoLineHeightRule: "exactly" }}>
-                <HtmlDivider />
-            </td>
+            <td>{/* your raw markup */}</td>
         </tr>
     </MjmlRaw>
 </MjmlColumn>
 ```
 
-This applies to `MjmlColumn` and `MjmlHero`. `MjmlSection` and `MjmlWrapper` already place their children inside a shared cell, so any root element is safe there.
+`HtmlText` is the exception: it renders the `<td>` itself, so a surrounding `<tr>` is all it needs — unless its `element` prop renders something else, which needs a `<td>` again. `MjmlDivider` supplies both the row and the cell — use it instead of a hand-wrapped `HtmlDivider` whenever you are in an `MjmlColumn`.
+
+The rule applies to `MjmlColumn` and `MjmlHero`. `MjmlSection` and `MjmlWrapper` already place their children inside a shared cell, so any root element is safe there.
 
 ### Avoid Block-Level HTML Elements Inside Ending Tags
 

--- a/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
@@ -369,11 +369,9 @@ It supports the same `variant` and `bottomSpacing` props as `MjmlText`:
 <MjmlSection>
     <MjmlColumn>
         <MjmlRaw>
-            <table>
-                <tr>
-                    <HtmlText>Themed text inside a raw HTML table</HtmlText>
-                </tr>
-            </table>
+            <tr>
+                <HtmlText>Themed text in a row of the column's table</HtmlText>
+            </tr>
         </MjmlRaw>
     </MjmlColumn>
 </MjmlSection>

--- a/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/3-blocks.md
@@ -17,6 +17,8 @@ Two components render `PixelImageBlockData` from the CMS — one for MJML contex
 | `MjmlPixelImageBlock` | re-exported `MjmlImage` | an `MjmlColumn` (standard MJML layout model)                                      |
 | `HtmlPixelImageBlock` | raw `<img>`             | raw HTML or [MJML ending tags](./1-email-basics.md#ending-tags) such as `MjmlRaw` |
 
+Inside `MjmlRaw` in an `MjmlColumn`, `HtmlPixelImageBlock` needs its own `<tr>` and `<td>` — see [Start Raw Content Inside a Column With `<tr>`](./1-email-basics.md#start-raw-content-inside-a-column-with-tr).
+
 ```tsx
 import { MjmlColumn, MjmlPixelImageBlock, MjmlSection } from "@comet/mail-react";
 
@@ -80,6 +82,8 @@ The `createRichTextBlock` factory creates components that render `RichTextBlockD
 | ------------------- | --------------------------- | --------------------------------------------------------------------------------- |
 | `MjmlRichTextBlock` | `MjmlText`                  | an `MjmlColumn` (standard MJML layout model)                                      |
 | `HtmlRichTextBlock` | `HtmlText` (`<div>`)        | raw HTML or [MJML ending tags](./1-email-basics.md#ending-tags) such as `MjmlRaw` |
+
+Inside `MjmlRaw` in an `MjmlColumn`, `HtmlRichTextBlock` needs its own `<tr>` and `<td>` — see [Start Raw Content Inside a Column With `<tr>`](./1-email-basics.md#start-raw-content-inside-a-column-with-tr).
 
 Call the factory once — at the top level of a file, not inside a component — and export the returned components:
 

--- a/packages/mail-react/src/blocks/pixelImage/HtmlPixelImageBlock.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/HtmlPixelImageBlock.tsx
@@ -12,6 +12,7 @@ export type HtmlPixelImageBlockProps = Omit<ComponentProps<"img">, "src" | "widt
  *
  * Use within raw HTML context — HTML-only emails or
  * [MJML ending tags](https://documentation.mjml.io/#ending-tags) like `MjmlRaw`.
+ * Inside `MjmlRaw` in an `MjmlColumn`, place `HtmlPixelImageBlock` in a `<tr>` and `<td>` of its own.
  * For MJML context, use `MjmlPixelImageBlock`.
  */
 export function HtmlPixelImageBlock({

--- a/packages/mail-react/src/blocks/pixelImage/__stories__/HtmlPixelImageBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/__stories__/HtmlPixelImageBlock.stories.tsx
@@ -49,7 +49,11 @@ export const Default: Story = {
             <MjmlSection indent>
                 <MjmlColumn>
                     <MjmlRaw>
-                        <HtmlPixelImageBlock {...args} />
+                        <tr>
+                            <td>
+                                <HtmlPixelImageBlock {...args} />
+                            </td>
+                        </tr>
                     </MjmlRaw>
                 </MjmlColumn>
             </MjmlSection>
@@ -77,8 +81,12 @@ export const AspectRatioOverride: Story = {
             <MjmlSection indent>
                 <MjmlColumn>
                     <MjmlRaw>
-                        <HtmlPixelImageBlock {...args} />
-                        <HtmlPixelImageBlock {...args} aspectRatio="16x9" />
+                        <tr>
+                            <td>
+                                <HtmlPixelImageBlock {...args} />
+                                <HtmlPixelImageBlock {...args} aspectRatio="16x9" />
+                            </td>
+                        </tr>
                     </MjmlRaw>
                 </MjmlColumn>
             </MjmlSection>

--- a/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
@@ -21,7 +21,7 @@ const config: Meta<typeof HtmlRichTextBlock> = {
             description: {
                 // Duplicates the TSDoc on HtmlRichTextBlock in createRichTextBlock.tsx — Storybook cannot read it from factory return type properties. Update both when the description changes.
                 component:
-                    "Renders CMS RichText block data (draft-js raw content) as one `HtmlText` div per draft block, for raw-HTML contexts such as `MjmlRaw`.",
+                    "Renders CMS RichText block data (draft-js raw content) as one `HtmlText` div per draft block, for raw-HTML contexts such as `MjmlRaw`. Inside `MjmlRaw` in an `MjmlColumn`, place `HtmlRichTextBlock` in a `<tr>` and `<td>` of its own.",
             },
         },
     },
@@ -35,7 +35,11 @@ export const Default: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlRichTextBlock data={exampleBlockData} />
+                    <tr>
+                        <td>
+                            <HtmlRichTextBlock data={exampleBlockData} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -60,7 +64,11 @@ export const ListVariety: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlRichTextBlock data={listVarietyBlockData} />
+                    <tr>
+                        <td>
+                            <HtmlRichTextBlock data={listVarietyBlockData} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -88,7 +96,11 @@ export const ListSpacing: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlRichTextBlock data={listSpacingBlockData} />
+                    <tr>
+                        <td>
+                            <HtmlRichTextBlock data={listSpacingBlockData} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -130,7 +142,11 @@ export const ListSpacingPerVariant: Story = {
         <MjmlSection indent className="perVariantListSpacingSection">
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlPerVariantRichTextBlock data={listSpacingBlockData} />
+                    <tr>
+                        <td>
+                            <HtmlPerVariantRichTextBlock data={listSpacingBlockData} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -153,7 +169,11 @@ export const WithCustomLinkType: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlCustomLinkTypeRichTextBlock data={exampleBlockData} />
+                    <tr>
+                        <td>
+                            <HtmlCustomLinkTypeRichTextBlock data={exampleBlockData} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -189,7 +209,11 @@ export const WithVariants: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlVariantsRichTextBlock data={exampleBlockData} />
+                    <tr>
+                        <td>
+                            <HtmlVariantsRichTextBlock data={exampleBlockData} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -212,7 +236,11 @@ export const WithCustomInlineStyle: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlCustomInlineStyleRichTextBlock data={highlightBlockData} />
+                    <tr>
+                        <td>
+                            <HtmlCustomInlineStyleRichTextBlock data={highlightBlockData} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -235,7 +263,11 @@ export const RestrictedHeadlineBlock: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlHeadlineRichTextBlock data={headlinesOnlyBlockData} />
+                    <tr>
+                        <td>
+                            <HtmlHeadlineRichTextBlock data={headlinesOnlyBlockData} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>

--- a/packages/mail-react/src/blocks/richText/createRichTextBlock.tsx
+++ b/packages/mail-react/src/blocks/richText/createRichTextBlock.tsx
@@ -102,7 +102,9 @@ function renderRichTextContent({ draftContent, blockTypes, linkTypes, inline, bl
  *
  * `MjmlRichTextBlock` renders each draft block as `MjmlText` and must be
  * placed within an `MjmlColumn`. `HtmlRichTextBlock` renders each draft block
- * as `HtmlText` for raw-HTML contexts (e.g. inside `MjmlRaw`).
+ * as `HtmlText` for raw-HTML contexts (e.g. inside `MjmlRaw`); inside
+ * `MjmlRaw` in an `MjmlColumn`, place `HtmlRichTextBlock` in a `<tr>` and
+ * `<td>` of its own.
  *
  * ```ts
  * export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
@@ -120,7 +122,7 @@ export function createRichTextBlock<TLinkTypes extends Record<string, unknown> =
     /** Renders CMS RichText block data (draft-js raw content) as one `MjmlText` per draft block. Must be placed within an `MjmlColumn`. */
     MjmlRichTextBlock: (props: RichTextBlockProps) => ReactNode;
     // The description below is duplicated in HtmlRichTextBlock.stories.tsx because Storybook cannot read TSDoc from factory return type properties. Update both when the description changes.
-    /** Renders CMS RichText block data (draft-js raw content) as one `HtmlText` div per draft block, for raw-HTML contexts such as `MjmlRaw`. */
+    /** Renders CMS RichText block data (draft-js raw content) as one `HtmlText` div per draft block, for raw-HTML contexts such as `MjmlRaw`. Inside `MjmlRaw` in an `MjmlColumn`, place `HtmlRichTextBlock` in a `<tr>` and `<td>` of its own. */
     HtmlRichTextBlock: (props: RichTextBlockProps) => ReactNode;
 } {
     const blockTypes = options.blockTypes ?? {};

--- a/packages/mail-react/src/components/button/HtmlButton.tsx
+++ b/packages/mail-react/src/components/button/HtmlButton.tsx
@@ -14,6 +14,8 @@ export type HtmlButtonProps = ButtonProps & Omit<AnchorHTMLAttributes<HTMLAnchor
 
 /**
  * Themed button for use inside MJML ending tags or outside of the MJML context.
+ * Inside `MjmlRaw` in an `MjmlColumn`, place `HtmlButton` in a `<tr>` and `<td>` of its own.
+ * For MJML context, use `MjmlButton`.
  */
 export function HtmlButton({
     variant: variantProp,

--- a/packages/mail-react/src/components/button/__stories__/HtmlButton.stories.tsx
+++ b/packages/mail-react/src/components/button/__stories__/HtmlButton.stories.tsx
@@ -31,7 +31,11 @@ const config: Meta<typeof HtmlButton> = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlButton {...args} />
+                    <tr>
+                        <td>
+                            <HtmlButton {...args} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -59,15 +63,19 @@ export const WithVariants: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlButton href="https://example.com">Primary (default)</HtmlButton>
-                    <TemporaryHtmlSpacer height="16px" />
-                    <HtmlButton href="https://example.com" variant="secondary">
-                        Secondary
-                    </HtmlButton>
-                    <TemporaryHtmlSpacer height="16px" />
-                    <HtmlButton href="https://example.com" variant="tertiary">
-                        Tertiary
-                    </HtmlButton>
+                    <tr>
+                        <td>
+                            <HtmlButton href="https://example.com">Primary (default)</HtmlButton>
+                            <TemporaryHtmlSpacer height="16px" />
+                            <HtmlButton href="https://example.com" variant="secondary">
+                                Secondary
+                            </HtmlButton>
+                            <TemporaryHtmlSpacer height="16px" />
+                            <HtmlButton href="https://example.com" variant="tertiary">
+                                Tertiary
+                            </HtmlButton>
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -93,9 +101,13 @@ export const ResponsiveVariants: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlButton href="https://example.com" variant="primary">
-                        Shrinks on mobile
-                    </HtmlButton>
+                    <tr>
+                        <td>
+                            <HtmlButton href="https://example.com" variant="primary">
+                                Shrinks on mobile
+                            </HtmlButton>
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -117,7 +129,11 @@ export const DefaultVariant: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlButton href="https://example.com">Uses the default &quot;primary&quot; variant</HtmlButton>
+                    <tr>
+                        <td>
+                            <HtmlButton href="https://example.com">Uses the default &quot;primary&quot; variant</HtmlButton>
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -133,16 +149,20 @@ export const GradientBackground: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlButton
-                        href="https://example.com"
-                        style={{
-                            backgroundColor: "#5B4FC7",
-                            backgroundImage: "linear-gradient(to right, #5B4FC7, #FF6B6B)",
-                            color: "#FFFFFF",
-                        }}
-                    >
-                        Gradient button
-                    </HtmlButton>
+                    <tr>
+                        <td>
+                            <HtmlButton
+                                href="https://example.com"
+                                style={{
+                                    backgroundColor: "#5B4FC7",
+                                    backgroundImage: "linear-gradient(to right, #5B4FC7, #FF6B6B)",
+                                    color: "#FFFFFF",
+                                }}
+                            >
+                                Gradient button
+                            </HtmlButton>
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -166,13 +186,17 @@ export const HoverAndActiveState: Story = {
             <MjmlSection indent>
                 <MjmlColumn>
                     <MjmlRaw>
-                        <HtmlButton
-                            href="https://example.com"
-                            className="interactiveButton"
-                            style={{ backgroundColor: "#5B4FC7", color: "#FFFFFF", border: "2px solid #5B4FC7" }}
-                        >
-                            Hover and press me
-                        </HtmlButton>
+                        <tr>
+                            <td>
+                                <HtmlButton
+                                    href="https://example.com"
+                                    className="interactiveButton"
+                                    style={{ backgroundColor: "#5B4FC7", color: "#FFFFFF", border: "2px solid #5B4FC7" }}
+                                >
+                                    Hover and press me
+                                </HtmlButton>
+                            </td>
+                        </tr>
                     </MjmlRaw>
                 </MjmlColumn>
             </MjmlSection>
@@ -185,9 +209,13 @@ export const FullWidth: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlButton href="https://example.com" fullWidth>
-                        Full-width button
-                    </HtmlButton>
+                    <tr>
+                        <td>
+                            <HtmlButton href="https://example.com" fullWidth>
+                                Full-width button
+                            </HtmlButton>
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -199,17 +227,21 @@ export const FullWidthGradient: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlButton
-                        href="https://example.com"
-                        fullWidth
-                        style={{
-                            backgroundColor: "#5B4FC7",
-                            backgroundImage: "linear-gradient(to right, #5B4FC7, #FF6B6B)",
-                            color: "#FFFFFF",
-                        }}
-                    >
-                        Full-width gradient button
-                    </HtmlButton>
+                    <tr>
+                        <td>
+                            <HtmlButton
+                                href="https://example.com"
+                                fullWidth
+                                style={{
+                                    backgroundColor: "#5B4FC7",
+                                    backgroundImage: "linear-gradient(to right, #5B4FC7, #FF6B6B)",
+                                    color: "#FFFFFF",
+                                }}
+                            >
+                                Full-width gradient button
+                            </HtmlButton>
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -239,9 +271,13 @@ export const FullWidthOnMobile: Story = {
             <MjmlSection indent>
                 <MjmlColumn>
                     <MjmlRaw>
-                        <HtmlButton href="https://example.com" className="mobileFullWidth">
-                            Full width on mobile only
-                        </HtmlButton>
+                        <tr>
+                            <td>
+                                <HtmlButton href="https://example.com" className="mobileFullWidth">
+                                    Full width on mobile only
+                                </HtmlButton>
+                            </td>
+                        </tr>
                     </MjmlRaw>
                 </MjmlColumn>
             </MjmlSection>
@@ -258,35 +294,31 @@ export const Alignment: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <table role="presentation" width="100%" cellPadding={0} cellSpacing={0} border={0}>
-                        <tbody>
-                            <tr>
-                                <td align="left">
-                                    <HtmlButton href="https://example.com">Left</HtmlButton>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <TemporaryHtmlSpacer height="16px" />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td align="center">
-                                    <HtmlButton href="https://example.com">Center</HtmlButton>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <TemporaryHtmlSpacer height="16px" />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td align="right">
-                                    <HtmlButton href="https://example.com">Right</HtmlButton>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                    <tr>
+                        <td align="left">
+                            <HtmlButton href="https://example.com">Left</HtmlButton>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <TemporaryHtmlSpacer height="16px" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center">
+                            <HtmlButton href="https://example.com">Center</HtmlButton>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <TemporaryHtmlSpacer height="16px" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="right">
+                            <HtmlButton href="https://example.com">Right</HtmlButton>
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -302,19 +334,23 @@ export const SideBySide: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <table role="presentation" cellPadding={0} cellSpacing={0} border={0}>
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <HtmlButton href="https://example.com">Button A</HtmlButton>
-                                </td>
-                                <td style={{ width: "16px", fontSize: "0", lineHeight: "0" }}>&nbsp;</td>
-                                <td>
-                                    <HtmlButton href="https://example.com">Button B</HtmlButton>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                    <tr>
+                        <td>
+                            <table role="presentation" cellPadding={0} cellSpacing={0} border={0}>
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            <HtmlButton href="https://example.com">Button A</HtmlButton>
+                                        </td>
+                                        <td style={{ width: "16px", fontSize: "0", lineHeight: "0" }}>&nbsp;</td>
+                                        <td>
+                                            <HtmlButton href="https://example.com">Button B</HtmlButton>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -326,32 +362,36 @@ export const IconBeforeText: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlButton href="https://example.com">
-                        <table
-                            role="presentation"
-                            cellPadding={0}
-                            cellSpacing={0}
-                            border={0}
-                            style={{ display: "inline-block", verticalAlign: "middle" }}
-                        >
-                            <tbody>
-                                <tr>
-                                    <td valign="middle" style={{ paddingRight: "8px", fontSize: "0" }}>
-                                        <img
-                                            src="https://picsum.photos/seed/buttonicon/18/18"
-                                            alt=""
-                                            width={18}
-                                            height={18}
-                                            style={{ display: "block" }}
-                                        />
-                                    </td>
-                                    <td valign="middle" style={{ color: "#FFFFFF", textDecoration: "none" }}>
-                                        Icon before text
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </HtmlButton>
+                    <tr>
+                        <td>
+                            <HtmlButton href="https://example.com">
+                                <table
+                                    role="presentation"
+                                    cellPadding={0}
+                                    cellSpacing={0}
+                                    border={0}
+                                    style={{ display: "inline-block", verticalAlign: "middle" }}
+                                >
+                                    <tbody>
+                                        <tr>
+                                            <td valign="middle" style={{ paddingRight: "8px", fontSize: "0" }}>
+                                                <img
+                                                    src="https://picsum.photos/seed/buttonicon/18/18"
+                                                    alt=""
+                                                    width={18}
+                                                    height={18}
+                                                    style={{ display: "block" }}
+                                                />
+                                            </td>
+                                            <td valign="middle" style={{ color: "#FFFFFF", textDecoration: "none" }}>
+                                                Icon before text
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </HtmlButton>
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>

--- a/packages/mail-react/src/components/divider/HtmlDivider.tsx
+++ b/packages/mail-react/src/components/divider/HtmlDivider.tsx
@@ -17,6 +17,8 @@ export type HtmlDividerProps = DividerProps;
 
 /**
  * Themed divider for use inside MJML ending tags or outside of the MJML context.
+ * Inside `MjmlRaw` in an `MjmlColumn`, place `HtmlDivider` in a `<tr>` and `<td>` of its own.
+ * For MJML context, use `MjmlDivider`.
  */
 export function HtmlDivider({
     variant: variantProp,

--- a/packages/mail-react/src/components/divider/__stories__/HtmlDivider.stories.tsx
+++ b/packages/mail-react/src/components/divider/__stories__/HtmlDivider.stories.tsx
@@ -24,7 +24,11 @@ const config: Meta<typeof HtmlDivider> = {
             <MjmlColumn>
                 <MjmlSpacer height="16px" />
                 <MjmlRaw>
-                    <HtmlDivider {...args} />
+                    <tr>
+                        <td style={{ fontSize: 0, lineHeight: 0, msoLineHeightRule: "exactly" }}>
+                            <HtmlDivider {...args} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
                 <MjmlSpacer height="16px" />
             </MjmlColumn>
@@ -71,11 +75,19 @@ export const WithVariants: Story = {
             <MjmlColumn>
                 <MjmlSpacer height="16px" />
                 <MjmlRaw>
-                    <HtmlDivider {...args} />
+                    <tr>
+                        <td style={{ fontSize: 0, lineHeight: 0, msoLineHeightRule: "exactly" }}>
+                            <HtmlDivider {...args} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
                 <MjmlSpacer height="16px" />
                 <MjmlRaw>
-                    <HtmlDivider {...args} variant="thick" />
+                    <tr>
+                        <td style={{ fontSize: 0, lineHeight: 0, msoLineHeightRule: "exactly" }}>
+                            <HtmlDivider {...args} variant="thick" />
+                        </td>
+                    </tr>
                 </MjmlRaw>
                 <MjmlSpacer height="16px" />
             </MjmlColumn>

--- a/packages/mail-react/src/components/image/HtmlImage.tsx
+++ b/packages/mail-react/src/components/image/HtmlImage.tsx
@@ -12,6 +12,7 @@ export type HtmlImageProps = ComponentProps<"img">;
  *
  * Use within raw HTML context — HTML-only emails or
  * [MJML ending tags](https://documentation.mjml.io/#ending-tags) like `MjmlRaw`.
+ * Inside `MjmlRaw` in an `MjmlColumn`, place `HtmlImage` in a `<tr>` and `<td>` of its own.
  * For MJML context, use `MjmlImage`.
  */
 export function HtmlImage({ className, ...restProps }: HtmlImageProps): ReactNode {

--- a/packages/mail-react/src/components/image/__stories__/HtmlImage.stories.tsx
+++ b/packages/mail-react/src/components/image/__stories__/HtmlImage.stories.tsx
@@ -32,7 +32,11 @@ export const Default: Story = {
         <MjmlSection indent>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlImage {...args} src={`https://picsum.photos/seed/html-image/${args.width}/${args.height}`} />
+                    <tr>
+                        <td>
+                            <HtmlImage {...args} src={`https://picsum.photos/seed/html-image/${args.width}/${args.height}`} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -48,7 +52,11 @@ export const FullWidth: Story = {
         <MjmlSection>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlImage {...args} src={`https://picsum.photos/seed/html-image-full-width/${args.width}/${args.height}`} />
+                    <tr>
+                        <td>
+                            <HtmlImage {...args} src={`https://picsum.photos/seed/html-image-full-width/${args.width}/${args.height}`} />
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>

--- a/packages/mail-react/src/components/text/HtmlText.tsx
+++ b/packages/mail-react/src/components/text/HtmlText.tsx
@@ -61,6 +61,8 @@ export type HtmlTextProps<E extends keyof JSX.IntrinsicElements = "td"> = HtmlTe
 
 /**
  * Themed text component for use inside MJML ending tags or outside of the MJML context.
+ * Inside `MjmlRaw` in an `MjmlColumn`, place `HtmlText` in a `<tr>` of its own,
+ * and in a `<td>` too when `element` is not the default `td`.
  */
 export function HtmlText<E extends keyof JSX.IntrinsicElements>(
     props: HtmlTextOwnProps & { element: E } & Omit<ComponentPropsWithoutRef<E>, keyof HtmlTextOwnProps | "element">,

--- a/packages/mail-react/src/components/text/__stories__/HtmlText.stories.tsx
+++ b/packages/mail-react/src/components/text/__stories__/HtmlText.stories.tsx
@@ -21,11 +21,9 @@ export const Default: Story = {
         <MjmlSection>
             <MjmlColumn>
                 <MjmlRaw>
-                    <table>
-                        <tr>
-                            <HtmlText>Default text with base theme styles</HtmlText>
-                        </tr>
-                    </table>
+                    <tr>
+                        <HtmlText>Default text with base theme styles</HtmlText>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -52,17 +50,15 @@ export const WithVariants: Story = {
         <MjmlSection>
             <MjmlColumn>
                 <MjmlRaw>
-                    <table>
-                        <tr>
-                            <HtmlText variant="heading">Heading variant</HtmlText>
-                        </tr>
-                        <tr>
-                            <HtmlText variant="body">Body variant</HtmlText>
-                        </tr>
-                        <tr>
-                            <HtmlText variant="caption">Caption variant</HtmlText>
-                        </tr>
-                    </table>
+                    <tr>
+                        <HtmlText variant="heading">Heading variant</HtmlText>
+                    </tr>
+                    <tr>
+                        <HtmlText variant="body">Body variant</HtmlText>
+                    </tr>
+                    <tr>
+                        <HtmlText variant="caption">Caption variant</HtmlText>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -87,11 +83,9 @@ export const ResponsiveVariants: Story = {
         <MjmlSection>
             <MjmlColumn>
                 <MjmlRaw>
-                    <table>
-                        <tr>
-                            <HtmlText variant="heading">Responsive heading — shrinks on mobile</HtmlText>
-                        </tr>
-                    </table>
+                    <tr>
+                        <HtmlText variant="heading">Responsive heading — shrinks on mobile</HtmlText>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -113,19 +107,17 @@ export const BottomSpacing: Story = {
         <MjmlSection>
             <MjmlColumn>
                 <MjmlRaw>
-                    <table>
-                        <tr>
-                            <HtmlText variant="heading" bottomSpacing>
-                                Heading with bottom spacing
-                            </HtmlText>
-                        </tr>
-                        <tr>
-                            <HtmlText bottomSpacing>Base text with bottom spacing</HtmlText>
-                        </tr>
-                        <tr>
-                            <HtmlText>Text without bottom spacing</HtmlText>
-                        </tr>
-                    </table>
+                    <tr>
+                        <HtmlText variant="heading" bottomSpacing>
+                            Heading with bottom spacing
+                        </HtmlText>
+                    </tr>
+                    <tr>
+                        <HtmlText bottomSpacing>Base text with bottom spacing</HtmlText>
+                    </tr>
+                    <tr>
+                        <HtmlText>Text without bottom spacing</HtmlText>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -148,14 +140,12 @@ export const DefaultVariant: Story = {
         <MjmlSection>
             <MjmlColumn>
                 <MjmlRaw>
-                    <table>
-                        <tr>
-                            <HtmlText>Uses the default &quot;body&quot; variant automatically</HtmlText>
-                        </tr>
-                        <tr>
-                            <HtmlText variant="heading">Explicit heading variant</HtmlText>
-                        </tr>
-                    </table>
+                    <tr>
+                        <HtmlText>Uses the default &quot;body&quot; variant automatically</HtmlText>
+                    </tr>
+                    <tr>
+                        <HtmlText variant="heading">Explicit heading variant</HtmlText>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -167,7 +157,11 @@ export const ElementPropAsDiv: Story = {
         <MjmlSection>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlText element="div">Rendered as a div with theme styles</HtmlText>
+                    <tr>
+                        <td>
+                            <HtmlText element="div">Rendered as a div with theme styles</HtmlText>
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>
@@ -179,9 +173,13 @@ export const ElementPropAsAnchor: Story = {
         <MjmlSection>
             <MjmlColumn>
                 <MjmlRaw>
-                    <HtmlText element="a" href="https://example.com" style={{ textDecoration: "underline" }}>
-                        Rendered as an anchor with href
-                    </HtmlText>
+                    <tr>
+                        <td>
+                            <HtmlText element="a" href="https://example.com" style={{ textDecoration: "underline" }}>
+                                Rendered as an anchor with href
+                            </HtmlText>
+                        </td>
+                    </tr>
                 </MjmlRaw>
             </MjmlColumn>
         </MjmlSection>

--- a/skills/comet-mail-react/SKILL.md
+++ b/skills/comet-mail-react/SKILL.md
@@ -127,21 +127,21 @@ Always use `theme.breakpoints.*.belowMediaQuery` inside `registerStyles` instead
 
 ### Start Raw Content Inside a Column With `<tr>`
 
-`mj-column` wraps every child in its own `<tr><td>` — except `MjmlRaw` content, which goes straight into the column's table unwrapped. A `<table>`, `<div>`, or `<img>` in that position breaks the surrounding layout: the section or column after it renders outside its wrapper or group, and MJML reports no error. Open with a `<tr>` and put the markup in a `<td>`, zeroing that cell's `padding`, `font-size`, and `line-height` so it adds no height:
+`mj-column` wraps every child in its own `<tr><td>` — except `MjmlRaw` content, which goes straight into the column's table unwrapped. A `<table>`, `<div>`, or `<img>` in that position ends up outside the column's table instead, and MJML reports no error. This covers the `Html*` components. Open with a `<tr>` and put the markup in a `<td>`:
 
 ```tsx
 <MjmlColumn>
     <MjmlRaw>
         <tr>
-            <td style={{ padding: 0, fontSize: 0, lineHeight: 0, msoLineHeightRule: "exactly" }}>
-                <HtmlDivider />
-            </td>
+            <td>{/* your raw markup */}</td>
         </tr>
     </MjmlRaw>
 </MjmlColumn>
 ```
 
-`MjmlColumn` and `MjmlHero` are both affected — `MjmlSection` and `MjmlWrapper` already place their children inside a shared cell, so any root element is safe there. `MjmlDivider` handles this itself; use it instead of a hand-wrapped `HtmlDivider` whenever you are in an `MjmlColumn`.
+`HtmlText` is the exception: it renders the `<td>` itself, so a surrounding `<tr>` is all it needs — unless its `element` prop renders something else, which needs a `<td>` again.
+
+`MjmlColumn` and `MjmlHero` are both affected — `MjmlSection` and `MjmlWrapper` already place their children inside a shared cell, so any root element is safe there. `MjmlDivider` supplies both the row and the cell; use it instead of a hand-wrapped `HtmlDivider` whenever you are in an `MjmlColumn`.
 
 ### Avoid Block-Level HTML Elements Inside Ending Tags
 
@@ -321,6 +321,8 @@ All components are imported from `@comet/mail-react` — never from `@faire/mjml
 | `MjmlPixelImageBlock` | re-exported `MjmlImage` | an `MjmlColumn` (standard MJML layout)         |
 | `HtmlPixelImageBlock` | raw `<img>`             | raw HTML or MJML ending tags such as `MjmlRaw` |
 
+Inside `MjmlRaw` in an `MjmlColumn`, `HtmlPixelImageBlock` needs its own `<tr>` and `<td>` — see _Start Raw Content Inside a Column With `<tr>`_ above.
+
 ```tsx
 <MjmlSection indent>
     <MjmlColumn>
@@ -378,6 +380,8 @@ export const { MjmlRichTextBlock, HtmlRichTextBlock } = createRichTextBlock({
 | ------------------- | --------------------------- | ---------------------------------------------- |
 | `MjmlRichTextBlock` | `MjmlText`                  | an `MjmlColumn` (standard MJML layout)         |
 | `HtmlRichTextBlock` | `HtmlText` (`<div>`)        | raw HTML or MJML ending tags such as `MjmlRaw` |
+
+Inside `MjmlRaw` in an `MjmlColumn`, `HtmlRichTextBlock` needs its own `<tr>` and `<td>` — see _Start Raw Content Inside a Column With `<tr>`_ above.
 
 Usage sites pass only `data`:
 

--- a/skills/comet-mail-react/references/components-and-theme.md
+++ b/skills/comet-mail-react/references/components-and-theme.md
@@ -282,13 +282,13 @@ Themed text for use inside ending tags (`MjmlText`, `MjmlRaw`) or custom HTML st
 **CSS classes:** `.htmlText`, `.htmlText--{variant}`, `.htmlText--bottomSpacing`.
 
 ```tsx
-<MjmlRaw>
-    <table>
+<MjmlColumn>
+    <MjmlRaw>
         <tr>
-            <HtmlText variant="body">Themed text inside a raw table</HtmlText>
+            <HtmlText variant="body">Themed text in a row of the column's table</HtmlText>
         </tr>
-    </table>
-</MjmlRaw>
+    </MjmlRaw>
+</MjmlColumn>
 
 <MjmlText>
     <HtmlText element="div" variant="caption">Rendered as a div</HtmlText>


### PR DESCRIPTION
The examples placed `Html*` components directly in `MjmlRaw` inside an `MjmlColumn`, where children go into the column's content table with no cell around them — the HTML parser then moves them out into the cell around that table. The `Html*` components do not add the row and cell themselves: they also serve HTML-only emails, where a `<td>` root would be invalid.

### What the fix changes in the output

`HtmlDivider` inside `MjmlRaw` in an `MjmlColumn`:

```diff
 <MjmlColumn>
     <MjmlRaw>
-        <HtmlDivider />
+        <tr>
+            <td>
+                <HtmlDivider />
+            </td>
+        </tr>
     </MjmlRaw>
 </MjmlColumn>
```

The column's content cell, from the browser's parsed DOM in Storybook:

```diff
 <td style="vertical-align:top;padding:0;">
   <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
     <tbody>
-    </tbody>
-  </table>
-  <table class="htmlDivider">…</table>
+      <tr>
+        <td>
+          <table class="htmlDivider">…</table>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </td>
```