### PR TITLE
[Backport v8] Skip auto assign for bot pull requests

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -8,7 +8,3 @@ reviewers:
 skipKeywords:
     - Merge main into next
     - Version Packages
-
-skipUsers:
-    - renovate[bot]
-    - Copilot

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
     auto-assign:
+        # auto-assign-action has no option to skip pull requests based on their author,
+        # so bot pull requests (Renovate, Copilot, ...) are filtered out here.
+        if: github.event.pull_request.user.type != 'Bot'
         runs-on: ubuntu-latest
         steps:
             - uses: kentaro-m/auto-assign-action@v2.0.2


### PR DESCRIPTION
Backport of #6071 to `v8.x.x`.

Clean cherry-pick, no conflicts. Only `.github/` CI configuration is touched (no packages changed), so no package build/lint/demo verification applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMj4JDBpiDUtELhFwQUW7i)_