### PR TITLE
Restore package versions and add changesets for the Dextinity rebranding

### DIFF
--- a/.changeset/rename-admin-babel-preset-to-dextinity.md
+++ b/.changeset/rename-admin-babel-preset-to-dextinity.md
@@ -1,0 +1,12 @@
+---
+"@dextinity/admin-babel-preset": major
+---
+
+Rename `@comet/admin-babel-preset` to `@dextinity/admin-babel-preset`
+
+Update the dependency in `package.json` and the preset name in your Babel configuration:
+
+```diff
+- "presets": ["@comet/admin-babel-preset"]
++ "presets": ["@dextinity/admin-babel-preset"]
+```

--- a/.changeset/rename-admin-color-picker-to-dextinity.md
+++ b/.changeset/rename-admin-color-picker-to-dextinity.md
@@ -1,0 +1,11 @@
+---
+"@dextinity/admin-color-picker": major
+---
+
+Rename `@comet/admin-color-picker` to `@dextinity/admin-color-picker`
+
+Update the dependency in `package.json` and all imports.
+
+**Breaking changes**
+
+- Rename the theme component prefix from `CometAdmin` to `DextinityAdmin`. This affects `components` overrides passed to `createDextinityTheme` and the generated CSS class names

--- a/.changeset/rename-admin-date-time-to-dextinity.md
+++ b/.changeset/rename-admin-date-time-to-dextinity.md
@@ -1,0 +1,11 @@
+---
+"@dextinity/admin-date-time": major
+---
+
+Rename `@comet/admin-date-time` to `@dextinity/admin-date-time`
+
+Update the dependency in `package.json` and all imports.
+
+**Breaking changes**
+
+- Rename the theme component prefix from `CometAdmin` to `DextinityAdmin`. This affects `components` overrides passed to `createDextinityTheme` and the generated CSS class names

--- a/.changeset/rename-admin-generator-to-dextinity.md
+++ b/.changeset/rename-admin-generator-to-dextinity.md
@@ -1,0 +1,19 @@
+---
+"@dextinity/admin-generator": major
+---
+
+Rename `@comet/admin-generator` to `@dextinity/admin-generator`
+
+Update the dependency in `package.json` and all imports.
+
+**Breaking changes**
+
+- Rename the `comet-admin-generator` binary to `dextinity-admin-generator`:
+
+    ```diff
+    - "generate-admin": "comet-admin-generator generate"
+    + "generate-admin": "dextinity-admin-generator generate"
+    ```
+
+- Rename the config file suffix from `.cometGen.tsx` to `.dextinityGen.tsx`. The default file pattern is now `src/**/*.dextinityGen.{ts,tsx}`
+- Change the header of generated files. Rerun the generator to update them

--- a/.changeset/rename-admin-icons-to-dextinity.md
+++ b/.changeset/rename-admin-icons-to-dextinity.md
@@ -1,0 +1,21 @@
+---
+"@dextinity/admin-icons": major
+---
+
+Rename `@comet/admin-icons` to `@dextinity/admin-icons`
+
+Update the dependency in `package.json` and all imports.
+
+**Breaking changes**
+
+- Remove the `Comet` and `CometOutline` icons
+- Remove the `CometColor` component. Use `DextinityIcon` instead, which provides the `light`, `dark` and `masked` variants
+- Remove the `CometDigitalExperienceLogo` component. Use `DextinityLogo` instead, which provides the `light`, `dark` and `monochrome` variants
+- Rename the `CometColor` member of the `IconName` type to `DextinityIcon`
+
+`DextinityIcon` and `DextinityLogo` derive their size from `fontSize`, so call sites no longer pass `width`/`height` pairs:
+
+```diff
+- <CometDigitalExperienceLogo width={132} height={30} />
++ <DextinityLogo sx={{ fontSize: 30 }} />
+```

--- a/.changeset/rename-admin-rte-to-dextinity.md
+++ b/.changeset/rename-admin-rte-to-dextinity.md
@@ -1,0 +1,12 @@
+---
+"@dextinity/admin-rte": major
+---
+
+Rename `@comet/admin-rte` to `@dextinity/admin-rte`
+
+Update the dependency in `package.json` and all imports.
+
+**Breaking changes**
+
+- Rename the theme component prefix from `CometAdmin` to `DextinityAdmin`. This affects `components` overrides passed to `createDextinityTheme` and the generated CSS class names
+- Rename the `--comet-admin-rte-outer-border-color` CSS variable to `--dextinity-admin-rte-outer-border-color`

