### PR TITLE
Extract scope comparison into `contentScopesAreEqual`

### DIFF
--- a/packages/api/cms-api/src/dam/files/files.controller.ts
+++ b/packages/api/cms-api/src/dam/files/files.controller.ts
@@ -30,7 +30,7 @@ import { createHashedPath } from "../../blob-storage/utils/create-hashed-path.ut
 import { CometValidationException } from "../../common/errors/validation.exception";
 import { FileUploadInput } from "../../file-utils/file-upload.input";
 import { calculatePartialRanges, slugifyFilename } from "../../file-utils/files.utils";
-import { ContentScopeService } from "../../user-permissions/content-scope.service";
+import { contentScopesAreEqual } from "../../user-permissions/content-scopes-are-equal";
 import { RequiredPermission } from "../../user-permissions/decorators/required-permission.decorator";
 import { CurrentUser } from "../../user-permissions/dto/current-user";
 import { ACCESS_CONTROL_SERVICE } from "../../user-permissions/user-permissions.constants";
@@ -67,7 +67,6 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
             private readonly filesService: FilesService,
             private readonly blobStorageBackendService: BlobStorageBackendService,
             @Inject(ACCESS_CONTROL_SERVICE) private accessControlService: AccessControlServiceInterface,
-            private readonly contentScopeService: ContentScopeService,
             private readonly foldersService: FoldersService,
         ) {}
 
@@ -97,7 +96,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
                 if (!folder) {
                     throw new BadRequestException(`Folder ${folderId} not found`);
                 }
-                if (!this.contentScopeService.scopesAreEqual(folder.scope, scope)) {
+                if (!contentScopesAreEqual(folder.scope, scope)) {
                     throw new BadRequestException("Folder scope doesn't match passed scope");
                 }
             }
@@ -136,7 +135,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
                 if (!folder) {
                     throw new BadRequestException(`Folder ${folderId} not found`);
                 }
-                if (!this.contentScopeService.scopesAreEqual(folder.scope, scope)) {
+                if (!contentScopesAreEqual(folder.scope, scope)) {
                     throw new BadRequestException("Folder scope doesn't match passed scope");
                 }
             }

--- a/packages/api/cms-api/src/dam/files/files.service.spec.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.spec.ts
@@ -40,7 +40,6 @@ function createServiceWithMockQueryBuilder() {
         null as never, // DAM_CONFIG
         null as never, // imgproxyService
         null as never, // orm
-        null as never, // contentScopeService
         null as never, // entityManager
     );
 

--- a/packages/api/cms-api/src/dam/files/files.service.ts
+++ b/packages/api/cms-api/src/dam/files/files.service.ts
@@ -22,7 +22,7 @@ import { slugifyFilename } from "../../file-utils/files.utils";
 import { FocalPoint } from "../../file-utils/focal-point.enum";
 import { Extension, ResizingType } from "../../imgproxy/imgproxy.enum";
 import { ImgproxyService } from "../../imgproxy/imgproxy.service";
-import { ContentScopeService } from "../../user-permissions/content-scope.service";
+import { contentScopesAreEqual } from "../../user-permissions/content-scopes-are-equal";
 import { CometImageResolutionException } from "../common/errors/image-resolution.exception";
 import { DamConfig } from "../dam.config";
 import { DAM_CONFIG } from "../dam.constants";
@@ -129,7 +129,6 @@ export class FilesService {
         @Inject(DAM_CONFIG) private readonly config: DamConfig,
         private readonly imgproxyService: ImgproxyService,
         private readonly orm: MikroORM,
-        private readonly contentScopeService: ContentScopeService,
         private readonly entityManager: EntityManager,
     ) {}
 
