### PR TITLE
cms-admin: Add read-only rendering to the TipTap rich text block

### DIFF
--- a/.changeset/tiptap-rich-text-read-only.md
+++ b/.changeset/tiptap-rich-text-read-only.md
@@ -4,10 +4,10 @@
 
 Add read-only rendering to the TipTap rich text block
 
-`createTipTapRichTextBlock` now returns a `RenderReadOnly` component that renders saved content without an editing UI, for showing the content where it must not be editable.
+`createTipTapRichTextBlock` now returns a `ReadOnlyComponent` that renders saved content without an editing UI, for showing the content where it must not be editable.
 
 ```tsx
 const RichTextBlock = createTipTapRichTextBlock();
 
-<RichTextBlock.RenderReadOnly state={state} />;
+<RichTextBlock.ReadOnlyComponent state={state} />;
 ```

--- a/.changeset/tiptap-rich-text-read-only.md
+++ b/.changeset/tiptap-rich-text-read-only.md
@@ -1,0 +1,13 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add read-only rendering to the TipTap rich text block
+
+`createTipTapRichTextBlock` now returns a `RenderReadOnly` component that renders saved content without an editing UI, for showing the content where it must not be editable.
+
+```tsx
+const RichTextBlock = createTipTapRichTextBlock();
+
+<RichTextBlock.RenderReadOnly state={state} />;
+```

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -71,6 +71,58 @@ export const Default: Story = {
     },
 };
 
