### PR TITLE
demo: Generate fixture content for both table blocks

### DIFF
--- a/demo/api/src/db/fixtures/fixtures.module.ts
+++ b/demo/api/src/db/fixtures/fixtures.module.ts
@@ -51,6 +51,7 @@ import { StandaloneHeadingBlockFixtureService } from "./generators/blocks/text-a
 import { TableBlockFixtureService } from "./generators/blocks/text-and-content/table-block-fixture.service";
 import { TextImageBlockFixtureService } from "./generators/blocks/text-and-content/text-image-block-fixture.service";
 import { TipTapRichTextBlockFixtureService } from "./generators/blocks/text-and-content/tip-tap-rich-text-block-fixture.service";
+import { TipTapTableBlockFixtureService } from "./generators/blocks/text-and-content/tip-tap-table-block-fixture.service";
 import { DocumentGeneratorService } from "./generators/document-generator.service";
 import { DraftJsMigrationPageFixtureService } from "./generators/draft-js-migration-page-fixture.service";
 import { FileUploadsFixtureService } from "./generators/file-uploads-fixture.service";
@@ -128,6 +129,7 @@ import { VideoFixtureService } from "./generators/video-fixture.service";
         ProductListBlockFixtureService,
         TableBlockFixtureService,
         TipTapRichTextBlockFixtureService,
+        TipTapTableBlockFixtureService,
     ],
 })
 export class FixturesModule {}

--- a/demo/api/src/db/fixtures/generators/blocks/layout/content-group-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/layout/content-group-block-fixture.service.ts
@@ -12,6 +12,8 @@ import { TeaserBlockFixtureService } from "../teaser/teaser-block-fixture.servic
 import { KeyFactsBlockFixtureService } from "../text-and-content/key-facts-block-fixture.service";
 import { StandaloneHeadingBlockFixtureService } from "../text-and-content/standalone-heading-block-fixture.service";
 import { StandaloneRichTextBlockFixtureService } from "../text-and-content/standalone-rich-text-block-fixture.service";
+import { TableBlockFixtureService } from "../text-and-content/table-block-fixture.service";
+import { TipTapTableBlockFixtureService } from "../text-and-content/tip-tap-table-block-fixture.service";
 import { AccordionBlockFixtureService } from "./accordion-block-fixture.service";
 import { ColumnsBlockFixtureService } from "./columns-block-fixture.service";
 import { SpaceBlockFixtureService } from "./space-block-fixture.service";
