### PR TITLE
Demo: Use mail-react's rich text block factory

### DIFF
--- a/demo/admin/src/mail/blocks/MailLinkBlock.tsx
+++ b/demo/admin/src/mail/blocks/MailLinkBlock.tsx
@@ -1,0 +1,9 @@
+import { createLinkBlock, ExternalLinkBlock, PhoneLinkBlock } from "@dextinity/cms-admin";
+
+export const MailLinkBlock = createLinkBlock({
+    name: "MailLink",
+    supportedBlocks: {
+        external: ExternalLinkBlock,
+        phone: PhoneLinkBlock,
+    },
+});

--- a/demo/admin/src/mail/blocks/MailRichTextBlock.tsx
+++ b/demo/admin/src/mail/blocks/MailRichTextBlock.tsx
@@ -1,8 +1,40 @@
-import { createRichTextBlock, ExternalLinkBlock } from "@dextinity/cms-admin";
+import { createRichTextBlock } from "@dextinity/cms-admin";
+import { Typography } from "@mui/material";
+import { MailLinkBlock } from "@src/mail/blocks/MailLinkBlock";
+import { FormattedMessage } from "react-intl";
 
 export const MailRichTextBlock = createRichTextBlock({
-    link: ExternalLinkBlock,
+    link: MailLinkBlock,
     rte: {
-        supports: ["bold", "italic", "header-one", "header-two", "header-three", "header-four", "header-five", "header-six", "link", "links-remove"],
+        supports: [
+            "bold",
+            "italic",
+            "sub",
+            "sup",
+            "strikethrough",
+            "unordered-list",
+            "ordered-list",
+            "history",
+            "link",
+            "links-remove",
+            "non-breaking-space",
+            "soft-hyphen",
+        ],
+        standardBlockType: "copy",
+        blocktypeMap: {
+            title: {
+                label: <FormattedMessage id="mail.richText.blockType.title" defaultMessage="Title" />,
+                renderConfig: {
+                    element: (props) => <Typography variant="h1" {...props} />,
+                },
+            },
+            header: {
+                label: <FormattedMessage id="mail.richText.blockType.header" defaultMessage="Header" />,
+                renderConfig: {
+                    element: (props) => <Typography variant="h2" {...props} />,
+                },
+            },
+            copy: { label: <FormattedMessage id="mail.richText.blockType.copy" defaultMessage="Copy" /> },
+        },
     },
 });

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -1740,6 +1740,79 @@
         "inputFields": []
     },
     {
+        "name": "MailLink",
+        "fields": [
+            {
+                "name": "title",
+                "kind": "String",
+                "nullable": true
+            },
+            {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": {
+                                "external": "ExternalLink",
+                                "phone": "PhoneLink"
+                            },
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
+            {
+                "name": "activeType",
+                "kind": "String",
+                "nullable": true
+            },
+            {
+                "name": "block",
+                "kind": "NestedObject",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": {
+                                "external": "ExternalLink",
+                                "phone": "PhoneLink"
+                            },
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": true
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "activeType",
+                "kind": "String",
+                "nullable": false
+            },
+            {
+                "name": "title",
+                "kind": "String",
+                "nullable": true
+            }
+        ]
+    },
+    {
         "name": "Media",
         "fields": [
             {

--- a/demo/api/src/db/fixtures/generators/welcome-email-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/welcome-email-fixture.service.ts
@@ -36,11 +36,11 @@ export class WelcomeEmailFixtureService {
 const greeting = {
     draftContent: {
         blocks: [
-            { key: "welcome", text: "Welcome to Dextinity", type: "header-one", depth: 0, inlineStyleRanges: [], entityRanges: [], data: {} },
+            { key: "welcome", text: "Welcome to Dextinity", type: "title", depth: 0, inlineStyleRanges: [], entityRanges: [], data: {} },
             {
                 key: "intro",
                 text: "Your account is ready. We are glad to have you on board.",
-                type: "unstyled",
+                type: "copy",
                 depth: 0,
                 inlineStyleRanges: [],
                 entityRanges: [],
@@ -54,11 +54,11 @@ const greeting = {
 const nextSteps = {
     draftContent: {
         blocks: [
-            { key: "next-steps", text: "What happens next", type: "header-two", depth: 0, inlineStyleRanges: [], entityRanges: [], data: {} },
+            { key: "next-steps", text: "What happens next", type: "header", depth: 0, inlineStyleRanges: [], entityRanges: [], data: {} },
             {
                 key: "next-steps-text",
                 text: "Sign in to the admin to edit this mail. Every change shows up in the preview beside the form.",
-                type: "unstyled",
+                type: "copy",
                 depth: 0,
                 inlineStyleRanges: [],
                 entityRanges: [],

--- a/demo/api/src/mail/blocks/mail-link.block.ts
+++ b/demo/api/src/mail/blocks/mail-link.block.ts
@@ -1,0 +1,11 @@
+import { createLinkBlock, ExternalLinkBlock, PhoneLinkBlock } from "@dextinity/cms-api";
+
+export const MailLinkBlock = createLinkBlock(
+    {
+        supportedBlocks: {
+            external: ExternalLinkBlock,
+            phone: PhoneLinkBlock,
+        },
+    },
+    "MailLink",
+);

--- a/demo/api/src/mail/blocks/mail-rich-text.block.ts
+++ b/demo/api/src/mail/blocks/mail-rich-text.block.ts
@@ -1,3 +1,4 @@
-import { createRichTextBlock, ExternalLinkBlock } from "@dextinity/cms-api";
+import { createRichTextBlock } from "@dextinity/cms-api";
+import { MailLinkBlock } from "@src/mail/blocks/mail-link.block";
 
-export const MailRichTextBlock = createRichTextBlock({ link: ExternalLinkBlock });
+export const MailRichTextBlock = createRichTextBlock({ link: MailLinkBlock });

--- a/demo/site/src/mail/blocks/MailRichTextBlock.tsx
+++ b/demo/site/src/mail/blocks/MailRichTextBlock.tsx
@@ -1,54 +1,23 @@
-import { MjmlColumn, MjmlSection, MjmlText, type MjmlTextProps, type PropsWithData } from "@dextinity/mail-react";
-import { ExternalLinkBlock } from "@dextinity/site-nextjs";
-import type { ExternalLinkBlockData, RichTextBlockData } from "@src/blocks.generated";
-import { type FC, isValidElement } from "react";
-import redraft, { type Renderers, type TextBlockRenderFn } from "redraft";
+import { createRichTextBlock, MjmlColumn, MjmlSection, type PropsWithData } from "@dextinity/mail-react";
+import type { PhoneLinkBlockData, RichTextBlockData } from "@src/blocks.generated";
 
-function createTextBlockRenderFn(props: MjmlTextProps): TextBlockRenderFn {
-    return (children, { keys }) =>
-        children.map((child, index) => (
-            <MjmlText key={keys[index]} bottomSpacing {...props}>
-                {child}
-            </MjmlText>
-        ));
-}
-
-const defaultRichTextRenderers: Renderers = {
-    inline: {
-        BOLD: (children, { key }) => <b key={key}>{children}</b>,
-        ITALIC: (children, { key }) => <i key={key}>{children}</i>,
+const { MjmlRichTextBlock } = createRichTextBlock({
+    blockTypes: {
+        title: { variant: "title" },
+        header: { variant: "header" },
+        copy: { variant: "copy" },
     },
-    blocks: {
-        unstyled: createTextBlockRenderFn({ variant: "copy" }),
-        "header-one": createTextBlockRenderFn({ variant: "title" }),
-        "header-two": createTextBlockRenderFn({ variant: "header" }),
-        "header-three": createTextBlockRenderFn({ variant: "header" }),
-        "header-four": createTextBlockRenderFn({ variant: "header" }),
-        "header-five": createTextBlockRenderFn({ variant: "header" }),
-        "header-six": createTextBlockRenderFn({ variant: "header" }),
+    linkTypes: {
+        phone: (props: PhoneLinkBlockData) => (props.phone ? `tel:${props.phone}` : undefined),
     },
-    /**
-     * Entities receive children and the entity data
-     */
-    entities: {
-        // key is the entity key value from raw
-        LINK: (children, data: ExternalLinkBlockData, { key }) =>
-            data.targetUrl && isValidElement(children) ? (
-                <ExternalLinkBlock key={key} data={data}>
-                    {children}
-                </ExternalLinkBlock>
-            ) : (
-                <span key={key}>{children}</span>
-            ),
-    },
-};
+});
 
-export const MailRichTextBlock: FC<PropsWithData<RichTextBlockData>> = ({ data }) => {
-    const rendered = redraft(data.draftContent, defaultRichTextRenderers);
-
+export const MailRichTextBlock = ({ data }: PropsWithData<RichTextBlockData>) => {
     return (
         <MjmlSection indent>
-            <MjmlColumn>{rendered}</MjmlColumn>
+            <MjmlColumn>
+                <MjmlRichTextBlock data={data} />
+            </MjmlColumn>
         </MjmlSection>
     );
 };


### PR DESCRIPTION
The editor offered six heading levels while the mail theme has only three text variants, so `header-three` through `header-six` all rendered the same. Authors could pick a style that changed nothing.

The demo also had no example of lists or phone links.

Rich text stored before this change breaks, and there is no migration. Old headings render as body text, and old links lose their href because `MailLinkBlock` nests the link data under `block`. Only Brevo email campaigns can hold such content, and they are rare enough not to justify a migration in a demo that runs only locally.