### PR TITLE
Generate TipTapNode type for rich text blocks

### DIFF
--- a/.changeset/generate-block-types-tiptap-node-type.md
+++ b/.changeset/generate-block-types-tiptap-node-type.md
@@ -2,9 +2,9 @@
 "@dextinity/cli": minor
 ---
 
-Add `TipTapNode` type to `generate-block-types` output and use it for TipTap rich text fields
+Add `TipTapNode` type to `generate-block-types` output and use it for TipTap rich text blocks
 
-Fields of TipTap rich text blocks were typed as `unknown`, forcing consumers to cast the content before rendering it.
+TipTap rich text blocks were typed as `unknown`, forcing consumers to cast the content before rendering it.
 They are now typed as `TipTapNode`, which is generated into `blocks.generated.ts` (together with `TipTapMark`) whenever a TipTap rich text block is used.
 
 **Example**

--- a/.changeset/generate-block-types-tiptap-node-type.md
+++ b/.changeset/generate-block-types-tiptap-node-type.md
@@ -1,0 +1,18 @@
+---
+"@dextinity/cli": minor
+---
+
+Add `TipTapNode` type to `generate-block-types` output and use it for TipTap rich text fields
+
+Fields of TipTap rich text blocks were typed as `unknown`, forcing consumers to cast the content before rendering it.
+They are now typed as `TipTapNode`, which is generated into `blocks.generated.ts` (together with `TipTapMark`) whenever a TipTap rich text block is used.
+
+**Example**
+
+```tsx
+// Before
+const content = data.tipTapContent as TipTapNode;
+
+// After
+const content = data.tipTapContent;
+```

--- a/demo/site/src/common/blocks/TipTapRichTextBlock.tsx
+++ b/demo/site/src/common/blocks/TipTapRichTextBlock.tsx
@@ -5,7 +5,6 @@ import {
     type PropsWithData,
     renderTipTapRichText,
     type TipTapMarkHandler,
-    type TipTapNode,
     type TipTapNodeHandler,
     withPreview,
 } from "@dextinity/site-nextjs";
