### PR TITLE
cms-admin: Make TipTap rich text block toolbar sticky

### DIFF
--- a/.changeset/tiptap-toolbar-sticky.md
+++ b/.changeset/tiptap-toolbar-sticky.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/cms-admin": patch
+---
+
+Make the TipTap rich text block's toolbar sticky
+
+The toolbar now stays fixed at the top of the editor while scrolling through longer text content, matching the previous Draft.js-based rich text editor's behavior.

--- a/packages/admin/cms-admin/src/blocks/common/BlockAdminComponentRoot.tsx
+++ b/packages/admin/cms-admin/src/blocks/common/BlockAdminComponentRoot.tsx
@@ -31,7 +31,7 @@ export { BlockAdminComponentRoot };
 
 const ChildrenContainer = styled("div")`
     .DextinityAdminRte-root > .DextinityAdminRteToolbar-root,
-    .TipTapToolbar-root {
+    .DextinityAdminTipTapToolbar-root {
         top: 70px;
     }
 `;

--- a/packages/admin/cms-admin/src/blocks/common/BlockAdminComponentRoot.tsx
+++ b/packages/admin/cms-admin/src/blocks/common/BlockAdminComponentRoot.tsx
@@ -30,7 +30,8 @@ const BlockAdminComponentRoot = (props: PropsWithChildren<Props>) => {
 export { BlockAdminComponentRoot };
 
 const ChildrenContainer = styled("div")`
-    .DextinityAdminRte-root > .DextinityAdminRteToolbar-root {
+    .DextinityAdminRte-root > .DextinityAdminRteToolbar-root,
+    .TipTapToolbar-root {
         top: 70px;
     }
 `;

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -331,6 +331,9 @@ export const TipTapToolbar = ({
             sx={{
                 display: "flex",
                 flexWrap: "wrap",
+                position: "sticky",
+                top: 0,
+                zIndex: 2,
                 borderTop: `1px solid ${greyPalette[100]}`,
                 backgroundColor: muiGreyPalette[100],
                 px: "6px",

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -328,6 +328,7 @@ export const TipTapToolbar = ({
 
     return (
         <Box
+            className="TipTapToolbar-root"
             sx={{
                 display: "flex",
                 flexWrap: "wrap",

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -328,7 +328,7 @@ export const TipTapToolbar = ({
 
     return (
         <Box
-            className="TipTapToolbar-root"
+            className="DextinityAdminTipTapToolbar-root"
             sx={{
                 display: "flex",
                 flexWrap: "wrap",

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -1131,7 +1131,7 @@ function findStickyAncestor(element: HTMLElement): HTMLElement {
 export const StickyToolbar: StoryObj<typeof StickyToolbarStory> = {
     render: () => <StickyToolbarStory />,
     play: async ({ canvas, canvasElement, step }) => {
-        const scrollContainer = canvasElement.querySelector('[data-testid="scroll-container"]') as HTMLElement;
+        const getScrollContainer = () => canvasElement.querySelector('[data-testid="scroll-container"]') as HTMLElement | null;
 
         await step("Editor is ready and the container has more content than fits", async () => {
             await waitFor(
@@ -1142,10 +1142,13 @@ export const StickyToolbar: StoryObj<typeof StickyToolbarStory> = {
             );
 
             await waitFor(() => {
-                expect(scrollContainer.scrollHeight).toBeGreaterThan(scrollContainer.clientHeight);
+                const scrollContainer = getScrollContainer();
+                expect(scrollContainer).not.toBeNull();
+                expect(scrollContainer!.scrollHeight).toBeGreaterThan(scrollContainer!.clientHeight);
             });
         });
 
+        const scrollContainer = getScrollContainer()!;
         const undoButton = canvas.getAllByRole("button")[0];
         const toolbar = findStickyAncestor(undoButton);
         const firstParagraph = canvas.getByText("Paragraph 1: enough text to make the container scroll past the toolbar.");

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -1,4 +1,5 @@
 import { Box, chipClasses, Typography } from "@mui/material";
+import { styled } from "@mui/material/styles";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type HTMLAttributes, type ReactNode, useState } from "react";
 import { expect, waitFor, within } from "storybook/test";
@@ -1088,6 +1089,83 @@ export const CombinedTextBlockAndInlineStyles: StoryObj<typeof CombinedStylesSto
             // Heading select + text block style select + inline style select
             const comboboxes = canvas.getAllByRole("combobox");
             expect(comboboxes.length).toBeGreaterThanOrEqual(3);
+        });
+    },
+};
+
+// Simulates the surrounding admin UI, which scrolls the block's container rather than the block itself.
+const ScrollableContainer = styled("div")({
+    height: 250,
+    overflowY: "auto",
+});
+
+const longTextContent: TipTapRichTextBlockState = {
+    tipTapContent: {
+        type: "doc",
+        content: Array.from({ length: 30 }, (_, index) => ({
+            type: "paragraph",
+            content: [{ type: "text", text: `Paragraph ${index + 1}: enough text to make the container scroll past the toolbar.` }],
+        })),
+    },
+};
+
+function StickyToolbarStory() {
+    const [state, setState] = useState<TipTapRichTextBlockState>(longTextContent);
+
+    return (
+        <ScrollableContainer data-testid="scroll-container">
+            <TipTapRichTextBlock.AdminComponent state={state} updateState={setState} />
+        </ScrollableContainer>
+    );
+}
+
+function findStickyAncestor(element: HTMLElement): HTMLElement {
+    for (let current: HTMLElement | null = element; current; current = current.parentElement) {
+        if (getComputedStyle(current).position === "sticky") {
+            return current;
+        }
+    }
+    throw new Error("No sticky ancestor found");
+}
+
+export const StickyToolbar: StoryObj<typeof StickyToolbarStory> = {
+    render: () => <StickyToolbarStory />,
+    play: async ({ canvas, canvasElement, step }) => {
+        const scrollContainer = canvasElement.querySelector('[data-testid="scroll-container"]') as HTMLElement;
+
+        await step("Editor is ready and the container has more content than fits", async () => {
+            await waitFor(
+                () => {
+                    expect(canvas.getByRole("textbox")).toBeInTheDocument();
+                },
+                { timeout: 5000 },
+            );
+
+            await waitFor(() => {
+                expect(scrollContainer.scrollHeight).toBeGreaterThan(scrollContainer.clientHeight);
+            });
+        });
+
+        const undoButton = canvas.getAllByRole("button")[0];
+        const toolbar = findStickyAncestor(undoButton);
+        const firstParagraph = canvas.getByText("Paragraph 1: enough text to make the container scroll past the toolbar.");
+
+        const toolbarTopBeforeScroll = toolbar.getBoundingClientRect().top;
+        const paragraphTopBeforeScroll = firstParagraph.getBoundingClientRect().top;
+
+        await step("Scroll the container down", async () => {
+            scrollContainer.scrollTop = 300;
+
+            await waitFor(() => {
+                expect(scrollContainer.scrollTop).toBeGreaterThan(0);
+            });
+        });
+
+        await step("Toolbar stays pinned to the top while the content scrolls behind it", async () => {
+            await waitFor(() => {
+                expect(toolbar.getBoundingClientRect().top).toBe(toolbarTopBeforeScroll);
+                expect(firstParagraph.getBoundingClientRect().top).toBeLessThan(paragraphTopBeforeScroll);
+            });
         });
     },
 };

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -1141,11 +1141,14 @@ export const StickyToolbar: StoryObj<typeof StickyToolbarStory> = {
                 { timeout: 5000 },
             );
 
-            await waitFor(() => {
-                const scrollContainer = getScrollContainer();
-                expect(scrollContainer).not.toBeNull();
-                expect(scrollContainer!.scrollHeight).toBeGreaterThan(scrollContainer!.clientHeight);
-            });
+            await waitFor(
+                () => {
+                    const scrollContainer = getScrollContainer();
+                    expect(scrollContainer).not.toBeNull();
+                    expect(scrollContainer!.scrollHeight).toBeGreaterThan(scrollContainer!.clientHeight);
+                },
+                { timeout: 5000 },
+            );
         });
 
         const scrollContainer = getScrollContainer()!;
@@ -1159,16 +1162,22 @@ export const StickyToolbar: StoryObj<typeof StickyToolbarStory> = {
         await step("Scroll the container down", async () => {
             scrollContainer.scrollTop = 300;
 
-            await waitFor(() => {
-                expect(scrollContainer.scrollTop).toBeGreaterThan(0);
-            });
+            await waitFor(
+                () => {
+                    expect(scrollContainer.scrollTop).toBeGreaterThan(0);
+                },
+                { timeout: 5000 },
+            );
         });
 
         await step("Toolbar stays pinned to the top while the content scrolls behind it", async () => {
-            await waitFor(() => {
-                expect(toolbar.getBoundingClientRect().top).toBe(toolbarTopBeforeScroll);
-                expect(firstParagraph.getBoundingClientRect().top).toBeLessThan(paragraphTopBeforeScroll);
-            });
+            await waitFor(
+                () => {
+                    expect(toolbar.getBoundingClientRect().top).toBe(toolbarTopBeforeScroll);
+                    expect(firstParagraph.getBoundingClientRect().top).toBeLessThan(paragraphTopBeforeScroll);
+                },
+                { timeout: 5000 },
+            );
         });
     },
 };


### PR DESCRIPTION
## Description

In the TipTap-based rich text block (`createTipTapRichTextBlock`), the toolbar (Bold, Headline levels, etc.) scrolled away with the editor content on longer texts. The previous Draft.js-based rich text editor kept its toolbar fixed at the top while scrolling, so format options were always reachable.

The toolbar's root `Box` in `TipTapToolbar.tsx` had no `position: sticky`. The equivalent Draft.js toolbar (`@dextinity/admin-rte`'s `Toolbar.styles.tsx`) already uses `position: sticky; top: 0; z-index: 2`, so this change mirrors that.

## Solution

Added `position: sticky`, `top: 0`, and `zIndex: 2` to the toolbar's root `Box` `sx` in `packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx`, matching the old Draft.js RTE toolbar behavior.

## Example

Rich Text (TipTap) or Headline Rich Text block in the admin: enter enough text to make the editor scrollable, then scroll down — the toolbar now stays fixed at the top.

## Changeset

Added (`@dextinity/cms-admin`, patch).

## Open TODOs/questions

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L9QpQ6ZCDhw22zaY7GtxMi)_