### PR TITLE
cms-api: Support dextinity.com/* Kubernetes labels and annotations

### DIFF
--- a/.changeset/kubernetes-dextinity-labels.md
+++ b/.changeset/kubernetes-dextinity-labels.md
@@ -1,0 +1,28 @@
+---
+"@dextinity/cms-api": minor
+---
+
+Support `dextinity.com/*` Kubernetes labels and annotations
+
+The Builds, Cron Jobs and Kubernetes modules now read the labels and annotations of Kubernetes resources with the `dextinity.com` prefix:
+
+| Previously                      | Now                             |
+| ------------------------------- | ------------------------------- |
+| `comet-dxp.com/instance`        | `dextinity.com/instance`        |
+| `comet-dxp.com/parent-cron-job` | `dextinity.com/parent-cron-job` |
+| `comet-dxp.com/label`           | `dextinity.com/label`           |
+| `comet-dxp.com/builder`         | `dextinity.com/builder`         |
+| `comet-dxp.com/trigger`         | `dextinity.com/trigger`         |
+| `comet-dxp.com/content-scope`   | `dextinity.com/content-scope`   |
+
+The `comet-dxp.com` prefix is still supported, so existing Helm charts keep working without changes.
+Resources are expected to use one prefix or the other: if no resource matches the `dextinity.com` labels, the `comet-dxp.com` ones are used instead.
+
+**Example**
+
+```yaml
+metadata:
+    annotations:
+        dextinity.com/label: "Demo Cron Job"
+        dextinity.com/content-scope: '{ "domain": "main", "language": "en" }'
+```

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -294,7 +294,7 @@ type Build {
   id: ID!
 
   """
-  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  Human readable label provided by dextinity.com/label (or the legacy comet-dxp.com/label) annotation. Use name as fallback if not present
   """
   label: String
   name: String
@@ -307,7 +307,7 @@ type BuildTemplate {
   id: ID!
 
   """
-  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  Human readable label provided by dextinity.com/label (or the legacy comet-dxp.com/label) annotation. Use name as fallback if not present
   """
   label: String
   name: String!
@@ -770,7 +770,7 @@ type KubernetesCronJob {
   id: ID!
 
   """
-  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  Human readable label provided by dextinity.com/label (or the legacy comet-dxp.com/label) annotation. Use name as fallback if not present
   """
   label: String
   lastJobRun: KubernetesJob
@@ -785,7 +785,7 @@ type KubernetesJob {
   id: ID!
 
   """
-  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  Human readable label provided by dextinity.com/label (or the legacy comet-dxp.com/label) annotation. Use name as fallback if not present
   """
   label: String
   name: String!

--- a/docs/docs/3-features-modules/6-cron-jobs/index.md
+++ b/docs/docs/3-features-modules/6-cron-jobs/index.md
@@ -42,24 +42,30 @@ A `CronJobsPage` is available for `@dextinity/cms-admin` to display and manage C
 
 ### Scoping
 
-The Cron Job Module respects the [Kubernetes annotation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) `comet-dxp.com/content-scope` and will only allow access to the Cron Job if the user can access the specified content scope.
+The Cron Job Module respects the [Kubernetes annotation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) `dextinity.com/content-scope` and will only allow access to the Cron Job if the user can access the specified content scope.
 
 ```yaml
 …
 metadata:
     annotations:
-        comet-dxp.com/content-scope: "{ \"domain\": \"main\", \"language\": \"en\" }"
+        dextinity.com/content-scope: "{ \"domain\": \"main\", \"language\": \"en\" }"
 …
 ```
 
 ### Labeling
 
-Cron Jobs and Jobs can be given a human-readable label using the [Kubernetes annotation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) `comet-dxp.com/label`.
+Cron Jobs and Jobs can be given a human-readable label using the [Kubernetes annotation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) `dextinity.com/label`.
 
 ```yaml
 …
 metadata:
     annotations:
-        comet-dxp.com/label: "Demo Cron Job"
+        dextinity.com/label: "Demo Cron Job"
 …
 ```
+
+### Legacy `comet-dxp.com` labels and annotations
+
+All labels and annotations read by Dextinity use the `dextinity.com` prefix.
+The former `comet-dxp.com` prefix (for instance, `comet-dxp.com/content-scope`) is still supported, so existing Helm charts keep working.
+Resources are expected to use one prefix or the other: if no resource matches the `dextinity.com` labels, the `comet-dxp.com` ones are used instead.

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -163,7 +163,7 @@ type BuildTemplate {
   name: String!
 
   """
-  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  Human readable label provided by dextinity.com/label (or the legacy comet-dxp.com/label) annotation. Use name as fallback if not present
   """
   label: String
 }
@@ -180,7 +180,7 @@ type Build {
   name: String
 
   """
-  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  Human readable label provided by dextinity.com/label (or the legacy comet-dxp.com/label) annotation. Use name as fallback if not present
   """
   label: String
   trigger: String
@@ -208,7 +208,7 @@ type KubernetesCronJob {
   name: String!
 
   """
-  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  Human readable label provided by dextinity.com/label (or the legacy comet-dxp.com/label) annotation. Use name as fallback if not present
   """
   label: String
   schedule: String!
@@ -222,7 +222,7 @@ type KubernetesJob {
   name: String!
 
   """
-  Human readable label provided by comet-dxp.com/label annotation. Use name as fallback if not present
+  Human readable label provided by dextinity.com/label (or the legacy comet-dxp.com/label) annotation. Use name as fallback if not present
   """
   label: String
   status: KubernetesJobStatus!

--- a/packages/api/cms-api/src/builds/build-templates.resolver.ts
+++ b/packages/api/cms-api/src/builds/build-templates.resolver.ts
@@ -4,6 +4,7 @@ import { Query, Resolver } from "@nestjs/graphql";
 import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
 import { LABEL_ANNOTATION } from "../kubernetes/kubernetes.constants";
 import { KubernetesAuthenticationGuard } from "../kubernetes/kubernetes-authentication.guard";
+import { getAnnotation } from "../kubernetes/kubernetes-metadata";
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
 import { CurrentUser } from "../user-permissions/dto/current-user";
 import { BuildTemplatesService } from "./build-templates.service";
@@ -21,7 +22,7 @@ export class BuildTemplatesResolver {
         return builderCronJobs.map((cronJob) => ({
             id: cronJob.metadata?.uid as string,
             name: cronJob.metadata?.name as string,
-            label: cronJob.metadata?.annotations?.[LABEL_ANNOTATION],
+            label: getAnnotation(cronJob, LABEL_ANNOTATION),
         }));
     }
 }

--- a/packages/api/cms-api/src/builds/builds.constants.ts
+++ b/packages/api/cms-api/src/builds/builds.constants.ts
@@ -1,11 +1,13 @@
+import { LABEL_PREFIX } from "../kubernetes/kubernetes.constants";
+
 export const BUILDS_MODULE_OPTIONS = "builds-module-options";
 export const BUILDS_CONFIG = "builds-config";
 
 /** Annotation for the build Job: defines who triggered the build (CronJob, Manual, ChangesDetected) */
