### PR TITLE
Add `aiContentTypes` DAM config to restrict AI content type options

### DIFF
--- a/.changeset/dam-restrict-ai-content-types.md
+++ b/.changeset/dam-restrict-ai-content-types.md
@@ -1,0 +1,25 @@
+---
+"@comet/cms-admin": minor
+---
+
+Add `aiContentTypes` to the DAM config to restrict the AI content types editors can choose from
+
+Previously, the **AI content** field in the DAM file settings always offered both `Generated` and `Modified`, and there was no way to hide the field.
+Projects that only need one of the types (or none at all) can now configure which types are available:
+
+**Example**
+
+```tsx
+// In App.tsx
+<CometConfigProvider
+    dam={{
+        // Other DAM config
+        aiContentTypes: ["Generated"],
+    }}
+>
+```
+
+Pass an empty array to hide the **AI content** field entirely.
+It defaults to all types, so existing projects are unaffected.
+
+A type that is already set on an asset stays selectable, even if it isn't configured, so existing values aren't changed silently.

--- a/docs/docs/3-features-modules/3-asset-management/ai-content-disclosure.md
+++ b/docs/docs/3-features-modules/3-asset-management/ai-content-disclosure.md
@@ -39,6 +39,26 @@ Editors mark an asset in the DAM file settings via the **AI content** field, whi
 
 The field is shown for **image, video and audio assets only**, since a deep fake is image, audio or video content. Other file types (e.g. SVGs, documents) cannot constitute a deep fake — in particular, a vector SVG cannot appear photorealistic, so it falls outside the disclosure obligation.
 
+#### Restricting the available AI content types
+
+By default, editors can choose between both types.
+Projects that only need one of them can restrict the selection via `aiContentTypes` in the DAM config:
+
+```tsx
+// In App.tsx
+<CometConfigProvider
+    dam={{
+        // Other DAM config
+        aiContentTypes: ["Generated"],
+    }}
+>
+```
+
+Pass an empty array to hide the **AI content** field entirely.
+
+Assets that already have an AI content type set keep it selectable, even if the type isn't configured.
+This way, existing values aren't changed silently when an editor saves such an asset.
+
 ### Disclosure on the site
 
 When a marked asset is rendered, `PixelImageBlock` (`@comet/site-nextjs`) and `DamVideoBlock` (`@comet/site-react`) automatically render:

--- a/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/FileSettingsFields.tsx
@@ -14,6 +14,7 @@ import { useDamConfig } from "../config/damConfig";
 import { useDamAcceptedMimeTypes } from "../config/useDamAcceptedMimeTypes";
 import { useDamScope } from "../config/useDamScope";
 import { slugifyFilename } from "../helpers/slugifyFilename";
+import { aiContentTypeLabels, getSelectableAiContentTypes } from "./aiContentType";
 import { CropSettingsFields } from "./CropSettingsFields";
 import type { DamFileDetails, EditFileFormValues } from "./EditFile";
 import type { GQLDamIsFilenameOccupiedQuery, GQLDamIsFilenameOccupiedQueryVariables } from "./FileSettingsFields.generated";