--- a/.changeset/rename-admin-to-dextinity.md
+++ b/.changeset/rename-admin-to-dextinity.md
@@ -1,0 +1,19 @@
+---
+"@dextinity/admin": major
+---
+
+Rename `@comet/admin` to `@dextinity/admin`
+
+Update the dependency in `package.json` and all imports:
+
+```diff
+- import { MainContent } from "@comet/admin";
++ import { MainContent } from "@dextinity/admin";
+```
+
+**Breaking changes**
+
+- Rename `createCometTheme` to `createDextinityTheme`
+- Rename the theme component prefix from `CometAdmin` to `DextinityAdmin`. This affects `components` overrides passed to `createDextinityTheme`, the `name` passed to `useThemeProps` in custom components and the generated CSS class names (`.CometAdminClearInputAdornment-root` -> `.DextinityAdminClearInputAdornment-root`)
+- Rename the CSS variables from `--comet-admin-*` to `--dextinity-admin-*`, for instance, `--comet-admin-master-layout-content-top-spacing` -> `--dextinity-admin-master-layout-content-top-spacing`
+- Remove the `CometLogo` component. Use `DextinityLogo` from `@dextinity/admin-icons` instead

--- a/.changeset/rename-agent-features-to-dextinity.md
+++ b/.changeset/rename-agent-features-to-dextinity.md
@@ -1,0 +1,11 @@
+---
+"@dextinity/agent-features": major
+---
+
+Rename `@comet/agent-features` to `@dextinity/agent-features`
+
+Update the dependency in `package.json`.
+
+**Breaking changes**
+
+- Rename the skills to Dextinity: `comet-admin-ui` -> `dextinity-admin-ui`, `comet-block` -> `dextinity-block`, `comet-core-admin-component-authoring` -> `dextinity-core-admin-component-authoring`, `comet-mail-react` -> `dextinity-mail-react`, `comet-major-migration` -> `dextinity-major-migration` and `comet-minor-update` -> `dextinity-minor-update`. Rerun `dextinity install-agent-features` and remove the previously installed skills

--- a/.changeset/rename-api-generator-to-dextinity.md
+++ b/.changeset/rename-api-generator-to-dextinity.md
@@ -1,0 +1,18 @@
+---
+"@dextinity/api-generator": major
+---
+
+Rename `@comet/api-generator` to `@dextinity/api-generator`
+
+Update the dependency in `package.json` and all imports.
+
+**Breaking changes**
+
+- Rename the `comet-api-generator` binary to `dextinity-api-generator`:
+
+    ```diff
+    - "generate-crud": "comet-api-generator"
+    + "generate-crud": "dextinity-api-generator"
+    ```
+
+- Change the header of generated files. Rerun the generator to update them

--- a/.changeset/rename-brevo-admin-to-dextinity.md
+++ b/.changeset/rename-brevo-admin-to-dextinity.md
@@ -1,0 +1,11 @@
+---
+"@dextinity/brevo-admin": major
+---
+
+Rename `@comet/brevo-admin` to `@dextinity/brevo-admin`
+
+Update the dependency in `package.json` and all imports.
+
+**Breaking changes**
+
+- Resolve the configuration via `DextinityConfigProvider` instead of `CometConfigProvider`

--- a/.changeset/rename-brevo-api-to-dextinity.md
+++ b/.changeset/rename-brevo-api-to-dextinity.md
@@ -1,0 +1,12 @@
+---
+"@dextinity/brevo-api": major
+---
+
+Rename `@comet/brevo-api` to `@dextinity/brevo-api`
+
+Update the dependency in `package.json` and all imports:
+
+```diff
+- import { BrevoModule } from "@comet/brevo-api";
++ import { BrevoModule } from "@dextinity/brevo-api";
+```

--- a/.changeset/rename-cli-to-dextinity.md
+++ b/.changeset/rename-cli-to-dextinity.md
@@ -1,0 +1,16 @@
+---
+"@dextinity/cli": major
+---
+
+Rename `@comet/cli` to `@dextinity/cli`
+
+Update the dependency in `package.json`.
+
+**Breaking changes**
+
+- Rename the `comet` binary to `dextinity`:
+
+    ```diff
+    - "generate-block-types": "comet generate-block-types"
+    + "generate-block-types": "dextinity generate-block-types"
+    ```

