### PR TITLE
mail-react: Fix full-width button overflow in certain webmail clients

### DIFF
--- a/.changeset/mail-react-full-width-button-overflow.md
+++ b/.changeset/mail-react-full-width-button-overflow.md
@@ -1,0 +1,7 @@
+---
+"@comet/mail-react": patch
+---
+
+Fix the full-width button overflowing its container in some webmail clients
+
+A `MjmlButton` or `HtmlButton` with `fullWidth` set rendered wider than the content around it, reaching past the edge of the mail body.

--- a/packages/mail-react/src/components/button/HtmlButton.tsx
+++ b/packages/mail-react/src/components/button/HtmlButton.tsx
@@ -54,8 +54,6 @@ export function HtmlButton({
 
     const anchorStyle: CSSProperties = {
         display: fullWidth ? "block" : "inline-block",
-        boxSizing: fullWidth ? "border-box" : undefined,
-        width: fullWidth ? "100%" : undefined,
         backgroundColor,
         backgroundImage: getDefaultOrUndefined(mergedStyles.backgroundImage),
         color: getDefaultOrUndefined(mergedStyles.color),

--- a/packages/mail-react/src/components/button/MjmlButton.tsx
+++ b/packages/mail-react/src/components/button/MjmlButton.tsx
@@ -133,8 +133,6 @@ registerStyles(
     css`
         .mjmlButton--fullWidth a {
             display: block !important;
-            width: 100% !important;
-            box-sizing: border-box !important;
             text-align: center !important;
         }
     `,

--- a/packages/mail-react/src/components/button/__stories__/HtmlButton.stories.tsx
+++ b/packages/mail-react/src/components/button/__stories__/HtmlButton.stories.tsx
@@ -259,8 +259,6 @@ export const FullWidthOnMobile: Story = {
                     }
                     .mobileFullWidth a {
                         display: block !important;
-                        width: 100% !important;
-                        box-sizing: border-box !important;
                         text-align: center !important;
                     }
                 }

--- a/packages/mail-react/src/components/button/__stories__/MjmlButton.stories.tsx
+++ b/packages/mail-react/src/components/button/__stories__/MjmlButton.stories.tsx
@@ -190,8 +190,6 @@ export const FullWidthOnMobile: Story = {
                     }
                     .mobileFullWidth a {
                         display: block !important;
-                        width: 100% !important;
-                        box-sizing: border-box !important;
                         text-align: center !important;
                     }
                 }

--- a/packages/mail-react/src/components/button/__tests__/HtmlButton.test.tsx
+++ b/packages/mail-react/src/components/button/__tests__/HtmlButton.test.tsx
@@ -106,18 +106,13 @@ describe("HtmlButton", () => {
         expect(html).toContain("background-image:linear-gradient(to right, red, blue)");
     });
 
-    it("spans the full width when fullWidth is set", () => {
+    it("adds the full-width modifier class when fullWidth is set", () => {
         const html = renderToStaticMarkup(
             <HtmlButton href="https://example.com" fullWidth>
                 Full width
             </HtmlButton>,
         );
 
-        // fullWidth spans the table (width attribute, honored by Outlook) and fills the
-        // anchor (display:block + width:100%) so the whole button area is clickable.
-        expect(html).toContain('width="100%"');
-        expect(html).toContain("display:block");
-        expect(html).toContain("width:100%");
         expect(html).toContain("htmlButton--fullWidth");
     });
 

--- a/packages/mail-react/src/components/button/__tests__/MjmlButton.test.tsx
+++ b/packages/mail-react/src/components/button/__tests__/MjmlButton.test.tsx
@@ -107,14 +107,13 @@ describe("MjmlButton", () => {
         expect(html).toContain("mjmlButton--fullWidth");
     });
 
-    it("inlines the full-width styles onto the anchor so they survive clients that drop the style block", () => {
+    it("leaves no full-width rule in a style block, so it survives clients that drop them", () => {
         const { html } = renderInMailRoot(
             <MjmlButton href="https://example.com" fullWidth>
                 Full width
             </MjmlButton>,
         );
 
-        expect(html).toContain("box-sizing: border-box");
         expect(html).not.toMatch(/\.mjmlButton--fullWidth a\s*\{/);
     });
 


### PR DESCRIPTION
`display: block` already sizes the anchor on its own: it fills the cell and lays its padding inside that width. 
So `width: 100%` added nothing, and `box-sizing: border-box` was only there to correct for the width.

Both can go. Where `box-sizing` is supported the rendered width does not change; in webmail clients like AOL and Yahoo that lack it, the padding was added to the 100% width and pushed the anchor past its container.

#### Full-Width Button Previously - Yahoo Web-Mail in Chrome on Windows 10

<img width="1049" height="448" alt="Full-Width Button Previously - Yahoo com Chrome Windows 10" src="https://github.com/user-attachments/assets/265a1a15-b674-4284-b778-4e93f1d2bec7" /> 

#### Full-Width Button Now - Yahoo Web-Mail in Chrome on Windows 10

<img width="1049" height="448" alt="Full-Width Button Now - Yahoo com Chrome Windows 10" src="https://github.com/user-attachments/assets/8535a70a-91c0-4212-817e-d106d95b5a0b" />