### PR TITLE
Open Permissions tab by default in UserPermissionsPage

### DIFF
--- a/.changeset/user-permissions-default-permissions-tab.md
+++ b/.changeset/user-permissions-default-permissions-tab.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-admin": patch
+---
+
+Open the `Permissions` tab by default when editing a user in the `UserPermissionsPage`
+
+Selecting a user now opens the `Permissions` tab instead of `Basic Data`, while the tab order stays unchanged. Users without the `userPermissions` permission (who don't see the `Permissions` tab) continue to open the `Basic Data` tab.

--- a/packages/admin/cms-admin/src/userPermissions/UserPermissionsPage.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/UserPermissionsPage.tsx
@@ -28,7 +28,7 @@ export const UserPermissionsPage = () => {
                     <MainContent fullHeight>
                         <UserPermissionsUserGrid
                             rowAction={(params) => (
-                                <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id} subUrl="permissions">
+                                <IconButton color="primary" component={StackLink} pageName="edit" payload={params.row.id}>
                                     <Edit />
                                 </IconButton>
                             )}
@@ -41,12 +41,15 @@ export const UserPermissionsPage = () => {
                             <UserPermissionsUserPageToolbar userId={userId} />
                             <MainContent>
                                 <RouterTabs>
-                                    <RouterTab path="" label={<FormattedMessage id="comet.userPermissions.basicData" defaultMessage="Basic Data" />}>
+                                    <RouterTab
+                                        path={isAllowed("userPermissions") ? "/basic-data" : ""}
+                                        label={<FormattedMessage id="comet.userPermissions.basicData" defaultMessage="Basic Data" />}
+                                    >
                                         <UserPermissionsUserPageBasicDataPanel userId={userId} />
                                     </RouterTab>
                                     {isAllowed("userPermissions") && (
                                         <RouterTab
-                                            path="/permissions"
+                                            path=""
                                             label={<FormattedMessage id="comet.userPermissions.permissions" defaultMessage="Permissions" />}
                                         >
                                             <UserPermissionsUserPagePermissionsPanel userId={userId} />


### PR DESCRIPTION
## Problem

When selecting a user in the admin's `UserPermissionsPage`, the edit page opened on the `Basic Data` tab. In practice, users are most often opened to review or adjust their permissions, so the `Permissions` tab is the more useful landing point.

## Solution

Make the `Permissions` tab the default (opening) tab of the `RouterTabs`, while keeping the tab order unchanged (`Basic Data` first, `Permissions` second).

- `Permissions` now uses `path=""`, making it the tab rendered when opening the edit page.
- `Basic Data` moves to `path="/basic-data"` so it remains reachable, but only when the `Permissions` tab is actually rendered. Users without the `userPermissions` permission (e.g. those with only `impersonation`, who can reach the page but don't see the `Permissions` tab) keep `Basic Data` as their default tab via `path=""`.
- The grid row action no longer needs an explicit `subUrl="permissions"`, since the default edit URL now opens on `Permissions`.

## Result

Selecting a user opens the `Permissions` tab by default. The visual positioning of the tabs is unchanged.

## Changeset

Added a patch changeset for `@comet/cms-admin`.

https://claude.ai/code/session_01KshJBkG7HGy869SH6XybiD