--- a/.changeset/rename-cms-admin-to-dextinity.md
+++ b/.changeset/rename-cms-admin-to-dextinity.md
@@ -1,0 +1,17 @@
+---
+"@dextinity/cms-admin": major
+---
+
+Rename `@comet/cms-admin` to `@dextinity/cms-admin`
+
+Update the dependency in `package.json` and all imports.
+
+**Breaking changes**
+
+- Rename `CometConfigProvider` to `DextinityConfigProvider`, `useCometConfig` to `useDextinityConfig` and the `CometConfig` type to `DextinityConfig`. By convention, the project's `comet-config.json` is renamed to `dextinity-config.json`
+- Rename the `cometType` property of iframe messages to `dextinityType`. The site must use a matching `@dextinity/site-react` or `@dextinity/site-nextjs` version
+- Rename the site preview cookie from `__comet_site_preview` to `__dextinity_site_preview` and the impersonation cookie from `comet-impersonate-user-id` to `dextinity-impersonate-user-id`
+- Expect the renamed `DextinityImageResolutionException` and `DextinityValidationException` error codes in DAM file uploads. A matching `@dextinity/cms-api` version is required
+- Rename the theme component prefix from `CometAdmin` to `DextinityAdmin`. This affects `components` overrides passed to `createDextinityTheme` and the generated CSS class names
+- Rename the CSS variables from `--comet-admin-*` to `--dextinity-admin-*`
+- Replace the Comet logo in the header, the about modal and the site preview with the Dextinity logo

--- a/.changeset/rename-cms-api-to-dextinity.md
+++ b/.changeset/rename-cms-api-to-dextinity.md
@@ -1,0 +1,14 @@
+---
+"@dextinity/cms-api": major
+---
+
+Rename `@comet/cms-api` to `@dextinity/cms-api`
+
+Update the dependency in `package.json` and all imports.
+
+**Breaking changes**
+
+- Rename `CometException` and its subclasses: `CometValidationException` -> `DextinityValidationException`, `CometEntityNotFoundException` -> `DextinityEntityNotFoundException`, `CometImageResolutionException` -> `DextinityImageResolutionException`. The error codes returned by the API change accordingly, so a matching `@dextinity/cms-admin` version is required
+- Rename `CometAuthGuard` to `DextinityAuthGuard` and the `@DisableCometGuards()` decorator to `@DisableDextinityGuards()`
+- Rename the database tables `CometFileUpload`, `CometUserPermission` and `CometUserContentScopes` to `DextinityFileUpload`, `DextinityUserPermission` and `DextinityUserContentScopes`. A migration is shipped with the package, so running the migrations is sufficient
+- Rename the site preview cookie from `__comet_site_preview` to `__dextinity_site_preview` and the impersonation cookie from `comet-impersonate-user-id` to `dextinity-impersonate-user-id`

--- a/.changeset/rename-eslint-config-to-dextinity.md
+++ b/.changeset/rename-eslint-config-to-dextinity.md
@@ -1,0 +1,16 @@
+---
+"@dextinity/eslint-config": major
+---
+
+Rename `@comet/eslint-config` to `@dextinity/eslint-config`
+
+Update the dependency in `package.json` and the imports in your ESLint configuration:
+
+```diff
+- import eslintConfigReact from "@comet/eslint-config/future/react.js";
++ import eslintConfigReact from "@dextinity/eslint-config/future/react.js";
+```
+
+**Breaking changes**
+
+- Rename the plugin namespace from `@comet` to `@dextinity`. Rule overrides and disable comments must be updated, for instance, `@comet/no-other-module-relative-import` -> `@dextinity/no-other-module-relative-import`

--- a/.changeset/rename-eslint-plugin-to-dextinity.md
+++ b/.changeset/rename-eslint-plugin-to-dextinity.md
@@ -1,0 +1,11 @@
+---
+"@dextinity/eslint-plugin": major
+---
+
+Rename `@comet/eslint-plugin` to `@dextinity/eslint-plugin`
+
+Update the dependency in `package.json`.
+
+**Breaking changes**
+
+- Register the plugin under the `@dextinity` namespace instead of `@comet`. Rule names change accordingly, for instance, `@comet/no-private-sibling-import` -> `@dextinity/no-private-sibling-import`

