### PR TITLE
Count each permission only once in a user's permissionsCount

### DIFF
--- a/.changeset/user-permissions-distinct-permissions-count.md
+++ b/.changeset/user-permissions-distinct-permissions-count.md
@@ -1,0 +1,7 @@
+---
+"@comet/cms-api": patch
+---
+
+Count each permission only once in the `permissionsCount` of a user
+
+A permission that is granted both by rule and manually was counted twice, so the permissions count shown for a user in the admin could exceed the number of available permissions. It now counts distinct permissions.

--- a/packages/api/cms-api/src/user-permissions/user.resolver.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/user.resolver.spec.ts
@@ -1,0 +1,21 @@
+import { createMock } from "@golevelup/ts-vitest";
+import { describe, expect, it } from "vitest";
+
+import type { UserPermissionsUser } from "./dto/user";
+import type { UserPermission } from "./entities/user-permission.entity";
+import { UserResolver } from "./user.resolver";
+import type { UserContentScopesLoaderService } from "./user-content-scopes-loader.service";
+import type { UserPermissionsService } from "./user-permissions.service";
+
+describe("UserResolver", () => {
+    describe("permissionsCount", () => {
+        it("counts a permission granted both by rule and manually only once", async () => {
+            const userService = createMock<UserPermissionsService>({
+                getPermissions: async () => [{ permission: "pageTree" }, { permission: "pageTree" }, { permission: "dam" }] as UserPermission[],
+            });
+            const resolver = new UserResolver(userService, createMock<UserContentScopesLoaderService>());
+
+            expect(await resolver.permissionsCount({ id: "1" } as UserPermissionsUser)).toBe(2);
+        });
+    });
+});

--- a/packages/api/cms-api/src/user-permissions/user.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user.resolver.ts
@@ -114,7 +114,8 @@ export class UserResolver {
 
     @ResolveField(() => Int)
     async permissionsCount(@Parent() user: UserPermissionsUser): Promise<number> {
-        return (await this.userService.getPermissions(user)).length;
+        // Count distinct permissions: a permission can be granted both by rule and manually, but must only be counted once.
+        return new Set((await this.userService.getPermissions(user)).map((permission) => permission.permission)).size;
     }
 
     @ResolveField(() => Int)


### PR DESCRIPTION
## Problem

The `permissionsCount` field resolver for a user counted `getPermissions(user).length`. A permission can be granted **both** by rule and manually, in which case `getPermissions` returns it twice — so the permissions count shown for a user in the admin users list could be inflated and even exceed the number of available permissions (e.g. "19 of 18 permissions").

## Solution

Count **distinct** permissions by deduplicating on the permission name.

```ts
return new Set((await this.userService.getPermissions(user)).map((permission) => permission.permission)).size;
```

Adds a unit test covering a permission granted both by rule and manually.

## Note

This is an independent bugfix, extracted from the user-permissions content-scope stack (#6114 → #6115 → #6116) so it can be reviewed and merged on its own. It does not depend on that stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JVwZJtKmfrQq2VZmPAB76j)_