-export const TRIGGER_ANNOTATION = "comet-dxp.com/trigger";
+export const TRIGGER_ANNOTATION = `${LABEL_PREFIX}/trigger`;
 
 /** Label which identifies a build job */
-export const BUILDER_LABEL = "comet-dxp.com/builder";
+export const BUILDER_LABEL = `${LABEL_PREFIX}/builder`;
 
 /** Annotation that includes the content scope used for the CronJob or Job */
-export const CONTENT_SCOPE_ANNOTATION = "comet-dxp.com/content-scope";
+export const CONTENT_SCOPE_ANNOTATION = `${LABEL_PREFIX}/content-scope`;

--- a/packages/api/cms-api/src/builds/builds.resolver.ts
+++ b/packages/api/cms-api/src/builds/builds.resolver.ts
@@ -6,6 +6,7 @@ import { GetCurrentUser } from "../auth/decorators/get-current-user.decorator";
 import { INSTANCE_LABEL } from "../kubernetes/kubernetes.constants";
 import { KubernetesService } from "../kubernetes/kubernetes.service";
 import { KubernetesAuthenticationGuard } from "../kubernetes/kubernetes-authentication.guard";
+import { getLabel } from "../kubernetes/kubernetes-metadata";
 import { RequiredPermission } from "../user-permissions/decorators/required-permission.decorator";
 import { CurrentUser } from "../user-permissions/dto/current-user";
 import { ACCESS_CONTROL_SERVICE } from "../user-permissions/user-permissions.constants";