--- a/.changeset/rename-mail-react-to-dextinity.md
+++ b/.changeset/rename-mail-react-to-dextinity.md
@@ -1,0 +1,12 @@
+---
+"@dextinity/mail-react": major
+---
+
+Rename `@comet/mail-react` to `@dextinity/mail-react`
+
+Update the dependency in `package.json` and all imports:
+
+```diff
+- import { MjmlPixelImageBlock } from "@comet/mail-react";
++ import { MjmlPixelImageBlock } from "@dextinity/mail-react";
+```

--- a/.changeset/rename-site-nextjs-to-dextinity.md
+++ b/.changeset/rename-site-nextjs-to-dextinity.md
@@ -1,0 +1,12 @@
+---
+"@dextinity/site-nextjs": major
+---
+
+Rename `@comet/site-nextjs` to `@dextinity/site-nextjs`
+
+Update the dependency in `package.json` and all imports.
+
+**Breaking changes**
+
+- Rename the `cometType` property of iframe messages to `dextinityType`. A matching `@dextinity/cms-admin` version is required
+- Rename the site preview cookie from `__comet_site_preview` to `__dextinity_site_preview`. A matching `@dextinity/cms-api` version is required

--- a/.changeset/rename-site-react-to-dextinity.md
+++ b/.changeset/rename-site-react-to-dextinity.md
@@ -1,0 +1,12 @@
+---
+"@dextinity/site-react": major
+---
+
+Rename `@comet/site-react` to `@dextinity/site-react`
+
+Update the dependency in `package.json` and all imports.
+
+**Breaking changes**
+
+- Rename the `cometType` property of iframe messages to `dextinityType`. A matching `@dextinity/cms-admin` version is required
+- Rename the window property of `useLocalStorageCookieApi` from `window.cometLocalStorageCookieApi` to `window.dextinityLocalStorageCookieApi` and its localStorage key from `comet-dev-cookie-api-consented-cookies` to `dextinity-dev-cookie-api-consented-cookies`. Previously consented cookies are therefore reset in local development

--- a/packages/admin/admin-babel-preset/package.json
+++ b/packages/admin/admin-babel-preset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/admin-babel-preset",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/vivid-planet/comet",

