### PR TITLE
Use junit-unit.xml for unit test results in all packages

### DIFF
--- a/demo/api/vitest.config.ts
+++ b/demo/api/vitest.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
     test: {
         exclude: ["dist/**", "node_modules/**"],
         reporters: ["default", "junit"],
-        outputFile: { junit: "./junit.xml" },
+        outputFile: { junit: "./junit-unit.xml" },
     },
 });

--- a/packages/admin/admin-generator/vitest.config.ts
+++ b/packages/admin/admin-generator/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     test: {
         reporters: ["default", "junit"],
         outputFile: {
-            junit: "./junit.xml",
+            junit: "./junit-unit.xml",
         },
     },
 });

--- a/packages/admin/admin-rte/vitest.config.ts
+++ b/packages/admin/admin-rte/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
         environment: "jsdom",
         reporters: ["default", "junit"],
         outputFile: {
-            junit: "./junit.xml",
+            junit: "./junit-unit.xml",
         },
     },
 });

--- a/packages/admin/admin/vitest.config.ts
+++ b/packages/admin/admin/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     test: {
         reporters: ["default", "junit"],
         outputFile: {
-            junit: "./junit.xml",
+            junit: "./junit-unit.xml",
         },
         projects: [
             {

--- a/packages/admin/cms-admin/vitest.config.ts
+++ b/packages/admin/cms-admin/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     test: {
         reporters: ["default", "junit"],
         outputFile: {
-            junit: "./junit.xml",
+            junit: "./junit-unit.xml",
         },
         projects: [
             {

--- a/packages/api/api-generator/vitest.config.ts
+++ b/packages/api/api-generator/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
         setupFiles: ["./vitest.setup.ts"],
         reporters: ["default", "junit"],
         outputFile: {
-            junit: "./junit.xml",
+            junit: "./junit-unit.xml",
         },
         testTimeout: 20000,
         hookTimeout: 20000,

--- a/packages/api/brevo-api/vitest.config.ts
+++ b/packages/api/brevo-api/vitest.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
         environment: "node",
         setupFiles: ["./vitest.setup.ts"],
         reporters: ["default", "junit"],
-        outputFile: { junit: "./junit.xml" },
+        outputFile: { junit: "./junit-unit.xml" },
     },
 });

--- a/packages/api/cms-api/vitest.config.ts
+++ b/packages/api/cms-api/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
         setupFiles: ["./vitest.setup.ts"],
         reporters: ["default", "junit"],
         outputFile: {
-            junit: "./junit.xml",
+            junit: "./junit-unit.xml",
         },
         testTimeout: 10000,
     },

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     test: {
         environment: "node",
         reporters: ["default", "junit"],
-        outputFile: { junit: "./junit.xml" },
+        outputFile: { junit: "./junit-unit.xml" },
         exclude: ["lib/**", "node_modules/**"],
     },
 });

--- a/packages/eslint-plugin/vitest.config.ts
+++ b/packages/eslint-plugin/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     test: {
         environment: "node",
         reporters: ["default", "junit"],
-        outputFile: { junit: "./junit.xml" },
+        outputFile: { junit: "./junit-unit.xml" },
         setupFiles: "./vitest.setup.ts",
     },
 });

--- a/packages/mail-react/vitest.config.ts
+++ b/packages/mail-react/vitest.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
         reporters: ["default", "junit"],
-        outputFile: { junit: "./junit.xml" },
+        outputFile: { junit: "./junit-unit.xml" },
         projects: [
             {
                 test: {

--- a/packages/site/site-nextjs/vitest.config.ts
+++ b/packages/site/site-nextjs/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
         environment: "jsdom",
         reporters: ["default", "junit"],
         outputFile: {
-            junit: "./junit.xml",
+            junit: "./junit-unit.xml",
         },
     },
 });

--- a/packages/site/site-react/vitest.config.ts
+++ b/packages/site/site-react/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
         environment: "jsdom",
         reporters: ["default", "junit"],
         outputFile: {
-            junit: "./junit.xml",
+            junit: "./junit-unit.xml",
         },
     },
 });

--- a/storybook/vitest.config.ts
+++ b/storybook/vitest.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
         reporters: ["default", "junit"],
-        outputFile: { junit: "./junit-storybook.xml" },
+        outputFile: { junit: "./junit.xml" },
         projects: [
             {
                 plugins: [storybookTest({ configDir: ".storybook" })],

--- a/storybook/vitest.config.ts
+++ b/storybook/vitest.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
         reporters: ["default", "junit"],
-        outputFile: { junit: "./junit.xml" },
+        outputFile: { junit: "./junit-storybook.xml" },
         projects: [
             {
                 plugins: [storybookTest({ configDir: ".storybook" })],


### PR DESCRIPTION
## Description

The `Test (unit)` job in `.github/workflows/test.yml` uploads test results by collecting files matching `packages/*/junit-unit.xml` and `packages/*/*/junit-unit.xml`. Most packages' `vitest.config.ts` wrote their JUnit report to `junit.xml` instead, so those results were silently dropped from the uploaded artifact.

## Solution

Aligned each package's `vitest.config.ts` `outputFile.junit` setting to match the `Test (unit)` job's collection pattern, so unit test configs now write `./junit-unit.xml`.

`storybook/vitest.config.ts` is unchanged (`./junit.xml`) — the `Test (storybook)` job collects the root storybook package's own results from `storybook/junit.xml` verbatim; `packages/*/junit-storybook.xml` is only for storybook tests nested inside other packages (e.g. `packages/admin/admin`), which already produce the right filename via an `--outputFile.junit` CLI flag in their `test:storybook` script.

`packages/mail-react`, `packages/admin/admin`, and `packages/admin/cms-admin` also already produced the correct `junit-unit.xml`/`junit-storybook.xml` filenames via that same CLI flag, which overrides the base config — their `vitest.config.ts` defaults were still wrong (`junit.xml`) and are now fixed for consistency, even though it had no effect on CI.

## Example usage

Running `pnpm run test:unit` in, e.g., `packages/cli` now produces `packages/cli/junit-unit.xml` (verified locally), matching what the workflow's `actions/upload-artifact` step expects.

## Further information

No changeset added — this is an internal CI/test-config change with no effect on any package's public API or runtime behavior.

Closes #6179

---
_Generated by [Claude Code](https://claude.ai/code)_
