### PR TITLE
Fix `DateRangePicker` ignoring its theme customizations

### DIFF
--- a/.changeset/apply-date-range-picker-theme-customizations.md
+++ b/.changeset/apply-date-range-picker-theme-customizations.md
@@ -1,0 +1,7 @@
+---
+"@comet/admin": patch
+---
+
+Apply theme customizations for `DateRangePicker`
+
+`defaultProps` and `styleOverrides` defined for `CometAdminDateRangePicker` had no effect, as the component read its theme props from `CometAdminFutureDateRangePicker`.

--- a/packages/admin/admin/src/dateTime/dateRangePicker/DateRangePicker.test.tsx
+++ b/packages/admin/admin/src/dateTime/dateRangePicker/DateRangePicker.test.tsx
@@ -1,0 +1,28 @@
+import { createTheme, ThemeProvider } from "@mui/material";
+import { pickersInputBaseClasses } from "@mui/x-date-pickers";
+import { render, waitFor } from "test-utils";
+import { describe, expect, test } from "vitest";
+
+import { DateRangePicker } from "./DateRangePicker";
+
+describe("DateRangePicker", () => {
+    test("Should apply defaultProps defined in the theme", async () => {
+        const theme = createTheme({
+            components: {
+                CometAdminDateRangePicker: {
+                    defaultProps: {
+                        disabled: true,
+                    },
+                },
+            },
+        });
+
+        const rendered = render(
+            <ThemeProvider theme={theme}>
+                <DateRangePicker />
+            </ThemeProvider>,
+        );
+
+        await waitFor(() => expect(rendered.container.querySelector(`.${pickersInputBaseClasses.disabled}`)).not.toBeNull());
+    });
+});

--- a/packages/admin/admin/src/dateTime/dateRangePicker/DateRangePicker.tsx
+++ b/packages/admin/admin/src/dateTime/dateRangePicker/DateRangePicker.tsx
@@ -81,7 +81,7 @@ export const DateRangePicker = (inProps: DateRangePickerProps) => {
         ...restProps
     } = useThemeProps({
         props: inProps,
-        name: "CometAdminFutureDateRangePicker",
+        name: "CometAdminDateRangePicker",
     });
     const intl = useIntl();
 


### PR DESCRIPTION
## Problem

`defaultProps` and `styleOverrides` defined for `CometAdminDateRangePicker` have no effect. Every other date/time picker honors its theme entry, so the component silently ignores customizations a project reasonably expects to work.

## Cause

`DateRangePicker` reads its theme props from `CometAdminFutureDateRangePicker` — a leftover name — while the theme augmentation declares `CometAdminDateRangePicker`.

## Fix

`DateRangePicker` reads its theme props from `CometAdminDateRangePicker`, so `defaultProps` and `styleOverrides` for that component apply.

## Verification

Added a unit test that sets `defaultProps.disabled` through `CometAdminDateRangePicker` and asserts the rendered input is disabled. It fails on `main` and passes with this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqjS9kY1exCBtSGLsoKFwZ)_