--- a/packages/admin/admin-color-picker/package.json
+++ b/packages/admin/admin-color-picker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/admin-color-picker",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Dextinity Admin Color Picker component",
     "repository": {
         "directory": "packages/admin/admin-color-picker",

--- a/packages/admin/admin-date-time/package.json
+++ b/packages/admin/admin-date-time/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/admin-date-time",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Dextinity Admin Date Time component",
     "repository": {
         "directory": "packages/admin/admin-date-time",

--- a/packages/admin/admin-generator/package.json
+++ b/packages/admin/admin-generator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/admin-generator",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Dextinity Admin Generator CLI tool",
     "repository": {
         "directory": "packages/admin/admin-generator",

--- a/packages/admin/admin-icons/package.json
+++ b/packages/admin/admin-icons/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/admin-icons",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "A collection of icons for Dextinity Admin",
     "repository": {
         "directory": "packages/admin/admin-icons",

--- a/packages/admin/admin-rte/package.json
+++ b/packages/admin/admin-rte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/admin-rte",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Dextinity Admin Rich Text Editor component",
     "repository": {
         "directory": "packages/admin/admin-rte",

--- a/packages/admin/admin/package.json
+++ b/packages/admin/admin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/admin",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Dextinity Admin package",
     "repository": {
         "directory": "packages/admin/admin",

--- a/packages/admin/brevo-admin/package.json
+++ b/packages/admin/brevo-admin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/brevo-admin",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/vivid-planet/comet/",

--- a/packages/admin/cms-admin/package.json
+++ b/packages/admin/cms-admin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/cms-admin",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Dextinity CMS Admin package",
     "repository": {
         "directory": "packages/admin/cms-admin",

--- a/packages/agent-features/package.json
+++ b/packages/agent-features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/agent-features",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Agent features (skills and rules) for Dextinity projects",
     "repository": {
         "directory": "packages/agent-features",

--- a/packages/api/api-generator/package.json
+++ b/packages/api/api-generator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/api-generator",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Dextinity API Generator CLI tool",
     "repository": {
         "directory": "packages/api/api-generator",

--- a/packages/api/brevo-api/package.json
+++ b/packages/api/brevo-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/brevo-api",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/vivid-planet/comet/",

--- a/packages/api/cms-api/package.json
+++ b/packages/api/cms-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/cms-api",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Dextinity CMS API package",
     "repository": {
         "directory": "packages/api/cms-api",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/cli",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "A collection of CLI tools for Dextinity projects",
     "repository": {
         "directory": "packages/cli",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/eslint-config",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "A set of ESLint configurations for Dextinity projects",
     "repository": {
         "directory": "packages/eslint-config",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/eslint-plugin",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "A set of ESLint rules and configurations for Dextinity projects",
     "type": "commonjs",
     "main": "lib/index.js",

--- a/packages/mail-react/package.json
+++ b/packages/mail-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/mail-react",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Utilities for building HTML emails with React",
     "license": "BSD-2-Clause",
     "type": "module",

--- a/packages/site/site-nextjs/package.json
+++ b/packages/site/site-nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/site-nextjs",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Dextinity Site Next.js package",
     "repository": {
         "type": "git",

--- a/packages/site/site-react/package.json
+++ b/packages/site/site-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dextinity/site-react",
-    "version": "1.0.0",
+    "version": "9.2.2",
     "description": "Dextinity Site React package",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The rebranding reset all package versions from `9.2.2` to `1.0.0` in #6069, treating the rename as a fresh v1. That decision was reverted, so the version history has to continue where it left off and the rebranding has to ship as a regular major version instead.

On top of that, none of the rebranding pull requests (#6069–#6110) added a changeset, so the release would ship without a changelog documenting the rename.

Note that this pull request doesn't rename anything — the renames already landed in #6069–#6110. It only restores the versions and documents the rebranding.

## Changes

-   Restore `9.2.2` in the 19 published `@dextinity/*` packages, reverting exactly what #6069 reset. `storybook`, `docs` and `demo/*` are unaffected: their versions were never changed and they're ignored by Changesets. All inter-package dependencies use `workspace:*`, so no version ranges change
-   Add one `major` changeset per package. `.changeset/config.json` has `fixed: [["@dextinity/*"]]`, so all packages bump to `10.0.0` together either way — the per-package split keeps each `CHANGELOG.md` free of other packages' breaking changes

## Example

`.changeset/rename-cms-api-to-dextinity.md`:

```md
---
"@dextinity/cms-api": major
---

Rename `@comet/cms-api` to `@dextinity/cms-api`

Update the dependency in `package.json` and all imports.

**Breaking changes**

- Rename `CometException` and its subclasses: …
- Rename `CometAuthGuard` to `DextinityAuthGuard` and the `@DisableCometGuards()` decorator to `@DisableDextinityGuards()`
- Rename the database tables `CometFileUpload`, `CometUserPermission` and `CometUserContentScopes` …
- Rename the site preview cookie from `__comet_site_preview` to `__dextinity_site_preview` …
```

## Documented breaking changes

Each changeset lists only its own package's changes:

| Package | Documented changes |
| --- | --- |
| `admin` | `createCometTheme` → `createDextinityTheme`, `CometAdmin*` theme/CSS class prefix, `--comet-admin-*` CSS variables, removed `CometLogo` |
| `admin-icons` | Removed `Comet` and `CometOutline` icons, `CometColor` → `DextinityIcon`, `CometDigitalExperienceLogo` → `DextinityLogo`, `IconName` union, sizing via `fontSize` |
| `admin-rte`, `admin-color-picker`, `admin-date-time` | `CometAdmin*` theme prefix, `--comet-admin-rte-outer-border-color` |
| `cms-admin` | `DextinityConfigProvider`/`useDextinityConfig`, `cometType` → `dextinityType`, cookies, renamed API error codes, theme prefix and CSS variables, Dextinity logo |
| `brevo-admin` | Configuration via `DextinityConfigProvider` |
| `cms-api` | Exceptions, `DextinityAuthGuard`/`@DisableDextinityGuards()`, table renames (migration included), cookies |
| `admin-generator`, `api-generator`, `cli` | Binary names, `.cometGen.tsx` → `.dextinityGen.tsx`, generated file headers |
| `site-react`, `site-nextjs` | `cometType` → `dextinityType`, site preview cookie, `window.dextinityLocalStorageCookieApi` |
| `eslint-config`, `eslint-plugin` | `@comet` → `@dextinity` plugin namespace and rule names |
| `agent-features` | Renamed skills |
| `brevo-api`, `admin-babel-preset`, `mail-react` | Rename only |

The Format.js message ID rename (`comet.*` → `dextinity.*`) is intentionally not documented, as those message IDs are library-internal.

https://claude.ai/code/session_0167GgRxzC9X26EDu6zERYmv