@@ -29,14 +31,15 @@ export class ContentGroupBlockFixtureService {
         private readonly standaloneHeadingBlockFixtureService: StandaloneHeadingBlockFixtureService,
         private readonly standaloneCallToActionListBlockFixtureService: StandaloneCallToActionListBlockFixtureService,
         private readonly standaloneRichTextBlockFixtureService: StandaloneRichTextBlockFixtureService,
+        private readonly tableBlockFixtureService: TableBlockFixtureService,
         private readonly teaserBlockFixtureService: TeaserBlockFixtureService,
+        private readonly tipTapTableBlockFixtureService: TipTapTableBlockFixtureService,
     ) {}
 
     async generateContentGroupContentBlock(): Promise<ExtractBlockInputFactoryProps<typeof ContentBlock>> {
         const blocks: ExtractBlockInputFactoryProps<typeof ContentBlock>["blocks"] = [];
 
-        // TODO: Add table and tipTapTable fixtures (https://vivid-planet.atlassian.net/browse/COM-2227)
-        const blockCfg: Record<Exclude<(typeof blocks)[number]["type"], "table" | "tipTapTable">, BlockFixture> = {
+        const blockCfg: Record<(typeof blocks)[number]["type"], BlockFixture> = {
             accordion: this.accordionBlockFixtureService,
             anchor: this.anchorBlockFixtureService,
             callToActionList: this.standaloneCallToActionListBlockFixtureService,
@@ -47,7 +50,9 @@ export class ContentGroupBlockFixtureService {
             mediaGallery: this.mediaGalleryBlockFixtureService,
             richtext: this.standaloneRichTextBlockFixtureService,
             space: this.spaceBlockFixtureService,
+            table: this.tableBlockFixtureService,
             teaser: this.teaserBlockFixtureService,
+            tipTapTable: this.tipTapTableBlockFixtureService,
         };
 
         for (const block of Object.entries(blockCfg)) {

--- a/demo/api/src/db/fixtures/generators/blocks/text-and-content/table-block-fixture-base.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/text-and-content/table-block-fixture-base.ts
@@ -1,0 +1,107 @@
+import type { ExtractBlockInputFactoryProps } from "@comet/cms-api";
+import type { LinkBlock } from "@src/common/blocks/link.block";
+import { faker } from "@src/db/fixtures/faker";
+import type { LinkBlockFixtureService } from "@src/db/fixtures/generators/blocks/navigation/link-block-fixture.service";
+
+type LinkInput = ExtractBlockInputFactoryProps<typeof LinkBlock>;
+
+type ColumnSize = "extraSmall" | "small" | "standard" | "large" | "extraLarge";
+
+interface TableColumnInput {
+    id: string;
+    size: ColumnSize;
+    highlighted: boolean;
+}
+
+interface TableCellValueInput<RichTextInput> {
+    columnId: string;
+    value: RichTextInput;
+}
+
+interface TableRowInput<RichTextInput> {
+    id: string;
+    highlighted: boolean;
+    cellValues: TableCellValueInput<RichTextInput>[];
+}
+
+interface TableBlockInput<RichTextInput> {
+    columns: TableColumnInput[];
+    rows: TableRowInput<RichTextInput>[];
+}
+
+/** Content of a description cell, to be encoded by the rich text editor of the concrete fixture service. */
+export interface DescriptionCellContent {
+    jobTitle: string;
+    textBeforeLink: string;
+    linkText: string;
+    textAfterLink: string;
+    link: LinkInput;
+}
+
+const columnIds = {
+    name: "name",
+    email: "email",
+    address: "address",
+    description: "description",
+} as const;
+
+/**
+ * Generates the columns and rows of a table block, leaving the rich text of the cells to the subclass.
+ *
+ * `createTableBlock` returns a plain `Block`, so the input types can't be derived from it and are declared here.
+ */
+export abstract class TableBlockFixtureBase<RichTextInput> {
+    constructor(private readonly linkBlockFixtureService: LinkBlockFixtureService) {}
+
+    async generateBlockInput(): Promise<TableBlockInput<RichTextInput>> {
+        const columns: TableColumnInput[] = [
+            { id: columnIds.name, size: "standard", highlighted: false },
+            { id: columnIds.email, size: "standard", highlighted: false },
+            { id: columnIds.address, size: "large", highlighted: false },
+            { id: columnIds.description, size: "extraLarge", highlighted: false },
+        ];
+
+        const headerRow: TableRowInput<RichTextInput> = {
+            id: faker.string.uuid(),
+            highlighted: true,
+            cellValues: [
+                { columnId: columnIds.name, value: this.createSimpleCellRichText("Name") },
+                { columnId: columnIds.email, value: this.createSimpleCellRichText("Email") },
+                { columnId: columnIds.address, value: this.createSimpleCellRichText("Address") },
+                { columnId: columnIds.description, value: this.createSimpleCellRichText("Description") },
+            ],
+        };
+
+        const dataRowCount = faker.number.int({ min: 4, max: 5 });
+        const dataRows = await Promise.all(Array.from({ length: dataRowCount }, () => this.generateDataRow()));
+
+        return { columns, rows: [headerRow, ...dataRows] };
+    }
+
+    protected abstract createSimpleCellRichText(text: string): RichTextInput;
+
+    protected abstract createDescriptionCellRichText(content: DescriptionCellContent): RichTextInput;
+
+    private async generateDataRow(): Promise<TableRowInput<RichTextInput>> {
+        return {
+            id: faker.string.uuid(),
+            highlighted: false,
+            cellValues: [
+                { columnId: columnIds.name, value: this.createSimpleCellRichText(faker.person.fullName()) },
+                { columnId: columnIds.email, value: this.createSimpleCellRichText(faker.internet.email()) },
+                { columnId: columnIds.address, value: this.createSimpleCellRichText(faker.location.streetAddress({ useFullAddress: true })) },
+                { columnId: columnIds.description, value: this.createDescriptionCellRichText(await this.generateDescriptionCellContent()) },
+            ],
+        };
+    }
+
+    private async generateDescriptionCellContent(): Promise<DescriptionCellContent> {
+        const jobTitle = faker.person.jobTitle();
+        const linkText = faker.lorem.words(3);
+        const textBeforeLink = `${faker.lorem.words(faker.number.int({ min: 3, max: 6 }))} `;
+        const textAfterLink = ` ${faker.lorem.words(faker.number.int({ min: 3, max: 6 }))}`;
+        const link = await this.linkBlockFixtureService.generateBlockInput();
+
+        return { jobTitle, linkText, textBeforeLink, textAfterLink, link };
+    }
+}

--- a/demo/api/src/db/fixtures/generators/blocks/text-and-content/table-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/text-and-content/table-block-fixture.service.ts
@@ -4,82 +4,17 @@ import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 import { faker } from "@src/db/fixtures/faker";
 import { LinkBlockFixtureService } from "@src/db/fixtures/generators/blocks/navigation/link-block-fixture.service";
 
+import { DescriptionCellContent, TableBlockFixtureBase } from "./table-block-fixture-base";
+
 type RichTextInput = ExtractBlockInputFactoryProps<typeof RichTextBlock>;
 
-type ColumnSize = "extraSmall" | "small" | "standard" | "large" | "extraLarge";
-
-interface TableColumnInput {
-    id: string;
-    size: ColumnSize;
-    highlighted: boolean;
-}
-
-interface TableCellValueInput {
-    columnId: string;
-    value: RichTextInput;
-}
-
-interface TableRowInput {
-    id: string;
-    highlighted: boolean;
-    cellValues: TableCellValueInput[];
-}
-
-interface TableBlockInput {
-    columns: TableColumnInput[];
-    rows: TableRowInput[];
-}
-
-const columnIds = {
-    name: "name",
-    email: "email",
-    address: "address",
-    description: "description",
-} as const;
-
 @Injectable()
-export class TableBlockFixtureService {
-    constructor(private readonly linkBlockFixtureService: LinkBlockFixtureService) {}
-
-    async generateBlockInput(): Promise<TableBlockInput> {
-        const columns: TableColumnInput[] = [
-            { id: columnIds.name, size: "standard", highlighted: false },
-            { id: columnIds.email, size: "standard", highlighted: false },
-            { id: columnIds.address, size: "large", highlighted: false },
-            { id: columnIds.description, size: "extraLarge", highlighted: false },
-        ];
-
-        const headerRow: TableRowInput = {
-            id: faker.string.uuid(),
-            highlighted: true,
-            cellValues: [
-                { columnId: columnIds.name, value: this.generateSimpleCellRichText("Name") },
-                { columnId: columnIds.email, value: this.generateSimpleCellRichText("Email") },
-                { columnId: columnIds.address, value: this.generateSimpleCellRichText("Address") },
-                { columnId: columnIds.description, value: this.generateSimpleCellRichText("Description") },
-            ],
-        };
-
-        const dataRowCount = faker.number.int({ min: 4, max: 5 });
-        const dataRows = await Promise.all(Array.from({ length: dataRowCount }, () => this.generateDataRow()));
-
-        return { columns, rows: [headerRow, ...dataRows] };
+export class TableBlockFixtureService extends TableBlockFixtureBase<RichTextInput> {
+    constructor(linkBlockFixtureService: LinkBlockFixtureService) {
+        super(linkBlockFixtureService);
     }
 
-    private async generateDataRow(): Promise<TableRowInput> {
-        return {
-            id: faker.string.uuid(),
-            highlighted: false,
-            cellValues: [
-                { columnId: columnIds.name, value: this.generateSimpleCellRichText(faker.person.fullName()) },
-                { columnId: columnIds.email, value: this.generateSimpleCellRichText(faker.internet.email()) },
-                { columnId: columnIds.address, value: this.generateSimpleCellRichText(faker.location.streetAddress({ useFullAddress: true })) },
-                { columnId: columnIds.description, value: await this.generateDescriptionCellRichText() },
-            ],
-        };
-    }
-
-    generateSimpleCellRichText(text: string): RichTextInput {
+    protected createSimpleCellRichText(text: string): RichTextInput {
         return {
             draftContent: {
                 blocks: [
@@ -98,13 +33,7 @@ export class TableBlockFixtureService {
         };
     }
 
-    async generateDescriptionCellRichText(): Promise<RichTextInput> {
-        const jobTitle = faker.person.jobTitle();
-        const linkText = faker.lorem.words(3);
-        const sentencePrefix = `${faker.lorem.words(faker.number.int({ min: 3, max: 6 }))} `;
-        const sentenceSuffix = ` ${faker.lorem.words(faker.number.int({ min: 3, max: 6 }))}`;
-        const linkData = await this.linkBlockFixtureService.generateBlockInput();
-
+    protected createDescriptionCellRichText({ jobTitle, textBeforeLink, linkText, textAfterLink, link }: DescriptionCellContent): RichTextInput {
         return {
             draftContent: {
                 blocks: [
@@ -119,13 +48,13 @@ export class TableBlockFixtureService {
                     },
                     {
                         key: faker.string.uuid(),
-                        text: `${sentencePrefix}${linkText}${sentenceSuffix}`,
+                        text: `${textBeforeLink}${linkText}${textAfterLink}`,
                         type: "paragraph-small",
                         depth: 0,
                         inlineStyleRanges: [],
                         entityRanges: [
                             {
-                                offset: sentencePrefix.length,
+                                offset: textBeforeLink.length,
                                 length: linkText.length,
                                 key: 0,
                             },
@@ -137,7 +66,7 @@ export class TableBlockFixtureService {
                     "0": {
                         type: "LINK",
                         mutability: "MUTABLE",
-                        data: linkData,
+                        data: link,
                     },
                 },
             },

--- a/demo/api/src/db/fixtures/generators/blocks/text-and-content/tip-tap-table-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/blocks/text-and-content/tip-tap-table-block-fixture.service.ts
@@ -1,0 +1,63 @@
+import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
+import { Injectable } from "@nestjs/common";
+import { TipTapRichTextBlock } from "@src/common/blocks/tip-tap-rich-text.block";
+import { LinkBlockFixtureService } from "@src/db/fixtures/generators/blocks/navigation/link-block-fixture.service";
+
+import { DescriptionCellContent, TableBlockFixtureBase } from "./table-block-fixture-base";
+
+type TipTapRichTextInput = ExtractBlockInputFactoryProps<typeof TipTapRichTextBlock>;
+
+const standardParagraphStyle = "paragraph300";
+const smallParagraphStyle = "paragraph200";
+
+@Injectable()
+export class TipTapTableBlockFixtureService extends TableBlockFixtureBase<TipTapRichTextInput> {
+    constructor(linkBlockFixtureService: LinkBlockFixtureService) {
+        super(linkBlockFixtureService);
+    }
+
+    protected createSimpleCellRichText(text: string): TipTapRichTextInput {
+        return {
+            tipTapContent: {
+                type: "doc",
+                content: [
+                    {
+                        type: "paragraph",
+                        attrs: { textBlockStyle: standardParagraphStyle },
+                        content: [{ type: "text", text }],
+                    },
+                ],
+            },
+        };
+    }
+
+    protected createDescriptionCellRichText({
+        jobTitle,
+        textBeforeLink,
+        linkText,
+        textAfterLink,
+        link,
+    }: DescriptionCellContent): TipTapRichTextInput {
+        return {
+            tipTapContent: {
+                type: "doc",
+                content: [
+                    {
+                        type: "paragraph",
+                        attrs: { textBlockStyle: standardParagraphStyle },
+                        content: [{ type: "text", text: jobTitle }],
+                    },
+                    {
+                        type: "paragraph",
+                        attrs: { textBlockStyle: smallParagraphStyle },
+                        content: [
+                            { type: "text", text: textBeforeLink },
+                            { type: "text", marks: [{ type: "link", attrs: { data: link } }], text: linkText },
+                            { type: "text", text: textAfterLink },
+                        ],
+                    },
+                ],
+            },
+        };
+    }
+}

--- a/demo/api/src/db/fixtures/generators/page-content-block-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/page-content-block-fixture.service.ts
@@ -29,6 +29,7 @@ import { StandaloneHeadingBlockFixtureService } from "./blocks/text-and-content/
 import { TableBlockFixtureService } from "./blocks/text-and-content/table-block-fixture.service";
 import { TextImageBlockFixtureService } from "./blocks/text-and-content/text-image-block-fixture.service";
 import { TipTapRichTextBlockFixtureService } from "./blocks/text-and-content/tip-tap-rich-text-block-fixture.service";
+import { TipTapTableBlockFixtureService } from "./blocks/text-and-content/tip-tap-table-block-fixture.service";
 
 export type BlockCategory = "layout" | "media" | "navigation" | "teaser" | "textAndContent" | "form";
 
@@ -59,6 +60,7 @@ export class PageContentBlockFixtureService {
         private readonly contactFormBlockFixtureService: ContactFormBlockFixtureService,
         private readonly tableBlockFixtureService: TableBlockFixtureService,
         private readonly tipTapRichTextBlockFixtureService: TipTapRichTextBlockFixtureService,
+        private readonly tipTapTableBlockFixtureService: TipTapTableBlockFixtureService,
     ) {}
 
     async generateBlockInput(blockCategory?: BlockCategory): Promise<ExtractBlockInputFactoryProps<typeof PageContentBlock>> {
@@ -66,8 +68,8 @@ export class PageContentBlockFixtureService {
 
         type SupportedBlocks = (typeof blocks)[number]["type"];
 
-        // TODO add fixtures for newsDetail, newsList and tipTapTable
-        const fixtures: Record<Exclude<SupportedBlocks, "newsDetail" | "newsList" | "tipTapTable">, [BlockCategory, BlockFixture]> = {
+        // TODO add fixtures for newsDetail and newsList
+        const fixtures: Record<Exclude<SupportedBlocks, "newsDetail" | "newsList">, [BlockCategory, BlockFixture]> = {
             accordion: ["layout", this.accordionBlockFixtureService],
             columns: ["layout", this.columnsBlockFixtureService],
             contentGroup: ["layout", this.contentGroupBlockFixtureService],
@@ -91,6 +93,7 @@ export class PageContentBlockFixtureService {
             contactForm: ["form", this.contactFormBlockFixtureService],
             table: ["textAndContent", this.tableBlockFixtureService],
             tipTapRichText: ["textAndContent", this.tipTapRichTextBlockFixtureService],
+            tipTapTable: ["textAndContent", this.tipTapTableBlockFixtureService],
         };
 
         const supportedBlocksFixtureGenerators = Object.entries(fixtures)


### PR DESCRIPTION
The TipTap table block had no fixture, so seeded pages never showed it, and neither table appeared inside a content group.

The TipTap cells mirror the draft-js ones so both blocks can be compared side by side on the same page; their paragraph styles are the ones the block's `migrateFromDraftJs` map assigns to the draft-js types.

---

Task: https://vivid-planet.atlassian.net/browse/COM-3096