### PR TITLE
[Backport v8] Fix auto assigning

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -3,7 +3,7 @@ addAssignees: author
 addReviewers: true
 
 reviewers:
-    - johnnyomair
+    - VPS-Obi
 
 skipKeywords:
     - Merge main into next

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,10 @@
+name: "Auto Assign"
+on:
+    pull_request:
+        types: [opened, ready_for_review]
+
+jobs:
+    auto-assign:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: kentaro-m/auto-assign-action@v2.0.2


### PR DESCRIPTION
Backport of #5918 to `v8.x.x`.

Clean cherry-pick, no conflicts. Only `.github/` CI configuration is touched (no packages changed), so no package build/lint/demo verification applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_012tKRdTMdhcfvHVrZdrBFz8)_