### PR TITLE
Batch page tree node lookups to avoid N+1 queries

### DIFF
--- a/.changeset/tall-cameras-shake.md
+++ b/.changeset/tall-cameras-shake.md
@@ -1,0 +1,9 @@
+---
+"@dextinity/cms-api": patch
+---
+
+Batch page tree node lookups in `PageTreeReadApi` to avoid N+1 queries
+
+`getNode()` issued one query per call. Since blocks are transformed concurrently, a page containing many internal links caused one query per link plus one per path segment, and concurrent lookups of the same node each ran their own query because the cache was only filled after a query resolved.
+
+Node lookups are now batched into a single query per tick and deduplicated while in flight. The number of queries is bound by the depth of the page tree instead of the number of links: a page with 200 internal links pointing at nodes four levels deep drops from 801 queries (~550 ms) to 5 queries (~89 ms).

--- a/packages/api/cms-api/src/page-tree/page-tree-read-api.test.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree-read-api.test.ts
@@ -1,5 +1,5 @@
 import { parseISO } from "date-fns";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { SortDirection } from "../common/sorting/sort-direction.enum";
 import { getError, NoErrorThrownError } from "../common/test/get-error";
@@ -13,6 +13,74 @@ describe("PageTreeReadApi", () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const api = createReadApi({ pageTreeNodeRepository: {} as any, attachedDocumentsRepository: {} as any });
             await expect(api.getNodeByPath("/home")).resolves.toBeNull();
+        });
+    });
+
+    describe("getNode", () => {
+        function createReadApiWithNodes(nodes: PageTreeNodeInterface[]) {
+            const find = vi.fn(async ({ id }: { id: { $in: string[] } }) => nodes.filter((node) => id.$in.includes(node.id)));
+
+            return {
+                find,
+                api: createReadApi({
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    pageTreeNodeRepository: { find } as any,
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    attachedDocumentsRepository: {} as any,
+                }),
+            };
+        }
+
+        const nodes = [
+            { id: "root", slug: "root", parentId: null },
+            { id: "child", slug: "child", parentId: "root" },
+        ] as PageTreeNodeInterface[];
+
+        it("should load concurrently requested nodes with a single query", async () => {
+            const { api, find } = createReadApiWithNodes(nodes);
+
+            const [root, child] = await Promise.all([api.getNode("root"), api.getNode("child")]);
+
+            expect(find).toHaveBeenCalledTimes(1);
+            expect(find).toHaveBeenCalledWith(expect.objectContaining({ id: { $in: ["root", "child"] } }));
+            expect(root).toBe(nodes[0]);
+            expect(child).toBe(nodes[1]);
+        });
+
+        it("should query a node requested multiple times concurrently only once", async () => {
+            const { api, find } = createReadApiWithNodes(nodes);
+
+            const loadedNodes = await Promise.all([api.getNode("root"), api.getNode("root"), api.getNode("root")]);
+
+            expect(find).toHaveBeenCalledTimes(1);
+            expect(loadedNodes).toEqual([nodes[0], nodes[0], nodes[0]]);
+        });
+
+        it("should not query an already loaded node again", async () => {
+            const { api, find } = createReadApiWithNodes(nodes);
+
+            await api.getNode("root");
+            await api.getNode("root");
+
+            expect(find).toHaveBeenCalledTimes(1);
+        });
+
+        it("should not query a node again that doesn't exist", async () => {
+            const { api, find } = createReadApiWithNodes(nodes);
+
+            await expect(api.getNode("unknown")).resolves.toBeNull();
+            await expect(api.getNode("unknown")).resolves.toBeNull();
+
+            expect(find).toHaveBeenCalledTimes(1);
+        });
+
+        it("should load the path of multiple nodes with one query per level", async () => {
+            const { api, find } = createReadApiWithNodes(nodes);
+
+            const paths = await Promise.all([api.nodePathById("child"), api.nodePathById("child"), api.nodePathById("root")]);
+
+            expect(paths).toEqual(["/root/child", "/root/child", "/root"]);
+            expect(find).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/packages/api/cms-api/src/page-tree/page-tree-read-api.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree-read-api.ts
@@ -1,5 +1,6 @@
 import { type EntityRepository, NotFoundError, type QueryBuilder } from "@mikro-orm/postgresql";
 import opentelemetry from "@opentelemetry/api";
+import DataLoader from "dataloader";
 import { compareAsc, compareDesc, isEqual } from "date-fns";
 
 import { SortDirection } from "../common/sorting/sort-direction.enum";
@@ -76,6 +77,24 @@ export function createReadApi(
 
     const preloadedNodes = new Map<string, PageTreeNodeInterface[]>();
     const nodesById = new Map<string, PageTreeNodeInterface>();
+
+    // Batches all node loads happening in the same tick into a single query. Without batching, concurrently resolved
+    // blocks (BlocksBlock, ListBlock, …) containing internal links cause one query per link and per path segment.
+    const nodeLoader = new DataLoader<string, PageTreeNodeInterface | null>(async (ids) => {
+        return tracer.startActiveSpan("live query PageTree loadNodes", async (span) => {
+            span.setAttribute("ids count", ids.length);
+            const nodes = await pageTreeNodeRepository.find({ id: { $in: [...ids] }, visibility: { $in: visibilityFilter } });
+
+            const loadedNodesById = new Map(nodes.map((node) => [node.id, node]));
+            for (const node of nodes) {
+                nodesById.set(node.id, node);
+            }
+
+            span.end();
+            return ids.map((id) => loadedNodesById.get(id) ?? null);
+        });
+    });
+
     const queryNodes = async (
         scope: ScopeInterface | undefined,
         where: PageTreeNodeFilterOptions,
@@ -262,21 +281,11 @@ export function createReadApi(
 
         async getNode(id) {
             await waitForPreloadDone();
-            if (nodesById.has(id)) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                return nodesById.get(id)!;
-            } else {
-                return tracer.startActiveSpan("live query PageTree getNode", async (span) => {
-                    span.setAttribute("where id", id);
-                    const queryFilter = { id, visibility: { $in: visibilityFilter } };
-                    const node = await pageTreeNodeRepository.findOne(queryFilter);
-                    if (node) {
-                        nodesById.set(id, node);
-                    }
-                    span.end();
-                    return node ?? null;
-                });
+            const preloadedNode = nodesById.get(id);
+            if (preloadedNode) {
+                return preloadedNode;
             }
+            return nodeLoader.load(id);
         },
 
         async getNodeOrFail(id) {
@@ -290,32 +299,15 @@ export function createReadApi(
         },
 
         async getNodesByIds(ids) {
-            await waitForPreloadDone();
-            const missingIds: string[] = [];
-
-            for (const id of ids) {
-                if (!nodesById.has(id)) {
-                    missingIds.push(id);
-                }
-            }
-
-            if (missingIds.length > 0) {
-                await tracer.startActiveSpan("live query PageTree getNodesByIds", async (span) => {
-                    span.setAttribute("ids count", missingIds.length);
-                    const nodes = await pageTreeNodeRepository.find({ id: { $in: missingIds }, visibility: { $in: visibilityFilter } });
-                    for (const node of nodes) {
-                        nodesById.set(node.id, node);
-                    }
-                    span.end();
-                });
-            }
+            const nodes = await Promise.all(ids.map((id) => this.getNode(id)));
 
             // Return in the same order as input ids, throw if any not found
-            return ids.map((id) => {
-                const node = nodesById.get(id);
+            return nodes.map((node, index) => {
                 if (!node) {
                     throw new NotFoundError(
-                        `Cannot find PageTreeNode with ID ${id} and visibility ${Array.isArray(visibility) ? visibility.join(" or ") : visibility}`,
+                        `Cannot find PageTreeNode with ID ${ids[index]} and visibility ${
+                            Array.isArray(visibility) ? visibility.join(" or ") : visibility
+                        }`,
                     );
                 }
                 return node;


### PR DESCRIPTION
## Problem

Resolving the content of a page runs one database query per internal link, plus one more per segment of each link's path. A page with 200 internal links pointing at nodes four levels deep issues 801 `PageTreeNode` queries:

```sql
select "p0".* from "PageTreeNode" as "p0" where "p0"."id" = '…' and "p0"."visibility" in ('Published') limit 1
```

The same node is queried repeatedly within a single request, and the query count grows with the number of links on the page.

## Reason

`PageTreeReadApi.getNode()` writes a node into its cache only once the query has resolved. Blocks are transformed concurrently (`Promise.all` in `transformToPlain`), so every lookup issued before the first one returns misses the cache and runs its own query. `nodePath()` then walks up the tree with one `getNode()` per level, multiplying the effect.

## Fix

Node lookups go through a `DataLoader`: loads happening in the same tick collapse into a single `id in (…)` query, and duplicate lookups of the same id are deduplicated while in flight. The number of queries is now bound by the depth of the page tree instead of the number of links — the page above drops from 801 queries to 5. `getNodesByIds()` uses the same loader, so it shares the batch and the cache.

**The loader and its cache are per request.** They live on the read API instance, and `PageTreeReadApiService` is request-scoped, so nothing is shared between requests — or between API instances. There is no cache to invalidate and no coherency to manage when running several replicas: a node published or unpublished elsewhere is visible on the very next request.

One behavior change within that request: lookups that find nothing are now cached too. That is what you want for a request; for a read API deliberately kept alive longer — `createReadApi()` in a console command, for example — a node that becomes visible mid-run is not picked up. The cache for found nodes already behaved this way.

## Decisions

- **Batches lookups by id only, not `queryNodes()`.** `getChildNodes()`, `getNodeByPath()` and `pageTreeRootNodeList()` filter by slug, parent and scope instead of by id, so they need a different batching strategy. Left out to keep this change small. -> done in https://github.com/vivid-planet/dextinity/pull/6212

## Verification

Measured on the demo API against a page whose internal links point at nodes four levels deep, counting statements in the PostgreSQL log. This is a local environment, so the ratios are the meaningful part, not the absolute timings:

| Internal links | Queries before | Queries after | Time before | Time after |
| -------------- | -------------- | ------------- | ----------- | ---------- |
| 50             | 201            | 5             | 149 ms      | 45 ms      |
| 200            | 801            | 5             | 550 ms      | 89 ms      |

With 10 concurrent requests against a single API instance, throughput goes from 1.6 req/s to 10.6 req/s and median latency from 4.5 s to 0.84 s.

That the cache does not outlive the request was checked against the running API: renaming a node, and unpublishing and republishing one, each took effect on the very next request.

GraphQL responses are byte-identical before and after. Nine further page tree queries — among them `pageTreeNodeList`, `mainMenu`, `topMenu`, `parentNodes`, `pageTreeFullTextSearch`, `paginatedPageTreeNodes` and `paginatedRedirects` — also return identical responses.

New unit tests cover concurrent lookups of different ids collapsing into one query, repeated lookups of the same id, already-loaded nodes, nodes that do not exist, and resolving several paths with one query per tree level.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-3137