+const readOnlyState: TipTapRichTextBlockState = {
+    tipTapContent: {
+        type: "doc",
+        content: [
+            {
+                type: "heading",
+                attrs: { level: 1 },
+                content: [{ type: "text", text: "Read-only content" }],
+            },
+            {
+                type: "paragraph",
+                content: [
+                    { type: "text", text: "This content is rendered " },
+                    { type: "text", marks: [{ type: "bold" }], text: "read-only" },
+                    { type: "text", text: "." },
+                ],
+            },
+        ],
+    },
+};
+
+export const ReadOnly: Story = {
+    render: () => (
+        <StoryWrapper state={readOnlyState}>
+            <TipTapRichTextBlock.RenderReadOnly state={readOnlyState} />
+        </StoryWrapper>
+    ),
+    play: async ({ canvas, canvasElement, step }) => {
+        await step("Saved content renders", async () => {
+            await waitFor(
+                () => {
+                    expect(canvas.getByRole("heading", { level: 1, name: "Read-only content" })).toBeInTheDocument();
+                    expect(canvas.getByText("read-only")).toBeInTheDocument();
+                },
+                { timeout: 5000 },
+            );
+        });
+
+        await step("No element is editable", async () => {
+            for (const element of Array.from(canvasElement.querySelectorAll("[contenteditable]"))) {
+                expect(element).toHaveAttribute("contenteditable", "false");
+            }
+        });
+
+        await step("No editing toolbar is rendered", async () => {
+            // The editor keeps its textbox role when read-only, so the toolbar's absence is the tell.
+            expect(canvas.queryByRole("combobox")).not.toBeInTheDocument();
+            expect(canvas.queryAllByRole("button")).toHaveLength(0);
+        });
+    },
+};
+
 const BoldOnlyBlock = createTipTapRichTextBlock({ supports: ["bold"] });
 
 function BoldOnlyStory() {

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -107,7 +107,7 @@ const readOnlyState: TipTapRichTextBlockState = {
 export const ReadOnly: Story = {
     render: () => (
         <StoryWrapper state={readOnlyState}>
-            <ReadOnlyBlock.RenderReadOnly state={readOnlyState} />
+            <ReadOnlyBlock.ReadOnlyComponent state={readOnlyState} />
         </StoryWrapper>
     ),
     play: async ({ canvas, canvasElement, step }) => {

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -71,6 +71,17 @@ export const Default: Story = {
     },
 };
 
+const ReadOnlyBlock = createTipTapRichTextBlock({
+    textBlockStyles: [
+        {
+            name: "intro",
+            label: "Intro Text",
+            appliesTo: ["paragraph"],
+            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 20, fontStyle: "italic" }} {...props} />,
+        },
+    ],
+});
+
 const readOnlyState: TipTapRichTextBlockState = {
     tipTapContent: {
         type: "doc",
@@ -82,6 +93,7 @@ const readOnlyState: TipTapRichTextBlockState = {
             },
             {
                 type: "paragraph",
+                attrs: { textBlockStyle: "intro" },
                 content: [
                     { type: "text", text: "This content is rendered " },
                     { type: "text", marks: [{ type: "bold" }], text: "read-only" },
@@ -95,7 +107,7 @@ const readOnlyState: TipTapRichTextBlockState = {
 export const ReadOnly: Story = {
     render: () => (
         <StoryWrapper state={readOnlyState}>
-            <TipTapRichTextBlock.RenderReadOnly state={readOnlyState} />
+            <ReadOnlyBlock.RenderReadOnly state={readOnlyState} />
         </StoryWrapper>
     ),
     play: async ({ canvas, canvasElement, step }) => {
@@ -108,6 +120,20 @@ export const ReadOnly: Story = {
                 { timeout: 5000 },
             );
         });
+
+        await step(
+            "The block's own text block style is applied — this needs the block's textBlockStyles reaching the read-only renderer",
+            async () => {
+                await waitFor(
+                    () => {
+                        const styledElement = canvasElement.querySelector('[data-text-block-style="intro"]');
+                        expect(styledElement).not.toBeNull();
+                        expect(styledElement).toHaveStyle({ fontStyle: "italic" });
+                    },
+                    { timeout: 3000 },
+                );
+            },
+        );
 
         await step("No element is editable", async () => {
             for (const element of Array.from(canvasElement.querySelectorAll("[contenteditable]"))) {

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -5,7 +5,7 @@ import Subscript from "@tiptap/extension-subscript";
 import Superscript from "@tiptap/extension-superscript";
 import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import type { ComponentType, HTMLAttributes, ReactNode } from "react";
+import { type ComponentType, type HTMLAttributes, type ReactNode, useEffect } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { createBlockSkeleton } from "../helpers/createBlockSkeleton";
@@ -329,6 +329,7 @@ const TipTapEditor = ({
     childBlocks,
     maxTextBlocks,
     listLevelMax,
+    readOnly,
 }: {
     state: TipTapRichTextBlockState;
     updateState: React.Dispatch<React.SetStateAction<TipTapRichTextBlockState>>;
@@ -340,6 +341,7 @@ const TipTapEditor = ({
     childBlocks: Record<string, TipTapChildBlock>;
     maxTextBlocks?: number;
     listLevelMax?: number;
+    readOnly?: boolean;
 }) => {
     const hasTextBlockStyles = textBlockStyles.length > 0;
     const hasInlineStyles = inlineStyles.length > 0;
@@ -381,6 +383,7 @@ const TipTapEditor = ({
             ...(listLevelMax !== undefined ? [createListLevelMaxExtension(listLevelMax)] : []),
         ],
         content: state.tipTapContent,
+        editable: !readOnly,
         onUpdate: ({ editor }) => {
             if (maxTextBlocks !== undefined && editor.state.doc.childCount > maxTextBlocks) {
                 // Remove excess text blocks (e.g. from paste)
@@ -413,41 +416,57 @@ const TipTapEditor = ({
         },
     });
 
+    // useEditor sets content once, at creation, then ignores it. Read-only content can change while
+    // mounted (e.g. a grid row re-rendering), so it needs re-syncing here. Editable content doesn't:
+    // typing already keeps state.tipTapContent in sync, and re-syncing would reset the caret.
+    useEffect(() => {
+        if (readOnly && editor) {
+            editor.commands.setContent(state.tipTapContent, { emitUpdate: false });
+        }
+    }, [readOnly, editor, state.tipTapContent]);
+
     if (!editor) {
         return null;
     }
+
+    const editorNode = <EditorContent editor={editor} />;
 
     return (
         <TextBlockStyleContext.Provider value={textBlockStyles}>
             <InlineStyleContext.Provider value={inlineStyles}>
                 <ChildBlocksContext.Provider value={childBlocksByKey}>
-                    <Box sx={{ border: `1px solid ${greyPalette[100]}`, borderTopWidth: 0, backgroundColor: "white", borderRadius: "2px" }}>
-                        <TipTapToolbar
-                            editor={editor}
-                            supports={supports}
-                            textBlockStyles={textBlockStyles}
-                            inlineStyles={inlineStyles}
-                            placeholders={placeholders}
-                            linkBlock={linkBlock}
-                            childBlocks={childBlocks}
-                            listLevelMax={listLevelMax}
-                        />
-                        <Box sx={{ "& .tiptap": { minHeight: 200, p: "20px", outline: "none" } }}>
-                            <EditorContent editor={editor} />
+                    {readOnly ? (
+                        editorNode
+                    ) : (
+                        <Box sx={{ border: `1px solid ${greyPalette[100]}`, borderTopWidth: 0, backgroundColor: "white", borderRadius: "2px" }}>
+                            <TipTapToolbar
+                                editor={editor}
+                                supports={supports}
+                                textBlockStyles={textBlockStyles}
+                                inlineStyles={inlineStyles}
+                                placeholders={placeholders}
+                                linkBlock={linkBlock}
+                                childBlocks={childBlocks}
+                                listLevelMax={listLevelMax}
+                            />
+                            <Box sx={{ "& .tiptap": { minHeight: 200, p: "20px", outline: "none" } }}>{editorNode}</Box>
                         </Box>
-                    </Box>
+                    )}
                 </ChildBlocksContext.Provider>
             </InlineStyleContext.Provider>
         </TextBlockStyleContext.Provider>
     );
 };
 
+type TipTapRichTextBlockInterface = BlockInterface<TipTapRichTextBlockData, TipTapRichTextBlockState, TipTapRichTextBlockInput> & {
+    /** Renders the block's saved state read-only, without an editing UI. */
+    RenderReadOnly: ComponentType<{ state: TipTapRichTextBlockState }>;
+};
+
 /**
  * @experimental
  */
-export const createTipTapRichTextBlock = (
-    options?: TipTapRichTextBlockFactoryOptions,
-): BlockInterface<TipTapRichTextBlockData, TipTapRichTextBlockState, TipTapRichTextBlockInput> => {
+export const createTipTapRichTextBlock = (options?: TipTapRichTextBlockFactoryOptions): TipTapRichTextBlockInterface => {
     let supports = options?.supports ?? defaultSupports;
     const textBlockStyles = options?.textBlockStyles ?? [];
     const inlineStyles = options?.inlineStyles ?? [];
@@ -464,7 +483,9 @@ export const createTipTapRichTextBlock = (
         supports = [...supports, "link"];
     }
 
-    const TipTapRichTextBlock: BlockInterface<TipTapRichTextBlockData, TipTapRichTextBlockState, TipTapRichTextBlockInput> = {
+    const sharedEditorProps = { supports, textBlockStyles, inlineStyles, placeholders, linkBlock, childBlocks, maxTextBlocks, listLevelMax };
+
+    const TipTapRichTextBlock: TipTapRichTextBlockInterface = {
         ...createBlockSkeleton(),
 
         name: "TipTapRichText",
@@ -527,22 +548,9 @@ export const createTipTapRichTextBlock = (
             };
         },
 
-        AdminComponent: ({ state, updateState }) => {
-            return (
-                <TipTapEditor
-                    state={state}
-                    updateState={updateState}
-                    supports={supports}
-                    textBlockStyles={textBlockStyles}
-                    inlineStyles={inlineStyles}
-                    placeholders={placeholders}
-                    linkBlock={linkBlock}
-                    childBlocks={childBlocks}
-                    maxTextBlocks={maxTextBlocks}
-                    listLevelMax={listLevelMax}
-                />
-            );
-        },
+        AdminComponent: ({ state, updateState }) => <TipTapEditor state={state} updateState={updateState} {...sharedEditorProps} />,
+
+        RenderReadOnly: ({ state }) => <TipTapEditor state={state} updateState={() => {}} {...sharedEditorProps} readOnly />,
 
         previewContent: (state) => {
             const text = getPlainTextFromContent(state.tipTapContent);

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -460,7 +460,7 @@ const TipTapEditor = ({
 
 type TipTapRichTextBlockInterface = BlockInterface<TipTapRichTextBlockData, TipTapRichTextBlockState, TipTapRichTextBlockInput> & {
     /** Renders the block's saved state read-only, without an editing UI. */
-    RenderReadOnly: ComponentType<{ state: TipTapRichTextBlockState }>;
+    ReadOnlyComponent: ComponentType<{ state: TipTapRichTextBlockState }>;
 };
 
 /**
@@ -550,7 +550,7 @@ export const createTipTapRichTextBlock = (options?: TipTapRichTextBlockFactoryOp
 
         AdminComponent: ({ state, updateState }) => <TipTapEditor state={state} updateState={updateState} {...sharedEditorProps} />,
 
-        RenderReadOnly: ({ state }) => <TipTapEditor state={state} updateState={() => {}} {...sharedEditorProps} readOnly />,
+        ReadOnlyComponent: ({ state }) => <TipTapEditor state={state} updateState={() => {}} {...sharedEditorProps} readOnly />,
 
         previewContent: (state) => {
             const text = getPlainTextFromContent(state.tipTapContent);


### PR DESCRIPTION
The first use case will be the table block, which renders a non-editable rich text editor in its admin grid view.

The renderer comes from the block because only the block knows what the saved content means: the content stores names, such as a text block style name or a child block key, and the block holds what those names map to. Draft-js can offer a standalone read-only component because it attaches its link and whitespace renderers to the editor state itself. TipTap keeps all of it in the block's configuration, so a renderer without the block shows unstyled text and child blocks as their raw keys.

---

Task: https://vivid-planet.atlassian.net/browse/COM-3096