### PR TITLE
admin: Add `disabled` support to `ToggleButtonGroupField`

### DIFF
--- a/.changeset/toggle-button-group-field-disabled.md
+++ b/.changeset/toggle-button-group-field-disabled.md
@@ -1,0 +1,21 @@
+---
+"@comet/admin": minor
+---
+
+Add `disabled` support to `ToggleButtonGroupField`
+
+Setting `disabled` on the field was accepted but had no effect — every button stayed clickable. It now disables all buttons, and individual options can be disabled by setting `disabled` on the option. When both are set, the field wins — an option cannot re-enable itself.
+
+**Example**
+
+```tsx
+<ToggleButtonGroupField
+    name="type"
+    options={[
+        { label: "Address", value: "address" },
+        { label: "Coordinates", value: "coordinates", disabled: true },
+    ]}
+/>
+```
+
+`FinalFormToggleButtonGroup` now also supports `sx`, `className`, `slotProps` and theme customization through `CometAdminFinalFormToggleButtonGroup`, with the new `FinalFormToggleButtonGroupClassKey` type describing its slots.

--- a/packages/admin/admin/src/form/FinalFormToggleButtonGroup.tsx
+++ b/packages/admin/admin/src/form/FinalFormToggleButtonGroup.tsx
@@ -1,73 +1,115 @@
-import { ButtonBase, Typography, type TypographyProps } from "@mui/material";
-import { css, styled } from "@mui/material/styles";
+import { ButtonBase, Typography } from "@mui/material";
+import { type ComponentsOverrides, css, type Theme, useThemeProps } from "@mui/material/styles";
 import type { ReactNode } from "react";
 import type { FieldRenderProps } from "react-final-form";
 