@@ -35,7 +36,7 @@ export class BuildsResolver {
         const cronJobs: V1CronJob[] = [];
         for (const name of names) {
             const cronJob = await this.kubernetesService.getCronJob(name);
-            if (this.kubernetesService.helmRelease !== cronJob.metadata?.labels?.[INSTANCE_LABEL]) {
+            if (this.kubernetesService.helmRelease !== getLabel(cronJob, INSTANCE_LABEL)) {
                 throw new Error("Triggering build from different instance is not allowed");
             }
 

--- a/packages/api/cms-api/src/builds/builds.service.ts
+++ b/packages/api/cms-api/src/builds/builds.service.ts
@@ -8,6 +8,7 @@ import { format } from "date-fns";
 import { KubernetesJobStatus } from "../kubernetes/job-status.enum";
 import { INSTANCE_LABEL, LABEL_ANNOTATION, PARENT_CRON_JOB_LABEL } from "../kubernetes/kubernetes.constants";
 import { KubernetesService } from "../kubernetes/kubernetes.service";
+import { getAnnotation, getLabel } from "../kubernetes/kubernetes-metadata";
 import { CurrentUser } from "../user-permissions/dto/current-user";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
 import { ACCESS_CONTROL_SERVICE } from "../user-permissions/user-permissions.constants";
@@ -100,10 +101,10 @@ export class BuildsService {
                     completionTime: job.status?.completionTime,
                     estimatedCompletionTime: await this.kubernetesService.estimateJobCompletionTime(
                         job,
-                        `${PARENT_CRON_JOB_LABEL} = ${job.metadata?.labels?.[PARENT_CRON_JOB_LABEL]}`,
+                        `${PARENT_CRON_JOB_LABEL} = ${getLabel(job, PARENT_CRON_JOB_LABEL)}`,
                     ),
-                    trigger: job.metadata?.annotations?.[TRIGGER_ANNOTATION],
-                    label: job.metadata?.annotations?.[LABEL_ANNOTATION],
+                    trigger: getAnnotation(job, TRIGGER_ANNOTATION),
+                    label: getAnnotation(job, LABEL_ANNOTATION),
                 };
             }),
         );

--- a/packages/api/cms-api/src/builds/dto/build-template.object.ts
+++ b/packages/api/cms-api/src/builds/dto/build-template.object.ts
@@ -1,6 +1,7 @@
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 
 import { LABEL_ANNOTATION } from "../../kubernetes/kubernetes.constants";
