### PR TITLE
cms-admin: Rename TipTap block type entry "Default" to "Paragraph"

### DIFF
--- a/.changeset/tiptap-block-type-paragraph-label.md
+++ b/.changeset/tiptap-block-type-paragraph-label.md
@@ -1,0 +1,5 @@
+---
+"@comet/cms-admin": patch
+---
+
+Rename the TipTap block type dropdown's `Default` entry to `Paragraph`, after the HTML tag it produces

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -366,7 +366,7 @@ export const TipTapToolbar = ({
                             sx={selectSx}
                         >
                             <MenuItem value="paragraph" dense>
-                                <FormattedMessage id="comet.blocks.tipTapRichText.textBlockType.default" defaultMessage="Default" />
+                                <FormattedMessage id="comet.blocks.tipTapRichText.textBlockType.paragraph" defaultMessage="Paragraph" />
                             </MenuItem>
                             {([1, 2, 3, 4, 5, 6] as const).map((level) => (
                                 <MenuItem key={level} value={String(level)} dense>

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -53,9 +53,9 @@ export const Default: Story = {
                 { timeout: 5000 },
             );
 
-            // Heading select shows "Default"
+            // Block type select shows "Paragraph"
             expect(canvas.getByRole("combobox")).toBeInTheDocument();
-            expect(canvas.getByText("Default")).toBeInTheDocument();
+            expect(canvas.getByText("Paragraph")).toBeInTheDocument();
 
             // Toolbar has buttons (undo, redo, bold, italic, strike, more, ol, ul, indent, dedent, nbsp, shy)
             const buttons = canvas.getAllByRole("button");
@@ -141,7 +141,7 @@ export const TextBlockStyles: StoryObj<typeof TextBlockStylesStory> = {
     render: () => <TextBlockStylesStory />,
     play: async ({ canvas, userEvent, step }) => {
         await step("Editor is ready with text block style dropdown", async () => {
-            // Both heading select and text block style select show "Default"
+            // Block type select shows "Paragraph", text block style select shows "Default"
             await waitFor(
                 () => {
                     const comboboxes = canvas.getAllByRole("combobox");
@@ -150,8 +150,9 @@ export const TextBlockStyles: StoryObj<typeof TextBlockStylesStory> = {
                 { timeout: 5000 },
             );
 
-            const defaults = canvas.getAllByText("Default");
-            expect(defaults.length).toBeGreaterThanOrEqual(2);
+            const comboboxes = canvas.getAllByRole("combobox");
+            expect(comboboxes[0]).toHaveTextContent("Paragraph");
+            expect(comboboxes[1]).toHaveTextContent("Default");
         });
 
         await step("Select text block style 'Intro Text'", async () => {


### PR DESCRIPTION
The first toolbar dropdown selects the block's HTML tag (paragraph vs. heading). Its non-heading entry was labeled "Default", which did not convey that it produces a paragraph.

_As discussed here: https://github.com/vivid-planet/comet/pull/6004#issuecomment-4990673903_