@@ -346,8 +345,7 @@ export class FilesService {
         const updatedFiles = [];
 
         for (const file of files) {
-            // Convert to JS object because deep-comparing classes and objects doesn't work
-            if (targetFolder?.scope !== undefined && !this.contentScopeService.scopesAreEqual(file.scope, targetFolder.scope)) {
+            if (targetFolder?.scope !== undefined && !contentScopesAreEqual(file.scope, targetFolder.scope)) {
                 throw new Error("Target folder scope doesn't match file scope");
             }
 

--- a/packages/api/cms-api/src/dam/files/folders.service.ts
+++ b/packages/api/cms-api/src/dam/files/folders.service.ts
@@ -2,12 +2,12 @@ import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository, MikroORM, QueryBuilder, raw } from "@mikro-orm/postgresql";
 import { forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
 import JSZip from "jszip";
-import isEqual from "lodash.isequal";
 
 import { BlobStorageBackendService } from "../../blob-storage/backends/blob-storage-backend.service";
 import { createHashedPath } from "../../blob-storage/utils/create-hashed-path.util";
 import { CometEntityNotFoundException } from "../../common/errors/entity-not-found.exception";
 import { SortDirection } from "../../common/sorting/sort-direction.enum";
+import { contentScopesAreEqual } from "../../user-permissions/content-scopes-are-equal";
 import { DamConfig } from "../dam.config";
 import { DAM_CONFIG } from "../dam.constants";
 import { DamScopeInterface } from "../types";
@@ -262,8 +262,7 @@ export class FoldersService {
                 throw new Error("Target folder doesn't exist");
             }
 
-            // Convert to JS object because deep-comparing classes and objects doesn't work
-            if (scope && targetFolder.scope && !isEqual({ ...targetFolder.scope }, scope)) {
+            if (scope && targetFolder.scope && !contentScopesAreEqual(targetFolder.scope, scope)) {
                 throw new Error("Scope arg doesn't match folder scope");
             }
         }
@@ -275,8 +274,7 @@ export class FoldersService {
                 throw new Error("Folder doesn't exist");
             }
 
-            // Convert to JS object because deep-comparing classes and objects doesn't work
-            if (scope && folder.scope && !isEqual({ ...folder.scope }, scope)) {
+            if (scope && folder.scope && !contentScopesAreEqual(folder.scope, scope)) {
                 throw new Error("Scope arg doesn't match folder scope");
             }
 

--- a/packages/api/cms-api/src/user-permissions/content-scope.service.ts
+++ b/packages/api/cms-api/src/user-permissions/content-scope.service.ts
@@ -2,11 +2,11 @@ import { MikroORM } from "@mikro-orm/postgresql";
 import { ExecutionContext, Injectable, Optional } from "@nestjs/common";
 import { ModuleRef, Reflector } from "@nestjs/core";
 import { GqlExecutionContext } from "@nestjs/graphql";
-import isEqual from "lodash.isequal";
 
 import { PageTreeService } from "../page-tree/page-tree.service";
 import { SCOPED_ENTITY_METADATA_KEY, ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
 import { ContentScope } from "../user-permissions/interfaces/content-scope.interface";
+import { contentScopesAreEqual } from "./content-scopes-are-equal";
 import { AFFECTED_ENTITY_METADATA_KEY, AffectedEntityMeta } from "./decorators/affected-entity.decorator";
 import { AFFECTED_SCOPE_METADATA_KEY, AffectedScopeMeta } from "./decorators/affected-scope.decorator";
 import { getScopesForScopedEntity } from "./get-scopes-for-scoped-entity";
@@ -22,11 +22,7 @@ export class ContentScopeService {
     ) {}
 
     scopesAreEqual(scope1: ContentScope | undefined, scope2: ContentScope | undefined): boolean {
-        // The scopes are cloned because they could be
-        //   - an instance of a class (e.g. DamScope)
-        //   - or a plain object (from a GraphQL input)
-        // Then they are not deeply equal, although they represent the same scope
-        return isEqual({ ...scope1 }, { ...scope2 });
+        return contentScopesAreEqual(scope1, scope2);
     }
 
     async getScopesForPermissionCheck(context: ExecutionContext): Promise<ContentScope[][]> {

--- a/packages/api/cms-api/src/user-permissions/content-scopes-are-equal.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/content-scopes-are-equal.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { contentScopesAreEqual } from "./content-scopes-are-equal";
+
+class DamScope {
+    constructor(public domain: string) {}
+}
+
+describe("contentScopesAreEqual", () => {
+    it("considers a class instance and a plain object with the same values equal", () => {
+        expect(contentScopesAreEqual(new DamScope("main"), { domain: "main" })).toBe(true);
+    });
+
+    it("considers scopes with different values unequal", () => {
+        expect(contentScopesAreEqual({ domain: "main" }, { domain: "secondary" })).toBe(false);
+    });
+
+    it("considers scopes with different keys unequal", () => {
+        expect(contentScopesAreEqual({ domain: "main" }, { domain: "main", language: "en" })).toBe(false);
+    });
+
+    it("considers two undefined scopes equal", () => {
+        expect(contentScopesAreEqual(undefined, undefined)).toBe(true);
+    });
+
+    it("considers an undefined scope and a scope with values unequal", () => {
+        expect(contentScopesAreEqual(undefined, { domain: "main" })).toBe(false);
+    });
+});

--- a/packages/api/cms-api/src/user-permissions/content-scopes-are-equal.ts
+++ b/packages/api/cms-api/src/user-permissions/content-scopes-are-equal.ts
@@ -1,0 +1,7 @@
+import isEqual from "lodash.isequal";
+
+export function contentScopesAreEqual(scope1: object | undefined, scope2: object | undefined): boolean {
+    // A scope can be a class instance (e.g. DamScope) or a plain object (e.g. from a GraphQL input).
+    // Cloning both into plain objects makes them comparable across those two forms.
+    return isEqual({ ...scope1 }, { ...scope2 });
+}


### PR DESCRIPTION
## Problem

`FilesService` and the DAM files controller injected `ContentScopeService` only to call its `scopesAreEqual` method — a stateless deep comparison. That ties the DAM to the user-permissions layer for a check that needs no state. `FoldersService` ran the same comparison inline via `lodash.isequal`, so the rule existed twice.

## Solution

The comparison lives in `contentScopesAreEqual` now, next to the `ContentScope` interface in `user-permissions/`:

- `ContentScopeService.scopesAreEqual` delegates to it, so its callers are unaffected.
- The DAM services and the files controller call it directly and no longer inject `ContentScopeService`.

No changeset because `contentScopesAreEqual` is internal and `ContentScopeService.scopesAreEqual` keeps its signature, so the public API is unchanged.

## Verification

- New unit tests in `content-scopes-are-equal.spec.ts` cover a class instance against a plain object plus differing values, differing keys and `undefined` scopes

## Outlook

First of three stacked pull requests that let `DamFilesModule` be registered without `UserPermissionsModule`: #6151 splits `DamModule` into sub-modules, #6153 makes the DAM's scope-based access control optional.
