### PR TITLE
Migrate from @comet/dev-oidc-provider to dev-oidc-provider

### DIFF
--- a/dev-oidc-provider.config.mts
+++ b/dev-oidc-provider.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from "@comet/dev-oidc-provider";
+import { defineConfig } from "dev-oidc-provider";
 import { staticUsers } from "./demo/api/src/auth/static-users";
 
 export default defineConfig({

--- a/docs/docs/2-core-concepts/8-authentication/1-migrate-local-development-to-a-setup-with-authentication.md
+++ b/docs/docs/2-core-concepts/8-authentication/1-migrate-local-development-to-a-setup-with-authentication.md
@@ -10,7 +10,7 @@ That brings the development setup closer to the production setup as it requires 
 1. Install package
 
 ```bash
-npm i @comet/dev-oidc-provider
+npm i dev-oidc-provider
 ```
 
 2. Add configuration variables to `.env`
@@ -18,8 +18,8 @@ npm i @comet/dev-oidc-provider
 ```env
 # idp
 IDP_PORT=8080
-IDP_CLIENT_ID=comet-oidc-client
-IDP_CLIENT_SECRET=comet-oidc-secret
+IDP_CLIENT_ID=dev-oidc-client
+IDP_CLIENT_SECRET=dev-oidc-secret
 IDP_SSO_URL=http://${DEV_DOMAIN:-localhost}:${IDP_PORT}
 IDP_JWKS_URI=http://${DEV_DOMAIN:-localhost}:${IDP_PORT}/jwks
 IDP_END_SESSION_ENDPOINT=http://${DEV_DOMAIN:-localhost}:${IDP_PORT}/session/end
@@ -30,7 +30,7 @@ IDP_END_SESSION_ENDPOINT=http://${DEV_DOMAIN:-localhost}:${IDP_PORT}/session/end
 It might be possible that you have to alter the implementation of the `userProvider`-callback according to your `staticUsers`.
 
 ```ts
-import { defineConfig } from "@comet/dev-oidc-provider";
+import { defineConfig } from "dev-oidc-provider";
 import { staticUsers } from "./api/src/auth/static-users";
 
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "devDependencies": {
         "@changesets/cli": "^2.31.1",
         "@comet/cli": "workspace:*",
-        "@comet/dev-oidc-provider": "^1.2.1",
         "@formatjs/cli": "^6.7.2",
         "@types/node": "^24.13.3",
+        "dev-oidc-provider": "^2.0.0",
         "dev-process-manager": "^4.0.0",
         "dotenv-cli": "^9.0.0",
         "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,15 +17,15 @@ importers:
       '@comet/cli':
         specifier: workspace:*
         version: link:packages/cli
-      '@comet/dev-oidc-provider':
-        specifier: ^1.2.1
-        version: 1.2.1
       '@formatjs/cli':
         specifier: ^6.7.2
         version: 6.7.4(@vue/compiler-core@3.5.15)
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
+      dev-oidc-provider:
+        specifier: ^2.0.0
+        version: 2.0.0
       dev-process-manager:
         specifier: ^4.0.0
         version: 4.0.0
@@ -4135,11 +4135,6 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@comet/dev-oidc-provider@1.2.1':
-    resolution: {integrity: sha512-+fL5srKQ3gIoSCIBZr1dMoZEEGeMh3WOI8pb63fuK5jiEwEjFagqxlS3GKNRk72FXTAQaypG0dftqU2a2sMXHQ==}
-    engines: {node: '>=22'}
-    hasBin: true
-
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
@@ -6064,6 +6059,12 @@ packages:
     resolution: {integrity: sha512-LBSu5K0qAaaQcXX/0WIB9PGDevyCxxpnc1uq13vV/CgObaVxuis5hKl3Eboq/8gcb6ebnkAStW9NB/Em2eYyFA==}
     engines: {node: '>= 20'}
     deprecated: Please upgrade to v15 or higher. All reported bugs in this version are fixed in newer releases, dependencies have been updated, and security has been improved.
+
+  '@koa/router@15.7.0':
+    resolution: {integrity: sha512-WaAlk4TOl/O0rhTpOR0l052gz03syPMmI6Pe2gd7v3ubjfv5UcSGcnb0Y/J5NNC/ln+5FiUqPJTc/a15I+XqAA==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      koa: ^2.0.0 || ^3.0.0
 
   '@kubernetes/client-node@1.4.0':
     resolution: {integrity: sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==}
@@ -10244,6 +10245,10 @@ packages:
     resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -10871,6 +10876,11 @@ packages:
     resolution: {integrity: sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==}
     hasBin: true
 
+  dev-oidc-provider@2.0.0:
+    resolution: {integrity: sha512-7GXMNWpHEMmNXwW6IxTbtGTiKReNX8+V2Y0z6uWEmpnTDHYzb0oZZBkgkOghf2YSPohpN+jXNZJehD98pHWc7Q==}
+    engines: {node: '>=22'}
+    hasBin: true
+
   dev-process-manager@4.0.0:
     resolution: {integrity: sha512-xwQB6nyh4nfTOPQrYh1wuAfDQRRr/R3yJCqcOs5Fv01qXMwgnWccuIRyvl+zWfvkYgbp129zCn+yUmsCqjdz0Q==}
     engines: {node: '>=22'}
@@ -11479,8 +11489,8 @@ packages:
     resolution: {integrity: sha512-UVQ72Rqjy/ZKQalzV5dCCJP80GrmPrMxh6NlNf+erV6ObL0ZFkhCstWRawS85z3smdr3d2wXPsZEY7rDPfGd2g==}
     engines: {node: '>=6.0.0'}
 
-  eta@4.4.1:
-    resolution: {integrity: sha512-4o6fYxhRmFmO9SJcU9PxBLYPGapvJ/Qha0ZE+Y6UE9QIUd0Wk1qaLISQ6J1bM7nOcWHhs1YmY3mfrfwkJRBTWQ==}
+  eta@4.6.0:
+    resolution: {integrity: sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==}
     engines: {node: '>=20'}
 
   etag@1.8.1:
@@ -12929,8 +12939,8 @@ packages:
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
-  jose@6.1.1:
-    resolution: {integrity: sha512-GWSqjfOPf4cWOkBzw5THBjtGPhXKqYnfRBzh4Ni+ArTrQQ9unvmsA3oFLqaYKoKe5sjWmGu5wVKg9Ft1i+LQfg==}
+  jose@6.2.8:
+    resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -13150,8 +13160,8 @@ packages:
   koa-compose@4.1.0:
     resolution: {integrity: sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==}
 
-  koa@3.1.1:
-    resolution: {integrity: sha512-KDDuvpfqSK0ZKEO2gCPedNjl5wYpfj+HNiuVRlbhd1A88S3M0ySkdf2V/EJ4NWt5dwh5PXCdcenrKK2IQJAxsg==}
+  koa@3.2.1:
+    resolution: {integrity: sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==}
     engines: {node: '>= 18'}
 
   kolorist@1.8.0:
@@ -14034,9 +14044,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
-    engines: {node: ^18 || >=20}
+  nanoid@6.0.1:
+    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
+    engines: {node: ^22 || ^24 || >=26}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -14264,8 +14274,8 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  oidc-provider@9.5.2:
-    resolution: {integrity: sha512-lTI6U7ESvf34xuu9XPUfJX6sbIXuOsV2MUPT9YoT7dzDtajufc50iWSY2t/4xB/TuFQ4t0Q++JU2Cu270d11pg==}
+  oidc-provider@9.11.2:
+    resolution: {integrity: sha512-Z7CZzWtBfcNMSaIoNJwHmEbla6h4mW73soOAJM4Qo9XDALMgQ1J+amMg/FBZJD1BHoec1KLL5BHFDkvlgeUZqw==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -15341,6 +15351,10 @@ packages:
   raw-body@3.0.1:
     resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
     engines: {node: '>= 0.10'}
+
+  raw-body@4.0.0:
+    resolution: {integrity: sha512-TMHtwexrgOt9VJ2E5JF9RO8mRXGNgC5wXvKkc5AVSJUt1L5gxvjg7eiCQl96EqUEpCWrnNEkCnbAplYtyuq1IA==}
+    engines: {node: '>=22'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -19608,16 +19622,6 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@comet/dev-oidc-provider@1.2.1':
-    dependencies:
-      '@koa/ejs': 5.1.0
-      '@koa/router': 14.0.0
-      koa-body: 6.0.1
-      oidc-provider: 9.5.2
-      unconfig: 7.5.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -22278,6 +22282,16 @@ snapshots:
     dependencies:
       debug: 4.4.3
       http-errors: 2.0.1
+      koa-compose: 4.1.0
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@koa/router@15.7.0(koa@3.2.1)':
+    dependencies:
+      debug: 4.4.3
+      http-errors: 2.0.1
+      koa: 3.2.1
       koa-compose: 4.1.0
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
@@ -27249,6 +27263,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.0.1: {}
+
   content-type@1.0.5: {}
 
   convert-source-map@1.9.0: {}
@@ -27869,6 +27885,16 @@ snapshots:
     dependencies:
       address: 1.2.2
       debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  dev-oidc-provider@2.0.0:
+    dependencies:
+      '@koa/ejs': 5.1.0
+      '@koa/router': 14.0.0
+      koa-body: 6.0.1
+      oidc-provider: 9.11.2
+      unconfig: 7.5.0
     transitivePeerDependencies:
       - supports-color
 
@@ -28655,7 +28681,7 @@ snapshots:
 
   eta@2.2.0: {}
 
-  eta@4.4.1: {}
+  eta@4.6.0: {}
 
   etag@1.8.1: {}
 
@@ -30385,7 +30411,7 @@ snapshots:
 
   jose@5.10.0: {}
 
-  jose@6.1.1: {}
+  jose@6.2.8: {}
 
   joycon@3.1.1: {}
 
@@ -30647,10 +30673,10 @@ snapshots:
 
   koa-compose@4.1.0: {}
 
-  koa@3.1.1:
+  koa@3.2.1:
     dependencies:
       accepts: 1.3.8
-      content-disposition: 0.5.4
+      content-disposition: 1.0.1
       content-type: 1.0.5
       cookies: 0.9.1
       delegates: 1.0.0
@@ -31996,7 +32022,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  nanoid@5.1.6: {}
+  nanoid@6.0.1: {}
 
   natural-compare@1.4.0: {}
 
@@ -32225,18 +32251,18 @@ snapshots:
 
   obug@2.1.1: {}
 
-  oidc-provider@9.5.2:
+  oidc-provider@9.11.2:
     dependencies:
       '@koa/cors': 5.0.0
-      '@koa/router': 14.0.0
+      '@koa/router': 15.7.0(koa@3.2.1)
       debug: 4.4.3
-      eta: 4.4.1
-      jose: 6.1.1
+      eta: 4.6.0
+      jose: 6.2.8
       jsesc: 3.1.0
-      koa: 3.1.1
-      nanoid: 5.1.6
+      koa: 3.2.1
+      nanoid: 6.0.1
       quick-lru: 7.3.0
-      raw-body: 3.0.1
+      raw-body: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -33413,6 +33439,11 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.7.0
       unpipe: 1.0.0
+
+  raw-body@4.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
 
   rc@1.2.8:
     dependencies:

--- a/skills/comet-minor-update/SKILL.md
+++ b/skills/comet-minor-update/SKILL.md
@@ -16,7 +16,7 @@ Two rules hold across every `@comet/*` core package in the project, before and a
 - **Pinned versions only.** Every core `@comet/*` entry must be an exact version (e.g. `8.21.0`), never a range (`^8.21.0`, `~8.21.0`, `>=…`). If you see a caret or tilde on a core package, the project is in a broken state — stop and tell the user.
 - **All core packages on the same version.** Every core `@comet/*` package in the project must be pinned to the same version across every `package.json`. There is no supported mix-and-match.
 
-These rules apply only to the core set (packages released together from the Comet monorepo). Satellite `@comet/*` packages — anything released outside the monorepo, on its own cadence — are out of scope — see Step 1.
+These rules apply only to the core set (packages released together from the Comet monorepo). Any other `@comet/*` package a project happens to depend on is out of scope — see Step 1.
 
 ## When to use
 
@@ -60,8 +60,8 @@ grep -n '"@comet/' package.json api/package.json admin/package.json \
 
 Notes:
 
-- Not every `@comet/*` package follows the core release cadence. Packages that live outside the core monorepo may use a different versioning scheme (often `^x.y.z`). **Only** bump packages whose current version matches the core Comet version (the one shared by `@comet/cms-api`, `@comet/admin`, `@comet/site-nextjs`, etc.). Leave the others untouched.
-- Use the invariants to tell core from satellite: core packages are all pinned to the same exact version, with no caret or tilde. Anything with a range or a different version is not core — verify before touching it.
+- Not every `@comet/*` dependency you find follows the core release cadence. The dev tools once published as `@comet/dev-process-manager` and `@comet/dev-oidc-provider` have been renamed to `dev-process-manager` and `dev-oidc-provider`, but a project that hasn't migrated yet still depends on the old scoped names — on their own versioning scheme (often `^x.y.z`), unrelated to the core version. **Only** bump packages whose current version matches the core Comet version (the one shared by `@comet/cms-api`, `@comet/admin`, `@comet/site-nextjs`, etc.). Leave the others untouched.
+- Use the invariants to tell core from non-core: core packages are all pinned to the same exact version, with no caret or tilde. Anything with a range or a different version is not core — verify before touching it.
 - If you find core packages on different versions, or any core package using a range (`^`, `~`), the project violates the invariants. Stop and tell the user — don't paper over it by bumping.
 
 Confirm the **current major** from the version string (e.g. `8.20.4` → major `8`).
@@ -184,7 +184,7 @@ Tell the user:
 | Pitfall                                             | How to avoid                                                                                        |
 | --------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | Picking a canary/beta as "newest"                   | Filter out any version containing `-` in Step 2.                                                    |
-| Bumping a satellite `@comet/*` package by accident  | Only bump packages pinned to the shared core version — see Step 1.                                  |
+| Bumping a non-core `@comet/*` package by accident   | Only bump packages pinned to the shared core version — see Step 1.                                  |
 | Forgetting the root `package.json`                  | The repo root has its own `package.json` with `@comet/cli`. Always include it in the grep.          |
 | Assuming "up to date" means the install did nothing | It means the lockfile already satisfies the new range. Verify with `grep` against the lockfile.     |
 | Running installs in parallel in a sandbox           | If `&` backgrounding fails, just run the installs sequentially. Takes a bit longer, works reliably. |

--- a/skills/comet-minor-update/SKILL.md
+++ b/skills/comet-minor-update/SKILL.md
@@ -16,7 +16,7 @@ Two rules hold across every `@comet/*` core package in the project, before and a
 - **Pinned versions only.** Every core `@comet/*` entry must be an exact version (e.g. `8.21.0`), never a range (`^8.21.0`, `~8.21.0`, `>=…`). If you see a caret or tilde on a core package, the project is in a broken state — stop and tell the user.
 - **All core packages on the same version.** Every core `@comet/*` package in the project must be pinned to the same version across every `package.json`. There is no supported mix-and-match.
 
-These rules apply only to the core set (packages released together from the Comet monorepo). Satellite packages like `@comet/dev-oidc-provider` are out of scope — see Step 1.
+These rules apply only to the core set (packages released together from the Comet monorepo). Satellite `@comet/*` packages — anything released outside the monorepo, on its own cadence — are out of scope — see Step 1.
 
 ## When to use
 
@@ -60,7 +60,7 @@ grep -n '"@comet/' package.json api/package.json admin/package.json \
 
 Notes:
 
-- Not every `@comet/*` package follows the core release cadence. Packages that live outside the core monorepo (for example `@comet/dev-oidc-provider`) may use a different versioning scheme (often `^x.y.z`). **Only** bump packages whose current version matches the core Comet version (the one shared by `@comet/cms-api`, `@comet/admin`, `@comet/site-nextjs`, etc.). Leave the others untouched.
+- Not every `@comet/*` package follows the core release cadence. Packages that live outside the core monorepo may use a different versioning scheme (often `^x.y.z`). **Only** bump packages whose current version matches the core Comet version (the one shared by `@comet/cms-api`, `@comet/admin`, `@comet/site-nextjs`, etc.). Leave the others untouched.
 - Use the invariants to tell core from satellite: core packages are all pinned to the same exact version, with no caret or tilde. Anything with a range or a different version is not core — verify before touching it.
 - If you find core packages on different versions, or any core package using a range (`^`, `~`), the project violates the invariants. Stop and tell the user — don't paper over it by bumping.
 
@@ -100,7 +100,7 @@ grep -n '<OLD_VERSION>' package.json api/package.json admin/package.json \
 
 If every match is a `@comet/*` line, you can safely edit each file. If there are non-`@comet` matches, edit the `@comet` lines individually.
 
-**Do not touch** packages like `@comet/dev-oidc-provider` that don't share the core version — see Step 1.
+**Do not touch** `@comet/*` packages that don't share the core version — see Step 1.
 
 ---
 
@@ -181,11 +181,11 @@ Tell the user:
 
 ## Common pitfalls
 
-| Pitfall                                                     | How to avoid                                                                                        |
-| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Picking a canary/beta as "newest"                           | Filter out any version containing `-` in Step 2.                                                    |
-| Bumping `@comet/dev-oidc-provider` (or similar) by accident | Only bump packages pinned to the shared core version — see Step 1.                                  |
-| Forgetting the root `package.json`                          | The repo root has its own `package.json` with `@comet/cli`. Always include it in the grep.          |
-| Assuming "up to date" means the install did nothing         | It means the lockfile already satisfies the new range. Verify with `grep` against the lockfile.     |
-| Running installs in parallel in a sandbox                   | If `&` backgrounding fails, just run the installs sequentially. Takes a bit longer, works reliably. |
-| Crossing a major version                                    | This skill is minor/patch only. Stop and warn the user.                                             |
+| Pitfall                                             | How to avoid                                                                                        |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Picking a canary/beta as "newest"                   | Filter out any version containing `-` in Step 2.                                                    |
+| Bumping a satellite `@comet/*` package by accident  | Only bump packages pinned to the shared core version — see Step 1.                                  |
+| Forgetting the root `package.json`                  | The repo root has its own `package.json` with `@comet/cli`. Always include it in the grep.          |
+| Assuming "up to date" means the install did nothing | It means the lockfile already satisfies the new range. Verify with `grep` against the lockfile.     |
+| Running installs in parallel in a sandbox           | If `&` backgrounding fails, just run the installs sequentially. Takes a bit longer, works reliably. |
+| Crossing a major version                            | This skill is minor/patch only. Stop and warn the user.                                             |


### PR DESCRIPTION
Migrates the project from @comet/dev-oidc-provider to dev-oidc-provider v2. Replaces all references to the old package with the new one. Replaces Comet references in the docs with neutral terms, for instance, `dev-oidc-client`.

https://claude.ai/code/session_01NLN6geCXaqqDEJLsZY87ZR
