### PR TITLE
Describe the `DateRangePicker`'s actual input structure

### DIFF
--- a/packages/admin/admin/src/dateTime/dateRangePicker/DateRangePicker.tsx
+++ b/packages/admin/admin/src/dateTime/dateRangePicker/DateRangePicker.tsx
@@ -59,8 +59,8 @@ const getDateRangeValue = (value: DateRange | undefined): [Date | null, Date | n
 };
 
 /**
- * The DateRangePicker component allows users to select a date range from a calendar interface. It provides two
- * text fields with a calendar icon that opens a date range picker dialog. The component handles ISO 8601 date strings
+ * The DateRangePicker component allows users to select a date range from a calendar interface. It provides a single
+ * text field with a calendar icon that opens a date range picker dialog. The component handles ISO 8601 date strings
  * and includes features like clearing, read-only state, and customizable icons.
  *
  * - [Storybook](https://storybook.comet-dxp.com/?path=/docs/@comet/admin_components-datetime-daterangepicker--docs)


### PR DESCRIPTION
## Problem

`DateRangePicker`'s doc comment says it provides two text fields. It renders MUI's `SingleInputDateRangeField`, so both dates are edited in a single text field. The doc comment is what shows up on hover in the IDE, so it misleads about the component's markup and about where adornments end up.

## Fix

The doc comment describes a single text field. No changeset, as this changes neither behavior nor the public API.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqjS9kY1exCBtSGLsoKFwZ)_