@@ -88,7 +87,7 @@ interface TipTapRichTextBlockProps extends PropsWithData<TipTapRichTextBlockData
 
 export const TipTapRichTextBlock = withPreview(
     ({ data, disableLastBottomSpacing }: TipTapRichTextBlockProps) => {
-        const content = data.tipTapContent as TipTapNode;
+        const content = data.tipTapContent;
         const rendered = renderTipTapRichText({ content, nodeMapping, markMapping });
 
         return (

--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -1304,6 +1304,25 @@
         ]
     },
     {
+        "name": "TipTapRichText",
+        "fields": [
+            {
+                "name": "tipTapContent",
+                "kind": "TipTapRichTextBlock",
+                "nullable": false,
+                "childBlocks": {}
+            }
+        ],
+        "inputFields": [
+            {
+                "name": "tipTapContent",
+                "kind": "TipTapRichTextBlock",
+                "nullable": false,
+                "childBlocks": {}
+            }
+        ]
+    },
+    {
         "name": "VimeoVideo",
         "fields": [
             {

--- a/packages/api/cms-api/generate-block-meta.ts
+++ b/packages/api/cms-api/generate-block-meta.ts
@@ -7,6 +7,7 @@ import {
     createTableBlock,
     createTextImageBlock,
     createTextLinkBlock,
+    createTipTapRichTextBlock,
     EmailLinkBlock,
     ExternalLinkBlock,
     getBlocksMeta,
@@ -34,6 +35,9 @@ async function generateBlockMeta(): Promise<void> {
 
     // Create TableBlock for block types generation in client libraries
     createTableBlock({ richText: RichTextBlock });
+
+    // Create TipTapRichTextBlock for block types generation in client libraries
+    createTipTapRichTextBlock({ link: LinkBlock });
 
     const metaJson = getBlocksMeta();
     await fs.writeFile("block-meta.json", JSON.stringify(metaJson, null, 4));

--- a/packages/cli/src/commands/generate-block-types.ts
+++ b/packages/cli/src/commands/generate-block-types.ts
@@ -5,6 +5,21 @@ import { format, resolveConfig } from "prettier";
 import type { BlockMeta, BlockMetaField } from "../BlockMeta";
 
 let content = "";
+let isTipTapNodeTypeUsed = false;
+
+const tipTapNodeType = `export interface TipTapMark {
+    type: string;
+    attrs?: Record<string, unknown>;
+}
+
+export interface TipTapNode {
+    type: string;
+    attrs?: Record<string, unknown>;
+    content?: TipTapNode[];
+    marks?: TipTapMark[];
+    text?: string;
+}
+`;
 
 function writeFieldType(field: BlockMetaField, blockNamePostfix: string) {
     if (field.kind === "String") {
@@ -32,7 +47,8 @@ function writeFieldType(field: BlockMetaField, blockNamePostfix: string) {
             content += "[]";
         }
     } else if (field.kind === "TipTapRichTextBlock") {
-        content += "unknown";
+        isTipTapNodeTypeUsed = true;
+        content += "TipTapNode";
     } else if (field.kind === "Enum") {
         const enumType = `"${field.enum.join('" | "')}"`;
         content += field.array ? `(${enumType})[]` : enumType;
@@ -132,6 +148,10 @@ const generateBlockTypes = new Command("generate-block-types")
         }
 
         content += generateAllBlockNames(blockMeta);
+
+        if (isTipTapNodeTypeUsed) {
+            content = `${tipTapNodeType}\n${content}`;
+        }
 
         const prettierOptions = await resolveConfig(process.cwd());
         content = await format(content, { ...prettierOptions, parser: "typescript" });

--- a/packages/site/site-react/src/blocks/helpers/TipTapRichTextRenderer.tsx
+++ b/packages/site/site-react/src/blocks/helpers/TipTapRichTextRenderer.tsx
@@ -1,17 +1,8 @@
 import { cloneElement, isValidElement, type ReactNode } from "react";
 
-export interface TipTapMark {
-    type: string;
-    attrs?: Record<string, unknown>;
-}
+import type { TipTapMark, TipTapNode } from "../../blocks.generated";
 
-export interface TipTapNode {
-    type: string;
-    attrs?: Record<string, unknown>;
-    content?: TipTapNode[];
-    marks?: TipTapMark[];
-    text?: string;
-}
+export type { TipTapMark, TipTapNode };
 
 export interface TipTapNodeHandlerProps {
     node: TipTapNode;


### PR DESCRIPTION
## Summary
TipTap rich text blocks were generated as `unknown` in `blocks.generated.ts`, so every consumer had to cast the content before it could be rendered. They are now generated as `TipTapNode`.

## Changes
- `generate-block-types` emits `TipTapNode` (and `TipTapMark`) and uses `TipTapNode` for TipTap rich text blocks instead of `unknown`. The interfaces are only prepended to the output when a TipTap rich text block is actually present.
- `site-react` no longer defines `TipTapNode`/`TipTapMark` by hand — `TipTapRichTextRenderer` imports them from its generated block types and re-exports them, so there is a single definition. The exported type names and their shape are unchanged.
- `cms-api`'s `generate-block-meta.ts` creates the core `TipTapRichText` block, the same way it already does for `RichText`, `Table`, `TextImage`, `TextLink` and `Seo`, so the shared block meta carries it and the client libraries generate its types. `block-meta.json` was regenerated with the generator.
- Removed the now-unnecessary cast in the demo site.

**Why this direction:** the generated output has to stay standalone, because api, admin and mail clients run `generate-block-types` too and cannot depend on `site-react` (and `@dextinity/cli` is a devDependency with no `types` entry, so published packages could not resolve it either). The generator is therefore the definition, and `site-react` consumes it — mirroring how it already consumes the Draft.js `RichTextBlockData`.

**Example**

```tsx
// Before
const content = data.tipTapContent as TipTapNode;

// After
const content = data.tipTapContent;
```

https://claude.ai/code/session_01KeW8jj95RuXHci5TBJKfKy