### PR TITLE
mail-react: Keep list markers on one line in Outlook on the web

### DIFF
--- a/.changeset/fix-rich-text-list-marker-line-break.md
+++ b/.changeset/fix-rich-text-list-marker-line-break.md
@@ -1,0 +1,5 @@
+---
+"@comet/mail-react": patch
+---
+
+Fix the RichText block's ordered list markers (e.g. `10.`) breaking over two lines in Outlook on the web

--- a/packages/mail-react/src/blocks/richText/RichTextList.tsx
+++ b/packages/mail-react/src/blocks/richText/RichTextList.tsx
@@ -19,6 +19,15 @@ function variantModifier(variantName: string): string {
     return `richTextBlock__list--variant${variantName.charAt(0).toUpperCase()}${variantName.slice(1)}`;
 }
 
+// MJML wraps every child of a column in a `<td>` with `word-break: break-word`, and this cell inherits it. That lets a
+// browser shrink the cell to one character wide, so the full-width text cell next to it pushes the marker onto two
+// lines. `word-break: normal` undoes it; `white-space: nowrap` alone does not, because Outlook on the web strips
+// `white-space` from inline styles.
+const markerCellNoLineBreak: CSSProperties = {
+    whiteSpace: "nowrap",
+    wordBreak: "normal",
+};
+
 interface RichTextListItem {
     key: string;
     content: ReactNode;
@@ -110,7 +119,7 @@ export function RichTextList({ ordered, variant, bottomSpacing, depth, items }: 
                                 style={{
                                     ...cellStyle,
                                     ...markerCellPadding,
-                                    whiteSpace: "nowrap", // The full-width text cell squeezes this column, so markers such as `10.` must stay on one line.
+                                    ...markerCellNoLineBreak,
                                 }}
                             >
                                 {resolveMarker(ordered ? list.orderedMarker : list.unorderedMarker, { index, depth })}

--- a/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
@@ -224,12 +224,12 @@ const depthMarkersTheme = createTheme({
     },
     list: {
         unorderedMarker: ({ depth }) => bulletLadder[depth % bulletLadder.length],
-        // 97 is the code of "a", so nested items are lettered a., b., c.
-        orderedMarker: ({ index, depth }) => (depth === 0 ? `${index + 1}.` : `${String.fromCharCode(97 + index)}.`),
+        // 65 is the code of "A", so nested items are lettered ItemA., ItemB., ItemC.
+        orderedMarker: ({ index, depth }) => (depth === 0 ? `${index + 1}.` : `Item${String.fromCharCode(65 + index)}.`),
     },
 });
 
-/** Both markers vary by `depth`: the bullets cycle through `▪`, `–`, `·`, and nested numbered items are lettered, each nested list starting again at `a.`. */
+/** Both markers vary by `depth`: the bullets cycle through `▪`, `–`, `·`, and nested numbered items are lettered, each nested list starting again at `A.`. */
 export const ListMarkersPerDepth: Story = {
     parameters: {
         theme: depthMarkersTheme,

--- a/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
@@ -222,12 +222,12 @@ const depthMarkersTheme = createTheme({
     },
     list: {
         unorderedMarker: ({ depth }) => bulletLadder[depth % bulletLadder.length],
-        // 97 is the code of "a", so nested items are lettered a., b., c.
-        orderedMarker: ({ index, depth }) => (depth === 0 ? `${index + 1}.` : `${String.fromCharCode(97 + index)}.`),
+        // 65 is the code of "A", so nested items are lettered ItemA., ItemB., ItemC.
+        orderedMarker: ({ index, depth }) => (depth === 0 ? `${index + 1}.` : `Item${String.fromCharCode(65 + index)}.`),
     },
 });
 
-/** Both markers vary by `depth`: the bullets cycle through `▪`, `–`, `·`, and nested numbered items are lettered, each nested list starting again at `a.`. */
+/** Both markers vary by `depth`: the bullets cycle through `▪`, `–`, `·`, and nested numbered items are lettered, each nested list starting again at `A.`. */
 export const ListMarkersPerDepth: Story = {
     parameters: {
         theme: depthMarkersTheme,


### PR DESCRIPTION
`word-break: normal` is the fix. Resetting `overflow-wrap` alone does not help, because `break-word` takes effect whatever `overflow-wrap` says. The legacy `nowrap` attribute on the cell is no safer than the CSS, since Outlook on the web strips that too. A word joiner between the marker's characters is ignored, because `break-word` breaks at arbitrary points rather than at the usual opportunities.

| Before | After |
| --- | --- |
| <img width="771" height="692" alt="Mail List in Microsoft365 Web Mail - Before fix" src="https://github.com/user-attachments/assets/e80feb3a-ff63-49d2-9155-b3911065b180" /> | <img width="808" height="475" alt="Mail List in Microsoft365 Web Mail - After fix" src="https://github.com/user-attachments/assets/9cbca1df-6508-4c90-9d69-785552b1b305" /> |

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13351