### PR TITLE
Keep the text block type in the Draft.js to TipTap migration

### DIFF
--- a/.changeset/tiptap-draftjs-migration-keep-heading-tag.md
+++ b/.changeset/tiptap-draftjs-migration-keep-heading-tag.md
@@ -1,0 +1,22 @@
+---
+"@comet/cms-api": patch
+---
+
+Keep the text block type when the Draft.js → TipTap migration maps a block type to a `textBlockStyle`
+
+A Draft.js block type listed in `migrateFromDraftJs.textBlockStyleMap` was always converted to a paragraph, so a `header-two` block mapped to a `headline450` style lost its heading tag and was rendered with whatever tag the style defaults to. Mapped header types now keep their heading level and only receive the mapped `textBlockStyle`.
+
+For custom Draft.js block types that were rendered as a heading (e.g. a `headline450` block type rendered as `<h2>`), the target text block type can now be set explicitly by passing an object instead of a style name:
+
+**Example**
+
+```ts
+createTipTapRichTextBlock({
+    textBlockStyles: [{ name: "headline450", appliesTo: ["heading-2"] }],
+    migrateFromDraftJs: {
+        textBlockStyleMap: { headline450: { textBlockType: "heading-2", textBlockStyle: "headline450" } },
+    },
+});
+```
+
+`textBlockType` accepts `paragraph` and `heading-1` … `heading-6`, and both properties are optional.