+import { toLegacyName } from "../../kubernetes/kubernetes-metadata";
 
 @ObjectType("BuildTemplate")
 export class BuildTemplateObject {
@@ -10,6 +11,9 @@ export class BuildTemplateObject {
     @Field()
     name: string;
 
-    @Field({ nullable: true, description: `Human readable label provided by ${LABEL_ANNOTATION} annotation. Use name as fallback if not present` })
+    @Field({
+        nullable: true,
+        description: `Human readable label provided by ${LABEL_ANNOTATION} (or the legacy ${toLegacyName(LABEL_ANNOTATION)}) annotation. Use name as fallback if not present`,
+    })
     label?: string;
 }

--- a/packages/api/cms-api/src/builds/dto/build.object.ts
+++ b/packages/api/cms-api/src/builds/dto/build.object.ts
@@ -2,6 +2,7 @@ import { Field, ID, ObjectType } from "@nestjs/graphql";
 
 import { KubernetesJobStatus } from "../../kubernetes/job-status.enum";
 import { LABEL_ANNOTATION } from "../../kubernetes/kubernetes.constants";
+import { toLegacyName } from "../../kubernetes/kubernetes-metadata";
 
 @ObjectType()
 export class Build {
@@ -14,7 +15,10 @@ export class Build {
     @Field({ nullable: true })
     name?: string;
 
-    @Field({ nullable: true, description: `Human readable label provided by ${LABEL_ANNOTATION} annotation. Use name as fallback if not present` })
+    @Field({
+        nullable: true,
+        description: `Human readable label provided by ${LABEL_ANNOTATION} (or the legacy ${toLegacyName(LABEL_ANNOTATION)}) annotation. Use name as fallback if not present`,
+    })
     label?: string;
 
     @Field({ nullable: true })

--- a/packages/api/cms-api/src/cron-jobs/cron-jobs.service.ts
+++ b/packages/api/cms-api/src/cron-jobs/cron-jobs.service.ts
@@ -2,6 +2,7 @@ import { V1CronJob } from "@kubernetes/client-node";
 import { Injectable } from "@nestjs/common";
 
 import { LABEL_ANNOTATION } from "../kubernetes/kubernetes.constants";
+import { getAnnotation } from "../kubernetes/kubernetes-metadata";
 import { CronJob } from "./dto/cron-job.object";
 
 @Injectable()
@@ -11,7 +12,7 @@ export class CronJobsService {
         return {
             id: cronJob.metadata?.uid as string,
             name: cronJob.metadata?.name as string,
-            label: cronJob.metadata?.annotations?.[LABEL_ANNOTATION],
+            label: getAnnotation(cronJob, LABEL_ANNOTATION),
             schedule: cronJob.spec?.schedule as string,
             suspended: cronJob.spec?.suspend as boolean,
             lastScheduledAt: cronJob.status?.lastScheduleTime,

--- a/packages/api/cms-api/src/cron-jobs/dto/cron-job.object.ts
+++ b/packages/api/cms-api/src/cron-jobs/dto/cron-job.object.ts
@@ -1,6 +1,7 @@
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 
 import { LABEL_ANNOTATION } from "../../kubernetes/kubernetes.constants";
+import { toLegacyName } from "../../kubernetes/kubernetes-metadata";
 
 @ObjectType("KubernetesCronJob")
 export class CronJob {
@@ -10,7 +11,10 @@ export class CronJob {
     @Field()
     name: string;
 
-    @Field({ nullable: true, description: `Human readable label provided by ${LABEL_ANNOTATION} annotation. Use name as fallback if not present` })
+    @Field({
+        nullable: true,
+        description: `Human readable label provided by ${LABEL_ANNOTATION} (or the legacy ${toLegacyName(LABEL_ANNOTATION)}) annotation. Use name as fallback if not present`,
+    })
     label?: string;
 
     @Field()

--- a/packages/api/cms-api/src/cron-jobs/dto/job.object.ts
+++ b/packages/api/cms-api/src/cron-jobs/dto/job.object.ts
@@ -2,6 +2,7 @@ import { Field, ID, ObjectType } from "@nestjs/graphql";
 
 import { KubernetesJobStatus } from "../../kubernetes/job-status.enum";
 import { LABEL_ANNOTATION } from "../../kubernetes/kubernetes.constants";
+import { toLegacyName } from "../../kubernetes/kubernetes-metadata";
 
 @ObjectType("KubernetesJob")
 export class Job {
@@ -11,7 +12,10 @@ export class Job {
     @Field()
     name: string;
 
-    @Field({ nullable: true, description: `Human readable label provided by ${LABEL_ANNOTATION} annotation. Use name as fallback if not present` })
+    @Field({
+        nullable: true,
+        description: `Human readable label provided by ${LABEL_ANNOTATION} (or the legacy ${toLegacyName(LABEL_ANNOTATION)}) annotation. Use name as fallback if not present`,
+    })
     label?: string;
 
     @Field(() => KubernetesJobStatus)

--- a/packages/api/cms-api/src/cron-jobs/jobs.service.ts
+++ b/packages/api/cms-api/src/cron-jobs/jobs.service.ts
@@ -4,6 +4,7 @@ import { format } from "date-fns";
 
 import { LABEL_ANNOTATION } from "../kubernetes/kubernetes.constants";
 import { KubernetesService } from "../kubernetes/kubernetes.service";
+import { getAnnotation } from "../kubernetes/kubernetes-metadata";
 import { Job } from "./dto/job.object";
 
 @Injectable()
@@ -14,7 +15,7 @@ export class JobsService {
         return {
             id: job.metadata?.uid as string,
             name: job.metadata?.name as string,
-            label: job.metadata?.annotations?.[LABEL_ANNOTATION],
+            label: getAnnotation(job, LABEL_ANNOTATION),
             startTime: job.status?.startTime,
             completionTime: job.status?.completionTime,
             status: this.kubernetesService.getStatusForKubernetesJob(job),

--- a/packages/api/cms-api/src/kubernetes/kubernetes-metadata.spec.ts
+++ b/packages/api/cms-api/src/kubernetes/kubernetes-metadata.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { LABEL_ANNOTATION, PARENT_CRON_JOB_LABEL } from "./kubernetes.constants";
+import { getAnnotation, getLabel, toLegacyLabelSelector, toLegacyName } from "./kubernetes-metadata";
+
+describe("kubernetes-metadata", () => {
+    describe("getAnnotation", () => {
+        it("should read the dextinity.com annotation", () => {
+            const resource = { metadata: { annotations: { "dextinity.com/label": "Demo Cron Job" } } };
+            expect(getAnnotation(resource, LABEL_ANNOTATION)).toBe("Demo Cron Job");
+        });
+
+        it("should fall back to the legacy annotation", () => {
+            const resource = { metadata: { annotations: { "comet-dxp.com/label": "Demo Cron Job" } } };
+            expect(getAnnotation(resource, LABEL_ANNOTATION)).toBe("Demo Cron Job");
+        });
+
+        it("should prefer the dextinity.com annotation over the legacy annotation", () => {
+            const resource = { metadata: { annotations: { "dextinity.com/label": "New", "comet-dxp.com/label": "Legacy" } } };
+            expect(getAnnotation(resource, LABEL_ANNOTATION)).toBe("New");
+        });
+
+        it("should return undefined if neither annotation is present", () => {
+            expect(getAnnotation({ metadata: {} }, LABEL_ANNOTATION)).toBeUndefined();
+        });
+    });
+
+    describe("getLabel", () => {
+        it("should fall back to the legacy label", () => {
+            const resource = { metadata: { labels: { "comet-dxp.com/parent-cron-job": "builder" } } };
+            expect(getLabel(resource, PARENT_CRON_JOB_LABEL)).toBe("builder");
+        });
+    });
+
+    describe("toLegacyLabelSelector", () => {
+        it("should rewrite all dextinity.com labels", () => {
+            expect(toLegacyLabelSelector("dextinity.com/builder = true, dextinity.com/instance = main")).toBe(
+                "comet-dxp.com/builder = true, comet-dxp.com/instance = main",
+            );
+        });
+
+        it("should return undefined for selectors without dextinity.com labels", () => {
+            expect(toLegacyLabelSelector("job-name=main-builder")).toBeUndefined();
+        });
+    });
+
+    describe("toLegacyName", () => {
+        it("should not change names without the dextinity.com prefix", () => {
+            expect(toLegacyName("job-name")).toBe("job-name");
+        });
+    });
+});

--- a/packages/api/cms-api/src/kubernetes/kubernetes-metadata.ts
+++ b/packages/api/cms-api/src/kubernetes/kubernetes-metadata.ts
@@ -1,0 +1,47 @@
+import type { V1ObjectMeta } from "@kubernetes/client-node";
+
+import { LABEL_PREFIX, LEGACY_LABEL_PREFIX } from "./kubernetes.constants";
+
+type KubernetesResource = { metadata?: V1ObjectMeta };
+
+/**
+ * Reads an annotation, falling back to the legacy `comet-dxp.com/*` annotation for resources that
+ * haven't been migrated to the `dextinity.com/*` prefix yet.
+ */
+export function getAnnotation(resource: KubernetesResource, annotation: string): string | undefined {
+    const annotations = resource.metadata?.annotations;
+    return annotations?.[annotation] ?? annotations?.[toLegacyName(annotation)];
+}
+
+/**
+ * Reads a label, falling back to the legacy `comet-dxp.com/*` label for resources that haven't been
+ * migrated to the `dextinity.com/*` prefix yet.
+ */
+export function getLabel(resource: KubernetesResource, label: string): string | undefined {
+    const labels = resource.metadata?.labels;
+    return labels?.[label] ?? labels?.[toLegacyName(label)];
+}
+
+/**
+ * Kubernetes label selectors can't express OR, so a selector using `dextinity.com/*` labels never matches
+ * resources that are still labeled with the legacy `comet-dxp.com/*` prefix. Such selectors are queried
+ * again with the legacy prefix if they don't match any resource.
+ *
+ * Returns undefined if the selector doesn't contain a `dextinity.com/*` label, as no second query is possible then.
+ */
+export function toLegacyLabelSelector(labelSelector: string): string | undefined {
+    if (!labelSelector.includes(`${LABEL_PREFIX}/`)) {
+        return undefined;
+    }
+
+    return labelSelector.replaceAll(`${LABEL_PREFIX}/`, `${LEGACY_LABEL_PREFIX}/`);
+}
+
+/** Returns the legacy `comet-dxp.com/*` name of a `dextinity.com/*` label or annotation */
+export function toLegacyName(name: string): string {
+    if (!name.startsWith(`${LABEL_PREFIX}/`)) {
+        return name;
+    }
+
+    return `${LEGACY_LABEL_PREFIX}/${name.slice(LABEL_PREFIX.length + 1)}`;
+}

--- a/packages/api/cms-api/src/kubernetes/kubernetes.constants.ts
+++ b/packages/api/cms-api/src/kubernetes/kubernetes.constants.ts
@@ -1,12 +1,18 @@
 export const KUBERNETES_CONFIG = "kubernetes-config";
 
+/** Prefix of the labels and annotations read from Kubernetes resources */
+export const LABEL_PREFIX = "dextinity.com";
+
+/** Prefix used before the rebranding to Dextinity. Labels and annotations using it are still supported. */
+export const LEGACY_LABEL_PREFIX = "comet-dxp.com";
+
 /** Label which specifies the instance a build is assigned to (Helm-Release) */
-export const INSTANCE_LABEL = "comet-dxp.com/instance";
+export const INSTANCE_LABEL = `${LABEL_PREFIX}/instance`;
 /**
  * Label which specifies the CronJob for a Job
  * k8s ownerReference is not set, if job is not created by CronJob Controller
  * */
-export const PARENT_CRON_JOB_LABEL = "comet-dxp.com/parent-cron-job";
+export const PARENT_CRON_JOB_LABEL = `${LABEL_PREFIX}/parent-cron-job`;
 
 /** Annotation for a cron job or job to provide a human readable name */
-export const LABEL_ANNOTATION = "comet-dxp.com/label";
+export const LABEL_ANNOTATION = `${LABEL_PREFIX}/label`;

--- a/packages/api/cms-api/src/kubernetes/kubernetes.service.ts
+++ b/packages/api/cms-api/src/kubernetes/kubernetes.service.ts
@@ -8,6 +8,7 @@ import { ContentScope } from "../user-permissions/interfaces/content-scope.inter
 import { KubernetesJobStatus } from "./job-status.enum";
 import { KUBERNETES_CONFIG, PARENT_CRON_JOB_LABEL } from "./kubernetes.constants";
 import { KubernetesConfig } from "./kubernetes.module";
+import { getAnnotation, toLegacyLabelSelector } from "./kubernetes-metadata";
 
 @Injectable()
 export class KubernetesService implements OnModuleInit {
@@ -64,7 +65,17 @@ export class KubernetesService implements OnModuleInit {
 
     async getAllCronJobs(labelSelector: string): Promise<V1CronJob[]> {
         const { items } = await this.batchApi.listNamespacedCronJob({ namespace: this.namespace, labelSelector });
-        return items;
+
+        const legacyLabelSelector = toLegacyLabelSelector(labelSelector);
+        if (items.length > 0 || !legacyLabelSelector) {
+            return items;
+        }
+
+        const { items: legacyItems } = await this.batchApi.listNamespacedCronJob({
+            namespace: this.namespace,
+            labelSelector: legacyLabelSelector,
+        });
+        return legacyItems;
     }
 
     async deleteJob(name: string): Promise<void> {
@@ -103,7 +114,14 @@ export class KubernetesService implements OnModuleInit {
      */
     async getAllJobs(labelSelector?: string): Promise<V1Job[]> {
         const { items } = await this.batchApi.listNamespacedJob({ namespace: this.namespace, labelSelector });
-        return items.sort((a, b) => (b.metadata?.creationTimestamp?.getTime() ?? 0) - (a.metadata?.creationTimestamp?.getTime() ?? 0));
+
+        const legacyLabelSelector = labelSelector ? toLegacyLabelSelector(labelSelector) : undefined;
+        const jobs =
+            items.length > 0 || !legacyLabelSelector
+                ? items
+                : (await this.batchApi.listNamespacedJob({ namespace: this.namespace, labelSelector: legacyLabelSelector })).items;
+
+        return jobs.sort((a, b) => (b.metadata?.creationTimestamp?.getTime() ?? 0) - (a.metadata?.creationTimestamp?.getTime() ?? 0));
     }
 
     async getAllJobsForCronJob(cronJob: string) {
@@ -178,7 +196,7 @@ export class KubernetesService implements OnModuleInit {
     }
 
     getContentScope(resource: V1Job | V1CronJob): ContentScope | null {
-        const contentScopeAnnotation = resource.metadata?.annotations?.[CONTENT_SCOPE_ANNOTATION];
+        const contentScopeAnnotation = getAnnotation(resource, CONTENT_SCOPE_ANNOTATION);
 
         if (contentScopeAnnotation) {
             let json = JSON.parse(contentScopeAnnotation);


### PR DESCRIPTION
The Builds, Cron Jobs and Kubernetes modules now read the labels and annotations of Kubernetes resources with the `dextinity.com` prefix:

| Previously                      | Now                             |
| ------------------------------- | ------------------------------- |
| `comet-dxp.com/instance`        | `dextinity.com/instance`        |
| `comet-dxp.com/parent-cron-job` | `dextinity.com/parent-cron-job` |
| `comet-dxp.com/label`           | `dextinity.com/label`           |
| `comet-dxp.com/builder`         | `dextinity.com/builder`         |
| `comet-dxp.com/trigger`         | `dextinity.com/trigger`         |
| `comet-dxp.com/content-scope`   | `dextinity.com/content-scope`   |

The `comet-dxp.com` prefix is still supported, so existing Helm charts keep working without changes.
Resources are expected to use one prefix or the other: if no resource matches the `dextinity.com` labels, the `comet-dxp.com` ones are used instead.

https://claude.ai/code/session_01AKy1ZzCsSd4BZXyuUiNemr