### PR TITLE
Show the GraphQL error messages in the error dialog again

### DIFF
--- a/.changeset/olive-pears-invent.md
+++ b/.changeset/olive-pears-invent.md
@@ -1,0 +1,8 @@
+---
+"@dextinity/admin": patch
+---
+
+Show the GraphQL error messages in the error dialog again
+
+`createErrorDialogApolloLink` only passed the message of network errors to the `ErrorDialog`.
+For GraphQL errors, the dialog showed "Unknown error" instead of the actual messages (e.g., the message of a `BadRequestException` thrown by the API).

--- a/packages/admin/admin/src/error/errordialog/createErrorDialogApolloLink.test.ts
+++ b/packages/admin/admin/src/error/errordialog/createErrorDialogApolloLink.test.ts
@@ -1,0 +1,76 @@
+import { ApolloClient, ApolloLink, type FetchResult, gql, InMemoryCache, Observable } from "@apollo/client";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createErrorDialogApolloLink } from "./createErrorDialogApolloLink";
+import { errorDialogVar } from "./errorDialogVar";
+
+const testQuery = gql`
+    query Test {
+        foo
+    }
+`;
+
+async function executeQueryWithError({ errors, networkError }: { errors?: GraphQLError[]; networkError?: Error }) {
+    const responseLink = new ApolloLink(
+        () =>
+            new Observable<FetchResult>((observer) => {
+                if (networkError) {
+                    observer.error(networkError);
+                } else {
+                    observer.next({ errors });
+                    observer.complete();
+                }
+            }),
+    );
+
+    const client = new ApolloClient({
+        link: ApolloLink.from([createErrorDialogApolloLink(), responseLink]),
+        cache: new InMemoryCache(),
+    });
+
+    try {
+        await client.query({ query: testQuery, fetchPolicy: "no-cache" });
+    } catch {
+        // The error is reported via errorDialogVar
+    }
+}
+
+describe("createErrorDialogApolloLink", () => {
+    beforeEach(() => {
+        errorDialogVar(undefined);
+    });
+
+    it("shows the messages of GraphQL errors", async () => {
+        await executeQueryWithError({
+            errors: [
+                new GraphQLError("Validation failed", { extensions: { code: "BAD_REQUEST" } }),
+                new GraphQLError("Product not found", { extensions: { code: "BAD_REQUEST" } }),
+            ],
+        });
+
+        expect(errorDialogVar()?.error).toEqual(["Validation failed", "Product not found"]);
+        expect(errorDialogVar()?.additionalInformation?.errorType).toBe("graphql");
+    });
+
+    it("shows the message of a network error", async () => {
+        await executeQueryWithError({ networkError: new Error("Failed to fetch") });
+
+        expect(errorDialogVar()?.error).toBe("Failed to fetch");
+        expect(errorDialogVar()?.additionalInformation?.errorType).toBe("network");
+    });
+
+    it("prioritizes GraphQL errors over the network error", async () => {
+        const serverError = Object.assign(new Error("Response not successful: Received status code 400"), {
+            name: "ServerError",
+            statusCode: 400,
+            result: { errors: [new GraphQLError("Validation failed", { extensions: { code: "BAD_REQUEST" } })] },
+        });
+
+        await executeQueryWithError({ networkError: serverError });
+
+        expect(errorDialogVar()?.error).toEqual(["Validation failed"]);
+        expect(errorDialogVar()?.additionalInformation?.errorType).toBe("graphql");
+        expect(errorDialogVar()?.additionalInformation?.httpStatus).toBe("400 Bad Request");
+    });
+});

--- a/packages/admin/admin/src/error/errordialog/createErrorDialogApolloLink.tsx
+++ b/packages/admin/admin/src/error/errordialog/createErrorDialogApolloLink.tsx
@@ -19,7 +19,9 @@ export const createErrorDialogApolloLink = (config?: { signInUrl?: string }) => 
         let errorType: ErrorType | undefined;
         let httpStatus: string | undefined;
 
-        if (graphQLErrors) {
+        if (graphQLErrors?.length) {
+            error = graphQLErrors.map(({ message }) => message);
+
             if (graphQLErrors.some((e) => e.extensions?.code === "FORBIDDEN")) {
                 errorType = "unauthenticated"; // Error is triggered by Dextinity Guard
             } else if (graphQLErrors.some((e) => e.extensions?.code === "UNAUTHENTICATED")) {


### PR DESCRIPTION
## Problem

When a request fails with a GraphQL error, the error dialog shows `Unknown error` instead of the actual message.

## Cause

`createErrorDialogApolloLink` assigns `error` only in the `networkError` branch. The `graphQLErrors` branch sets `errorType` but never `error`, so the dialog falls back to `"Unknown error"`.

The missing `error = graphQLErrors.map(({ message }) => message)` was dropped while resolving the auth error conflicts when `main` was merged into `next` before v7 ([`20eb0fa`](https://github.com/vivid-planet/comet/commit/20eb0fa445f6d99fa0af1dddb0c3557104a4d728)) — which is also why the `if (!error)` guard in the network branch has been dead code since.

## Fix

The link passes the messages of all GraphQL errors to the dialog again. Network errors are unchanged, and GraphQL errors take precedence over an accompanying network error, as the guard intended.

Nothing is newly exposed in production: `ExceptionFilter` in `@dextinity/cms-api` already masks unexpected errors as `Internal Server Error` when `debug` is off.

## Screenshots/screencasts

Demo Admin, opening a product with an ID that does not exist — the API answers with `Product not found ('00000000-…')`:

| Before | After |
| ------ | ----- |
| <img width="2048" height="972" alt="errordialogbefore" src="https://github.com/user-attachments/assets/77e98b5d-9bf7-4062-960d-0a859cd16b0c" />  | <img width="2048" height="972" alt="errordialogafter" src="https://github.com/user-attachments/assets/06dca171-45ec-4fed-bb99-0ebc7ee2c0d6" /> |

## Verification

Tests cover the three paths through the link: a GraphQL-only error, a network-only error, and a `ServerError` carrying GraphQL errors in its result. The first and third fail without the fix.