--- a/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
+++ b/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
@@ -202,6 +202,20 @@ export const TipTapRichTextBlock = createTipTapRichTextBlock({
 });
 ```
 
+A mapped block type keeps its text block type: `header-two` still becomes a heading with level 2, only with the mapped `textBlockStyle` applied. If the Draft.js block type doesn't carry that information — a custom block type such as `headline450` that was rendered as `<h2>` — pass a `{ textBlockType, textBlockStyle }` object to set the text block type explicitly, so the semantic tag isn't lost:
+
+```ts title="tip-tap-rich-text.block.ts"
+export const TipTapRichTextBlock = createTipTapRichTextBlock({
+    textBlockStyles: [{ name: "headline450", appliesTo: ["heading-2"] }],
+    migrateFromDraftJs: {
+        // highlight-next-line
+        textBlockStyleMap: { headline450: { textBlockType: "heading-2", textBlockStyle: "headline450" } },
+    },
+});
+```
+
+`textBlockType` accepts `paragraph` and `heading-1` … `heading-6`. Both parts are optional: pass only `textBlockType` to change the tag without applying a style, or only `textBlockStyle` (equivalent to the plain string form) to keep the text block type derived from the Draft.js block type.
+
 #### Migration versioning
 
 `migrateFromDraftJs` reserves **version 1** for the injected Draft.js → TipTap migration. Your own [block migrations](./5-migrations.mdx) must therefore start at **version 2**:

--- a/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
@@ -32,6 +32,7 @@ import { SoftHyphen } from "./extensions/SoftHyphen";
 import { TextBlockStyleHeading } from "./extensions/TextBlockStyleHeading";
 import { TextBlockStyleParagraph } from "./extensions/TextBlockStyleParagraph";
 import { buildDraftJsToTipTapMigration } from "./migrations/buildDraftJsToTipTapMigration";
+import type { TextBlockStyleMapping } from "./migrations/convertDraftJsToTipTap";
 
 export type TipTapSupports =
     | "bold"
@@ -140,14 +141,15 @@ export interface CreateTipTapRichTextBlockOptions {
      * to build the target schema, validates the converted document, and falls back to a
      * stripped-down plain-text-paragraph document if validation fails.
      *
-     * Pass an object with `textBlockStyleMap` to map DraftJS custom block types (e.g.
-     * `paragraph-small` from a DraftJS `blocktypeMap`) to TipTap paragraph `textBlockStyle`
-     * attribute values.
+     * Pass an object with `textBlockStyleMap` to map DraftJS block types (e.g. `paragraph-small`
+     * from a DraftJS `blocktypeMap`) to TipTap `textBlockStyle` attribute values. Use the
+     * `{ textBlockType, textBlockStyle }` form to also set the text block type, for instance to
+     * convert a DraftJS block type that was rendered as `<h2>` into a TipTap heading with level 2.
      *
      * Pass an object with `inlineStyleMap` to map DraftJS custom inline style names (e.g.
      * `highlight` from a DraftJS `customInlineStyles`) to TipTap `inlineStyle` mark type values.
      */
-    migrateFromDraftJs?: boolean | { textBlockStyleMap?: Record<string, string>; inlineStyleMap?: Record<string, string> };
+    migrateFromDraftJs?: boolean | { textBlockStyleMap?: Record<string, string | TextBlockStyleMapping>; inlineStyleMap?: Record<string, string> };
 }
 
 function buildExtensions(

--- a/packages/api/cms-api/src/blocks/tipTap/migrations/buildDraftJsToTipTapMigration.test.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/migrations/buildDraftJsToTipTapMigration.test.ts
@@ -173,6 +173,50 @@ describe("createTipTapRichTextBlock with migrateFromDraftJs", () => {
         });
     });
 
+    describe("textBlockStyleMap", () => {
+        const block = createTipTapRichTextBlock(
+            {
+                textBlockStyles: [
+                    { name: "headline450", appliesTo: ["heading-2"] },
+                    { name: "paragraph200", appliesTo: ["paragraph"] },
+                ],
+                migrateFromDraftJs: {
+                    textBlockStyleMap: {
+                        "paragraph-small": "paragraph200",
+                        "headline-450": { textBlockType: "heading-2", textBlockStyle: "headline450" },
+                    },
+                },
+            },
+            "MigratedRichTextTextBlockStyles",
+        );
+
+        it("converts a custom block type to a heading keeping both level and textBlockStyle", () => {
+            const data = block.blockDataFactory({
+                draftContent: {
+                    blocks: [draftBlock({ type: "headline-450", text: "Title" })],
+                    entityMap: {},
+                },
+            });
+            expect(data.tipTapContent).toEqual({
+                type: "doc",
+                content: [{ type: "heading", attrs: { level: 2, textBlockStyle: "headline450" }, content: [{ type: "text", text: "Title" }] }],
+            });
+        });
+
+        it("converts a custom block type to a styled paragraph", () => {
+            const data = block.blockDataFactory({
+                draftContent: {
+                    blocks: [draftBlock({ type: "paragraph-small", text: "small" })],
+                    entityMap: {},
+                },
+            });
+            expect(data.tipTapContent).toEqual({
+                type: "doc",
+                content: [{ type: "paragraph", attrs: { textBlockStyle: "paragraph200" }, content: [{ type: "text", text: "small" }] }],
+            });
+        });
+    });
+
     describe("maxTextBlocks fallback", () => {
         const block = createTipTapRichTextBlock({ maxTextBlocks: 2, migrateFromDraftJs: true }, "MigratedRichTextMaxBlocks");
 

--- a/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.test.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.test.ts
@@ -112,12 +112,72 @@ describe("convertDraftJsToTipTap", () => {
             expect(result.content).toEqual([{ type: "paragraph", attrs: { textBlockStyle: "small" }, content: [{ type: "text", text: "tiny" }] }]);
         });
 
-        it("textBlockStyleMap takes precedence over header mapping", () => {
+        it("keeps the heading level when a header type is mapped to a textBlockStyle", () => {
+            const result = convertDraftJsToTipTap(
+                { blocks: [makeBlock({ type: "header-two", text: "Title" })], entityMap: {} },
+                { supports: [...defaultSupports], textBlockStyleMap: { "header-two": "headline450" } },
+            );
+            expect(result.content).toEqual([
+                { type: "heading", attrs: { level: 2, textBlockStyle: "headline450" }, content: [{ type: "text", text: "Title" }] },
+            ]);
+        });
+
+        it("falls back to a paragraph for a mapped header type when heading is not supported", () => {
+            const result = convertDraftJsToTipTap(
+                { blocks: [makeBlock({ type: "header-two", text: "Title" })], entityMap: {} },
+                { supports: [], textBlockStyleMap: { "header-two": "headline450" } },
+            );
+            expect(result.content).toEqual([
+                { type: "paragraph", attrs: { textBlockStyle: "headline450" }, content: [{ type: "text", text: "Title" }] },
+            ]);
+        });
+
+        it("maps a custom block type to a heading with textBlockStyle via textBlockType", () => {
+            const result = convertDraftJsToTipTap(
+                { blocks: [makeBlock({ type: "headline450", text: "Title" })], entityMap: {} },
+                {
+                    supports: [...defaultSupports],
+                    textBlockStyleMap: { headline450: { textBlockType: "heading-2", textBlockStyle: "headline450" } },
+                },
+            );
+            expect(result.content).toEqual([
+                { type: "heading", attrs: { level: 2, textBlockStyle: "headline450" }, content: [{ type: "text", text: "Title" }] },
+            ]);
+        });
+
+        it("maps a custom block type to a heading without textBlockStyle", () => {
+            const result = convertDraftJsToTipTap(
+                { blocks: [makeBlock({ type: "headline450", text: "Title" })], entityMap: {} },
+                { supports: [...defaultSupports], textBlockStyleMap: { headline450: { textBlockType: "heading-2" } } },
+            );
+            expect(result.content).toEqual([{ type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "Title" }] }]);
+        });
+
+        it("textBlockType overrides the heading level derived from the DraftJS header type", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "header-one", text: "Title" })], entityMap: {} },
-                { supports: [...defaultSupports], textBlockStyleMap: { "header-one": "huge" } },
+                { supports: [...defaultSupports], textBlockStyleMap: { "header-one": { textBlockType: "heading-2" } } },
+            );
+            expect(result.content).toEqual([{ type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "Title" }] }]);
+        });
+
+        it("converts a header type to a paragraph when mapped to textBlockType paragraph", () => {
+            const result = convertDraftJsToTipTap(
+                { blocks: [makeBlock({ type: "header-one", text: "Title" })], entityMap: {} },
+                { supports: [...defaultSupports], textBlockStyleMap: { "header-one": { textBlockType: "paragraph", textBlockStyle: "huge" } } },
             );
             expect(result.content).toEqual([{ type: "paragraph", attrs: { textBlockStyle: "huge" }, content: [{ type: "text", text: "Title" }] }]);
+        });
+
+        it("keeps an empty mapped heading without inline content", () => {
+            const result = convertDraftJsToTipTap(
+                { blocks: [makeBlock({ type: "headline450", text: "" })], entityMap: {} },
+                {
+                    supports: [...defaultSupports],
+                    textBlockStyleMap: { headline450: { textBlockType: "heading-2", textBlockStyle: "headline450" } },
+                },
+            );
+            expect(result.content).toEqual([{ type: "heading", attrs: { level: 2, textBlockStyle: "headline450" } }]);
         });
     });
 

--- a/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.ts
@@ -38,14 +38,36 @@ interface DraftJsContent {
     entityMap: Record<string, DraftJsEntity>;
 }
 
+type TipTapTextBlockStyleTargetType = "paragraph" | "heading-1" | "heading-2" | "heading-3" | "heading-4" | "heading-5" | "heading-6";
+
+interface TextBlockStyleMapping {
+    /**
+     * TipTap text block type the DraftJS block is converted to. Use this for DraftJS block types
+     * that were rendered as a heading (e.g. a custom `headline450` block type rendered as `<h2>`),
+     * so the semantic tag isn't lost.
+     *
+     * Defaults to the type derived from the DraftJS block type: `header-one`…`header-six` keep
+     * their heading level, all other block types become a paragraph.
+     */
+    textBlockType?: TipTapTextBlockStyleTargetType;
+    /**
+     * TipTap `textBlockStyle` attribute value applied to the converted text block.
+     */
+    textBlockStyle?: string;
+}
+
 interface ConvertOptions {
     supports?: TipTapSupports[];
     link?: Block;
     /**
-     * Maps DraftJS block types (e.g. custom `paragraph-small`) to a TipTap paragraph
-     * `textBlockStyle` attribute value. Matched blocks become `{ type: "paragraph", attrs: { textBlockStyle: ... } }`.
+     * Maps DraftJS block types (e.g. custom `paragraph-small`) to a TipTap `textBlockStyle`
+     * attribute value. Matched blocks become `{ type: "paragraph", attrs: { textBlockStyle: ... } }`.
+     *
+     * Pass a `{ textBlockType, textBlockStyle }` object instead of a plain style name to also
+     * control the text block type, for instance to convert a DraftJS block type that was rendered
+     * as `<h2>` into a TipTap heading with level 2.
      */
-    textBlockStyleMap?: Record<string, string>;
+    textBlockStyleMap?: Record<string, string | TextBlockStyleMapping>;
     /**
      * Maps DraftJS custom inline style names (e.g. `highlight` from a DraftJS `customInlineStyles`
      * configuration) to TipTap `inlineStyle` mark type values.
@@ -70,6 +92,16 @@ const HEADER_TYPE_TO_LEVEL: Record<string, number> = {
     "header-four": 4,
     "header-five": 5,
     "header-six": 6,
+};
+
+const TEXT_BLOCK_TYPE_TO_HEADING_LEVEL: Record<TipTapTextBlockStyleTargetType, number | undefined> = {
+    paragraph: undefined,
+    "heading-1": 1,
+    "heading-2": 2,
+    "heading-3": 3,
+    "heading-4": 4,
+    "heading-5": 5,
+    "heading-6": 6,
 };
 
 function makeEmptyDoc(): JSONContent {
@@ -218,19 +250,23 @@ function splitAtomChars(text: string, marks: NonNullable<JSONContent["marks"]>, 
     return nodes;
 }
 
-function makeLeafBlockNode(type: "paragraph" | "heading", inlineContent: JSONContent[], headingLevel?: number): JSONContent {
-    const node: JSONContent = { type };
-    if (type === "heading" && headingLevel !== undefined) {
-        node.attrs = { level: headingLevel };
-    }
-    if (inlineContent.length > 0) {
-        node.content = inlineContent;
-    }
-    return node;
-}
+function makeTextBlockNode(
+    inlineContent: JSONContent[],
+    { headingLevel, textBlockStyle }: { headingLevel?: number; textBlockStyle?: string } = {},
+): JSONContent {
+    const node: JSONContent = { type: headingLevel !== undefined ? "heading" : "paragraph" };
 
-function makeParagraphWithTextBlockStyle(inlineContent: JSONContent[], textBlockStyle: string): JSONContent {
-    const node: JSONContent = { type: "paragraph", attrs: { textBlockStyle } };
+    const attrs: JSONContent["attrs"] = {};
+    if (headingLevel !== undefined) {
+        attrs.level = headingLevel;
+    }
+    if (textBlockStyle !== undefined) {
+        attrs.textBlockStyle = textBlockStyle;
+    }
+    if (Object.keys(attrs).length > 0) {
+        node.attrs = attrs;
+    }
+
     if (inlineContent.length > 0) {
         node.content = inlineContent;
     }
@@ -240,8 +276,15 @@ function makeParagraphWithTextBlockStyle(inlineContent: JSONContent[], textBlock
 function makeListItem(inlineContent: JSONContent[]): JSONContent {
     return {
         type: "listItem",
-        content: [makeLeafBlockNode("paragraph", inlineContent)],
+        content: [makeTextBlockNode(inlineContent)],
     };
+}
+
+function normalizeTextBlockStyleMapping(mapping: string | TextBlockStyleMapping | undefined): TextBlockStyleMapping | undefined {
+    if (mapping === undefined) {
+        return undefined;
+    }
+    return typeof mapping === "string" ? { textBlockStyle: mapping } : mapping;
 }
 
 export function convertDraftJsToTipTap(draftContent: DraftJsContent | undefined | null, options: ConvertOptions = {}): JSONContent {
@@ -291,18 +334,16 @@ export function convertDraftJsToTipTap(draftContent: DraftJsContent | undefined 
 
         flushList();
 
-        const mappedTextBlockStyle = textBlockStyleMap[block.type];
-        if (mappedTextBlockStyle !== undefined) {
-            topLevel.push(makeParagraphWithTextBlockStyle(inlineContent, mappedTextBlockStyle));
-            continue;
-        }
+        const mapping = normalizeTextBlockStyleMapping(textBlockStyleMap[block.type]);
+        const headingLevel =
+            mapping?.textBlockType !== undefined ? TEXT_BLOCK_TYPE_TO_HEADING_LEVEL[mapping.textBlockType] : HEADER_TYPE_TO_LEVEL[block.type];
 
-        const headerLevel = HEADER_TYPE_TO_LEVEL[block.type];
-        if (headerLevel !== undefined && supports.has("heading")) {
-            topLevel.push(makeLeafBlockNode("heading", inlineContent, headerLevel));
-        } else {
-            topLevel.push(makeLeafBlockNode("paragraph", inlineContent));
-        }
+        topLevel.push(
+            makeTextBlockNode(inlineContent, {
+                headingLevel: headingLevel !== undefined && supports.has("heading") ? headingLevel : undefined,
+                textBlockStyle: mapping?.textBlockStyle,
+            }),
+        );
     }
 
     flushList();
@@ -334,4 +375,4 @@ export function buildStrippedTipTapDoc(draftContent: DraftJsContent | undefined 
     return { type: "doc", content };
 }
 
-export type { ConvertOptions, DraftJsContent };
+export type { ConvertOptions, DraftJsContent, TextBlockStyleMapping };


### PR DESCRIPTION
A Draft.js block type listed in `migrateFromDraftJs.textBlockStyleMap` was always converted to a paragraph, so a `header-two` block mapped to a `headline450` style lost its heading tag and was rendered with whatever tag the style defaults to. Mapped header types now keep their heading level and only receive the mapped `textBlockStyle`.

For custom Draft.js block types that were rendered as a heading (e.g. a `headline450` block type rendered as `<h2>`), the target text block type can now be set explicitly by passing an object instead of a style name:

**Example**

```ts
createTipTapRichTextBlock({
    textBlockStyles: [{ name: "headline450", appliesTo: ["heading-2"] }],
    migrateFromDraftJs: {
        textBlockStyleMap: { headline450: { textBlockType: "heading-2", textBlockStyle: "headline450" } },
    },
});
```

`textBlockType` accepts `paragraph` and `heading-1` … `heading-6`, and both properties are optional.

https://claude.ai/code/session_01AXFCbB7HDnMGWBTWHWn4do