@@ -52,6 +53,10 @@ export const FileSettingsFields = ({ file }: SettingsFormProps) => {
     const damConfig = useDamConfig();
     const formApi = useForm();
     const { contentGeneration } = useDamConfig();
+    const selectableAiContentTypes = getSelectableAiContentTypes({
+        configuredAiContentTypes: damConfig.aiContentTypes,
+        currentAiContentType: file.aiContentType,
+    });
     const contentScope = useContentScope();
     const language = useContentLanguage(contentScope);
 
@@ -186,7 +191,7 @@ export const FileSettingsFields = ({ file }: SettingsFormProps) => {
                     }
                 />
             </FormSection>
-            {supportsAiContentType && (
+            {supportsAiContentType && selectableAiContentTypes.length > 0 && (
                 <FormSection title={<FormattedMessage id="comet.dam.file.aiContent" defaultMessage="AI content" />}>
                     <SelectField
                         name="aiContentType"
@@ -206,14 +211,10 @@ export const FileSettingsFields = ({ file }: SettingsFormProps) => {
                                 value: "",
                                 label: <FormattedMessage id="comet.dam.file.aiContentType.no" defaultMessage="No" />,
                             },
-                            {
-                                value: "Generated",
-                                label: <FormattedMessage id="comet.dam.file.aiContentType.generated" defaultMessage="AI generated" />,
-                            },
-                            {
-                                value: "Modified",
-                                label: <FormattedMessage id="comet.dam.file.aiContentType.modified" defaultMessage="AI modified" />,
-                            },
+                            ...selectableAiContentTypes.map((aiContentType) => ({
+                                value: aiContentType,
+                                label: aiContentTypeLabels[aiContentType],
+                            })),
                         ]}
                     />
                 </FormSection>

--- a/packages/admin/cms-admin/src/dam/FileForm/aiContentType.test.ts
+++ b/packages/admin/cms-admin/src/dam/FileForm/aiContentType.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { getSelectableAiContentTypes } from "./aiContentType";
+
+describe("getSelectableAiContentTypes", () => {
+    it("offers all types when none are configured", () => {
+        expect(getSelectableAiContentTypes({})).toEqual(["Generated", "Modified"]);
+    });
+
+    it("offers only the configured types", () => {
+        expect(getSelectableAiContentTypes({ configuredAiContentTypes: ["Generated"] })).toEqual(["Generated"]);
+        expect(getSelectableAiContentTypes({ configuredAiContentTypes: ["Modified"] })).toEqual(["Modified"]);
+    });
+
+    it("offers no type when the configured types are empty", () => {
+        expect(getSelectableAiContentTypes({ configuredAiContentTypes: [] })).toEqual([]);
+    });
+
+    it("keeps the type already set on the file selectable although it isn't configured", () => {
+        expect(getSelectableAiContentTypes({ configuredAiContentTypes: ["Generated"], currentAiContentType: "Modified" })).toEqual([
+            "Generated",
+            "Modified",
+        ]);
+        expect(getSelectableAiContentTypes({ configuredAiContentTypes: [], currentAiContentType: "Modified" })).toEqual(["Modified"]);
+    });
+
+    it("doesn't offer a type twice when it is both configured and set on the file", () => {
+        expect(getSelectableAiContentTypes({ configuredAiContentTypes: ["Generated"], currentAiContentType: "Generated" })).toEqual(["Generated"]);
+    });
+
+    it("keeps a stable order regardless of the configured order", () => {
+        expect(getSelectableAiContentTypes({ configuredAiContentTypes: ["Modified", "Generated"] })).toEqual(["Generated", "Modified"]);
+    });
+});

--- a/packages/admin/cms-admin/src/dam/FileForm/aiContentType.tsx
+++ b/packages/admin/cms-admin/src/dam/FileForm/aiContentType.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import { FormattedMessage } from "react-intl";
+
+import type { GQLDamFileAiContentType } from "../../graphql.generated";
+
+export type DamFileAiContentType = GQLDamFileAiContentType;
+
+export const aiContentTypeArray: readonly DamFileAiContentType[] = ["Generated", "Modified"];
+
+export const aiContentTypeLabels: { [key in DamFileAiContentType]: ReactNode } = {
+    Generated: <FormattedMessage id="comet.dam.file.aiContentType.generated" defaultMessage="AI generated" />,
+    Modified: <FormattedMessage id="comet.dam.file.aiContentType.modified" defaultMessage="AI modified" />,
+};
+
+export function getSelectableAiContentTypes({
+    configuredAiContentTypes = aiContentTypeArray,
+    currentAiContentType,
+}: {
+    configuredAiContentTypes?: readonly DamFileAiContentType[];
+    // A type that is already set on the file stays selectable, so that an existing value isn't silently changed on save.
+    currentAiContentType?: DamFileAiContentType | null;
+}): DamFileAiContentType[] {
+    return aiContentTypeArray.filter((aiContentType) => configuredAiContentTypes.includes(aiContentType) || aiContentType === currentAiContentType);
+}

--- a/packages/admin/cms-admin/src/dam/config/damConfig.ts
+++ b/packages/admin/cms-admin/src/dam/config/damConfig.ts
@@ -1,12 +1,18 @@
 import type { ReactNode } from "react";
 
 import { useCometConfig } from "../../config/CometConfigContext";
+import type { DamFileAiContentType } from "../FileForm/aiContentType";
 
 export interface DamConfig {
     acceptedMimeTypes?: string[];
     scopeParts?: string[];
     enableLicenseFeature?: boolean;
     requireLicense?: boolean;
+    /**
+     * AI content types editors can choose from in the DAM file settings. Defaults to all types.
+     * Pass an empty array to hide the AI content field entirely.
+     */
+    aiContentTypes?: readonly DamFileAiContentType[];
     additionalToolbarItems?: ReactNode;
     importSources?: Record<string, { label: ReactNode }>;
     contentGeneration?: {

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -155,6 +155,7 @@ export { DamPage } from "./dam/DamPage";
 export type { FileWithDamUploadMetadata } from "./dam/DataGrid/fileUpload/useDamFileUpload";
 export { useDamFileUpload } from "./dam/DataGrid/fileUpload/useDamFileUpload";
 export { createDamFileDependency } from "./dam/dependencies/createDamFileDependency";
+export type { DamFileAiContentType } from "./dam/FileForm/aiContentType";
 export { DashboardHeader, type DashboardHeaderProps } from "./dashboard/DashboardHeader";
 export { DashboardWidgetRoot, type DashboardWidgetRootProps } from "./dashboard/widgets/DashboardWidgetRoot";
 export { LatestBuildsDashboardWidget } from "./dashboard/widgets/LatestBuildsDashboardWidget";


### PR DESCRIPTION
## Motivation

The **AI content** field in the DAM file settings always offers both `Generated` and `Modified`, and there is no way to hide the field. Projects that only ever mark fully AI-generated assets cannot remove the `AI modified` option: `FileSettingsFields` isn't exported from `@comet/cms-admin`, so the option list can't be replaced from a project either.

## Solution

`aiContentTypes` in the DAM config restricts which AI content types editors can choose from:

```tsx
// In App.tsx
<CometConfigProvider
    dam={{
        // Other DAM config
        aiContentTypes: ["Generated"],
    }}
>
```

It defaults to all types, so existing projects are unaffected. An empty array hides the **AI content** field entirely.

A type that is already set on an asset stays selectable even if it isn't configured, so an editor saving such an asset doesn't silently drop the value.

The field label and helper text still mention both types. Projects that restrict the selection can override `comet.dam.file.aiContentType` and `comet.dam.file.aiContentType.helperText` in their lang files.

## Decisions

- **An allowlist array rather than a per-type boolean flag** — `aiContentTypes: ["Generated"]` also covers turning the field off entirely (`[]`) and extends without a new config field should the EU labelling categories grow. A boolean such as `enableAiModifiedOption` would do neither.
- **Admin-only, no enforcement in the API** — `UpdateFileInput` still accepts every `DamFileAiContentType`. The admin is the only writer, and an unexpected `Modified` means over-disclosure rather than a security or compliance problem. Enforcing it in the API would duplicate the config in `DamModule` for no practical gain.

## Verification

`getSelectableAiContentTypes` is unit-tested in `aiContentType.test.ts`: the default, a restriction to a single type, an empty configuration, the already-set-value carve-out, deduplication when a type is both configured and set, and a stable option order regardless of the configured order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJdmjTMqzTXfj364B8yrW6


---
_Generated by [Claude Code](https://claude.ai/code/session_01WJdmjTMqzTXfj364B8yrW6)_