### PR TITLE
Remove v7 from supported versions in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,7 @@ The versions of the project that are currently supported with security updates.
 |--------:|:--------------------------------------|
 |     9.x | :white_check_mark:                    |
 |     8.x | :white_check_mark: (until 2027-07-07) |
-|     7.x | :white_check_mark: (until 2026-08-07) |
-|   < 7.x | :x:                                   |
+|   < 8.x | :x:                                   |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
## Status quo

`SECURITY.md` still lists `7.x` as supported with security updates until `2026-08-07`. That date has passed, so the table claims support the project no longer provides.

## Change

Drop the `7.x` row and widen the unsupported row from `< 7.x` to `< 8.x`, so the supported versions are `9.x` and `8.x` (until `2027-07-07`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UCKHwZKAQPC76KDf7cBVrR)_