-export type FinalFormToggleButtonGroupProps<FieldValue> = {
-    options: Array<{ value: FieldValue; label: ReactNode }>;
+import { createComponentSlot } from "../helpers/createComponentSlot";
+import type { ThemedComponentBaseProps } from "../helpers/ThemedComponentBaseProps";
+
+export type FinalFormToggleButtonGroupClassKey = "root" | "button" | "label" | "selected" | "disabled";
+
+export interface FinalFormToggleButtonGroupProps<FieldValue>
+    extends ThemedComponentBaseProps<{
+        root: "div";
+        button: typeof ButtonBase;
+        label: typeof Typography;
+    }> {
+    options: Array<{ value: FieldValue; label: ReactNode; disabled?: boolean }>;
+    optionsPerRow?: number;
+    disabled?: boolean;
+}
+
+type FinalFormToggleButtonGroupInternalProps<FieldValue> = FieldRenderProps<FieldValue, HTMLDivElement>;
+
+type RootOwnerState = {
     optionsPerRow?: number;
 };
 
-type FinalFormToggleButtonGroupInternalProps<FieldValue> = FieldRenderProps<FieldValue, HTMLDivElement>;
+type ButtonOwnerState = {
+    selected: boolean;
+    disabled: boolean;
+};
 
 /**
  * Final Form-compatible ToggleButtonGroup component.
  *
  * @see {@link ToggleButtonGroupField} – preferred for typical form use. Use this only if no Field wrapper is needed.
  */
-export function FinalFormToggleButtonGroup<FieldValue = unknown>({
-    input: { value, onChange },
-    options,
-    optionsPerRow,
-}: FinalFormToggleButtonGroupProps<FieldValue> & FinalFormToggleButtonGroupInternalProps<FieldValue>) {
+export function FinalFormToggleButtonGroup<FieldValue = unknown>(
+    inProps: FinalFormToggleButtonGroupProps<FieldValue> & FinalFormToggleButtonGroupInternalProps<FieldValue>,
+) {
+    const {
+        input: { value, onChange },
+        meta,
+        options,
+        optionsPerRow,
+        disabled,
+        slotProps,
+        ...restProps
+    } = useThemeProps({ props: inProps, name: "CometAdminFinalFormToggleButtonGroup" });
+
     return (
-        <Root $optionsPerRow={optionsPerRow}>
-            {options.map(({ value: optionValue, label }, index) => (
-                <Button key={index} $selected={value === optionValue} onClick={() => onChange(optionValue)} focusRipple>
-                    <Label component="span" variant="body2">
-                        {label}
-                    </Label>
-                </Button>
-            ))}
+        <Root ownerState={{ optionsPerRow }} {...slotProps?.root} {...restProps}>
+            {options.map(({ value: optionValue, label, disabled: optionDisabled }, index) => {
+                const buttonDisabled = Boolean(disabled) || Boolean(optionDisabled);
+
+                return (
+                    <Button
+                        key={index}
+                        ownerState={{ selected: value === optionValue, disabled: buttonDisabled }}
+                        focusRipple
+                        {...slotProps?.button}
+                        onClick={() => onChange(optionValue)}
+                        disabled={buttonDisabled}
+                    >
+                        <Label variant="body2" {...slotProps?.label} variantMapping={{ body2: "span", ...slotProps?.label?.variantMapping }}>
+                            {label}
+                        </Label>
+                    </Button>
+                );
+            })}
         </Root>
     );
 }
 
-const Label = styled(Typography)<{ component: TypographyProps["component"] }>`
-    display: flex;
-    align-items: center;
-`;
+const Root = createComponentSlot("div")<FinalFormToggleButtonGroupClassKey, RootOwnerState>({
+    componentName: "FinalFormToggleButtonGroup",
+    slotName: "root",
+})(
+    ({ theme, ownerState }) => css`
+        display: inline-flex;
+        min-height: 40px;
+        border: 1px solid ${theme.palette.divider};
+        background-color: ${theme.palette.divider};
+        border-radius: 2px;
+        overflow: hidden;
+        gap: 1px;
 
-const Root = styled("div", { shouldForwardProp: (prop) => prop !== "$optionsPerRow" })<{ $optionsPerRow?: number }>`
-    display: inline-flex;
-    min-height: 40px;
-    border: 1px solid ${({ theme }) => theme.palette.divider};
-    background-color: ${({ theme }) => theme.palette.divider};
-    border-radius: 2px;
-    overflow: hidden;
-    gap: 1px;
-
-    ${({ $optionsPerRow }) =>
-        $optionsPerRow &&
+        ${ownerState.optionsPerRow &&
         css`
             display: inline-grid;
-            grid-template-columns: repeat(${$optionsPerRow}, 1fr);
+            grid-template-columns: repeat(${ownerState.optionsPerRow}, 1fr);
         `}
-`;
+    `,
+);
 
-const Button = styled(ButtonBase, { shouldForwardProp: (prop) => prop !== "$selected" })<{ $selected?: boolean }>`
-    padding-left: ${({ theme }) => theme.spacing(3)};
-    padding-right: ${({ theme }) => theme.spacing(3)};
-    padding-top: 9px;
-    padding-bottom: 9px;
-    background-color: ${({ theme }) => theme.palette.background.paper};
+const Button = createComponentSlot(ButtonBase)<FinalFormToggleButtonGroupClassKey, ButtonOwnerState>({
+    componentName: "FinalFormToggleButtonGroup",
+    slotName: "button",
+    classesResolver: ({ selected, disabled }) => [selected && "selected", disabled && "disabled"],
+})(
+    ({ theme, ownerState }) => css`
+        padding-left: ${theme.spacing(3)};
+        padding-right: ${theme.spacing(3)};
+        padding-top: 9px;
+        padding-bottom: 9px;
+        background-color: ${theme.palette.background.paper};
 
-    :hover {
-        background-color: ${({ theme }) => theme.palette.grey[50]};
-    }
+        :hover {
+            background-color: ${theme.palette.grey[50]};
+        }
 
-    ${({ $selected, theme }) =>
-        $selected &&
+        ${ownerState.selected &&
         css`
             color: ${theme.palette.primary.main};
 
@@ -81,4 +123,40 @@ const Button = styled(ButtonBase, { shouldForwardProp: (prop) => prop !== "$sele
                 background-color: ${theme.palette.primary.main};
             }
         `}
-`;
+
+        ${ownerState.disabled &&
+        css`
+            color: ${theme.palette.action.disabled};
+            background-color: ${theme.palette.grey[50]};
+
+            :before {
+                background-color: ${theme.palette.action.disabled};
+            }
+        `}
+    `,
+);
+
+const Label = createComponentSlot(Typography)<FinalFormToggleButtonGroupClassKey>({
+    componentName: "FinalFormToggleButtonGroup",
+    slotName: "label",
+})(css`
+    display: flex;
+    align-items: center;
+`);
+
+declare module "@mui/material/styles" {
+    interface ComponentsPropsList {
+        CometAdminFinalFormToggleButtonGroup: FinalFormToggleButtonGroupProps<unknown>;
+    }
+
+    interface ComponentNameToClassKey {
+        CometAdminFinalFormToggleButtonGroup: FinalFormToggleButtonGroupClassKey;
+    }
+
+    interface Components {
+        CometAdminFinalFormToggleButtonGroup?: {
+            defaultProps?: Partial<ComponentsPropsList["CometAdminFinalFormToggleButtonGroup"]>;
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminFinalFormToggleButtonGroup"];
+        };
+    }
+}

--- a/packages/admin/admin/src/form/__stories__/ToggleButtonGroupField.stories.tsx
+++ b/packages/admin/admin/src/form/__stories__/ToggleButtonGroupField.stories.tsx
@@ -37,6 +37,69 @@ export default config;
  */
 export const ToggleButtonFieldStory: Story = {
     name: "Toggle Button Field",
+    args: {
+        label: "Sample Type",
+        name: "type",
+        disabled: false,
+        options: [
+            {
+                label: "Label",
+                value: "label",
+            },
+            {
+                label: "Label 2",
+                value: "label-2",
+            },
+            {
+                label: <Info />,
+                value: "icon",
+            },
+            {
+                label: (
+                    <Box display="flex" gap={2} alignItems="center" component="span">
+                        <Info />
+                        Icon and Label
+                    </Box>
+                ),
+                value: "icon+label",
+            },
+        ],
+    },
+    render: (args) => {
+        interface FormValues {
+            type: string;
+        }
+        return (
+            <FinalForm<FormValues>
+                initialValues={{ type: "label" }}
+                mode="edit"
+                onSubmit={() => {
+                    // not handled
+                }}
+                subscription={{ values: true }}
+            >
+                {({ values }) => {
+                    return (
+                        <>
+                            <ToggleButtonGroupField {...args} />
+
+                            <Alert title="FormState">
+                                <pre>{JSON.stringify(values, null, 2)}</pre>
+                            </Alert>
+                        </>
+                    );
+                }}
+            </FinalForm>
+        );
+    },
+};
+
+/**
+ * Individual options can be disabled by setting `disabled` on the option.
+ *
+ * Setting `disabled` on the field itself disables the whole group — an option cannot re-enable itself in that case.
+ */
+export const DisabledOptions: Story = {
     render: () => {
         type SampleType = "label" | "label-2" | "icon" | "icon+label";
         interface FormValues {
@@ -63,12 +126,14 @@ export const ToggleButtonFieldStory: Story = {
                                         value: "label",
                                     },
                                     {
-                                        label: "Label 2",
+                                        label: "Disabled",
                                         value: "label-2",
+                                        disabled: true,
                                     },
                                     {
                                         label: <Info />,
                                         value: "icon",
+                                        disabled: true,
                                     },
                                     {
                                         label: (

--- a/packages/admin/admin/src/form/fields/ToggleButtonGroupField.tsx
+++ b/packages/admin/admin/src/form/fields/ToggleButtonGroupField.tsx
@@ -9,11 +9,29 @@ export type ToggleButtonGroupFieldProps<FieldValue> = FieldProps<FieldValue, HTM
  * This is especially useful when the user needs to choose between different types
  * of input for the same conceptual field — for example, selecting between an address or coordinate.
  */
-export function ToggleButtonGroupField<FieldValue = unknown>({ options, optionsPerRow, ...restProps }: ToggleButtonGroupFieldProps<FieldValue>) {
+export function ToggleButtonGroupField<FieldValue = unknown>({
+    options,
+    optionsPerRow,
+    slotProps,
+    sx,
+    className,
+    ...restProps
+}: ToggleButtonGroupFieldProps<FieldValue>) {
     return (
         <Field {...restProps}>
             {(fieldProps) => {
-                return <FinalFormToggleButtonGroup input={fieldProps.input} meta={fieldProps.meta} options={options} optionsPerRow={optionsPerRow} />;
+                return (
+                    <FinalFormToggleButtonGroup
+                        input={fieldProps.input}
+                        meta={fieldProps.meta}
+                        options={options}
+                        optionsPerRow={optionsPerRow}
+                        disabled={fieldProps.disabled}
+                        slotProps={slotProps}
+                        sx={sx}
+                        className={className}
+                    />
+                );
             }}
         </Field>
     );

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -174,7 +174,11 @@ export { FinalFormNumberInput, type FinalFormNumberInputProps } from "./form/Fin
 export { FinalFormRangeInput, type FinalFormRangeInputClassKey, type FinalFormRangeInputProps } from "./form/FinalFormRangeInput";
 export { FinalFormSearchTextField, type FinalFormSearchTextFieldProps } from "./form/FinalFormSearchTextField";
 export { FinalFormSelect, type FinalFormSelectProps } from "./form/FinalFormSelect";
-export { FinalFormToggleButtonGroup, type FinalFormToggleButtonGroupProps } from "./form/FinalFormToggleButtonGroup";
+export {
+    FinalFormToggleButtonGroup,
+    type FinalFormToggleButtonGroupClassKey,
+    type FinalFormToggleButtonGroupProps,
+} from "./form/FinalFormToggleButtonGroup";
 export { FormSection, type FormSectionClassKey, type FormSectionProps } from "./form/FormSection";
 export { OnChangeField } from "./form/helpers/OnChangeField";
 export { FinalFormRadio, type FinalFormRadioProps } from "./form/Radio";


### PR DESCRIPTION
`FieldProps` already declares `disabled`, so passing it type-checked while the render callback silently dropped it.

The move to `createComponentSlot` is not separable from the fix: a disabled button needs its own styling, since `ButtonBase` blocks the click but leaves the colors untouched, and a styled state needs a class key, which plain `styled()` cannot give it.

#### Before, for comparison — the field in its normal state:

<img width="343" alt="Toggle button group with four enabled options, the first selected in blue with a blue underline" src="https://github.com/user-attachments/assets/35c4b5ee-2f20-490a-ae27-29c4bf3c695c" />

#### `disabled` on the field — every button is greyed out, and the selected option keeps its underline in grey:

<img width="343" alt="The same toggle button group fully disabled, all four options in grey text on a grey background with grey icons, the selected option marked by a grey underline" src="https://github.com/user-attachments/assets/a2b4cff2-293a-46c9-800b-4b0ef1257d74" />

#### `disabled` on individual options — only those two are greyed out, the rest stay selectable:

<img width="352" alt="Toggle button group with the second and third options greyed out while the first and fourth remain enabled, the first still selected in blue" src="https://github.com/user-attachments/assets/736956ab-9fa8-4193-8f09-5a8952522d15" />