### PR TITLE
mail-react: Fix RichText block crash when it starts with a nested list item

### DIFF
--- a/.changeset/clamp-rich-text-draft-depths.md
+++ b/.changeset/clamp-rich-text-draft-depths.md
@@ -1,0 +1,7 @@
+---
+"@comet/mail-react": patch
+---
+
+Fix crash in the RichText block when it starts with a nested list item
+
+An editor produces this by pressing Tab on the first item of a list, or by clearing the text of the item above a nested one.

--- a/packages/mail-react/src/blocks/richText/__tests__/createRichTextBlock.test.tsx
+++ b/packages/mail-react/src/blocks/richText/__tests__/createRichTextBlock.test.tsx
@@ -473,3 +473,27 @@ describe("createRichTextBlock — lists", () => {
         expect(renderWithTheme(<HtmlRichTextBlock data={data} />, themeWithDefaultVariant)).toContain("richTextBlock__list--variantBody");
     });
 });
+
+describe("createRichTextBlock — draft depths", () => {
+    const { HtmlRichTextBlock } = createRichTextBlock();
+    const depthMarkerTheme = createTheme({ list: { unorderedMarker: ({ depth }) => `L${String(depth)}` } });
+
+    it("renders content that starts with a nested list item", () => {
+        const data = createBlockData([
+            createDraftBlock({ key: "a", text: "", type: "unordered-list-item" }),
+            createDraftBlock({ key: "b", text: "Item one", type: "unordered-list-item", depth: 1 }),
+        ]);
+
+        expect(renderWithTheme(<HtmlRichTextBlock data={data} />)).toContain("Item one");
+    });
+
+    it("gives the marker the depth of the level its item renders at", () => {
+        const data = createBlockData([
+            createDraftBlock({ key: "a", text: "Item one", type: "unordered-list-item" }),
+            createDraftBlock({ key: "b", text: "Item two", type: "unordered-list-item", depth: 3 }),
+        ]);
+        const markup = renderWithTheme(<HtmlRichTextBlock data={data} />, depthMarkerTheme);
+
+        expect(markerTextsInDocumentOrder(markup)).toEqual(["L0", "L1"]);
+    });
+});

--- a/packages/mail-react/src/blocks/richText/createRichTextBlock.tsx
+++ b/packages/mail-react/src/blocks/richText/createRichTextBlock.tsx
@@ -44,6 +44,7 @@ function HtmlBlockText({ bottomSpacing, variant, className, children, ...stylePr
 interface DraftBlock {
     key: string;
     text: string;
+    depth?: number;
 }
 
 function isDraftBlock(block: unknown): block is DraftBlock {
@@ -51,9 +52,11 @@ function isDraftBlock(block: unknown): block is DraftBlock {
         return false;
     }
 
-    const { key, text } = block;
+    const hasStringKey = typeof block.key === "string";
+    const hasStringText = typeof block.text === "string";
+    const hasOptionalNumberDepth = !("depth" in block) || typeof block.depth === "number";
 
-    return typeof key === "string" && typeof text === "string";
+    return hasStringKey && hasStringText && hasOptionalNumberDepth;
 }
 
 function isDraftContent(draftContent: unknown): draftContent is { blocks: DraftBlock[] } {
@@ -64,6 +67,19 @@ function isDraftContent(draftContent: unknown): draftContent is { blocks: DraftB
     const { blocks } = draftContent;
 
     return Array.isArray(blocks) && blocks.every(isDraftBlock);
+}
+
+/** `redraft` throws when the first block is nested, and reports a depth deeper than the level it nests at. */
+function withoutSkippedDepthLevels(blocks: DraftBlock[]): DraftBlock[] {
+    let deepestAllowedDepth = 0;
+
+    return blocks.map((block) => {
+        const depth = Math.min(block.depth ?? 0, deepestAllowedDepth);
+
+        deepestAllowedDepth = depth + 1;
+
+        return { ...block, depth };
+    });
 }
 
 interface RenderRichTextContentOptions {
@@ -88,7 +104,7 @@ function renderRichTextContent({ draftContent, blockTypes, linkTypes, inline, bl
 
     const renderers = createRichTextRenderers({ blockTypes, linkTypes, inline, blockTextComponent, lastBlockKey });
 
-    return redraft({ ...draftContent, blocks: blocksWithText }, renderers);
+    return redraft({ ...draftContent, blocks: withoutSkippedDepthLevels(blocksWithText) }, renderers);
 }
 
 /**


### PR DESCRIPTION
An editor produces this by pressing Tab on the first item of a list, or by clearing the text of the item above a nested one.

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13349