### PR TITLE
Batch child node lookups to avoid N+1 queries

### DIFF
--- a/.changeset/lucky-moons-repeat.md
+++ b/.changeset/lucky-moons-repeat.md
@@ -1,0 +1,9 @@
+---
+"@dextinity/cms-api": patch
+---
+
+Batch child node lookups in `PageTreeReadApi` to avoid N+1 queries
+
+Walking the page tree — rendering a menu, resolving a path segment by segment, or calling `getDescendants()` — issued one query per node to load its children.
+
+Lookups of the form "children of node X" are now batched into a single query per scope and tick, and `getDescendants()` descends into all children of a level at once instead of one after another. Resolving a three-level menu across 200 root nodes drops from 612 queries (~609 ms) to 4 queries (~119 ms).

--- a/packages/api/cms-api/src/page-tree/page-tree-read-api.test.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree-read-api.test.ts
@@ -84,6 +84,154 @@ describe("PageTreeReadApi", () => {
         });
     });
 
+    describe("getChildNodes", () => {
+        const scope = { domain: "main", language: "en" };
+
+        // A tree with three levels below the root: root > a > a1 > a1x, root > b > b1
+        const tree = [
+            { id: "root", slug: "root", parentId: null, scope, visibility: "Published", category: "main", hideInMenu: false },
+            { id: "a", slug: "a", parentId: "root", scope, visibility: "Published", category: "main", hideInMenu: false },
+            { id: "b", slug: "b", parentId: "root", scope, visibility: "Published", category: "main", hideInMenu: true },
+            { id: "a1", slug: "a1", parentId: "a", scope, visibility: "Published", category: "main", hideInMenu: false },
+            { id: "b1", slug: "b1", parentId: "b", scope, visibility: "Published", category: "main", hideInMenu: false },
+            { id: "a1x", slug: "a1x", parentId: "a1", scope, visibility: "Published", category: "main", hideInMenu: false },
+        ] as unknown as PageTreeNodeInterface[];
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        function matchesCondition(node: PageTreeNodeInterface, condition: Record<string, any>): boolean {
+            return Object.entries(condition).every(([field, value]) => {
+                if (field === "$or") {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    return (value as Array<Record<string, any>>).some((subCondition) => matchesCondition(node, subCondition));
+                }
+                if (field === "scope") {
+                    return JSON.stringify(node.scope) === JSON.stringify(value);
+                }
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const nodeValue = (node as any)[field];
+                if (Array.isArray(value)) {
+                    return value.includes(nodeValue);
+                }
+                if (value !== null && typeof value === "object" && "$in" in value) {
+                    return (value.$in as unknown[]).includes(nodeValue);
+                }
+                return nodeValue === value;
+            });
+        }
+
+        function createReadApiWithTree(nodes: PageTreeNodeInterface[] = tree) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const queries: Array<Record<string, any>> = [];
+
+            const createQueryBuilder = () => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const conditions: Array<Record<string, any>> = [];
+                const queryBuilder = {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    where(condition: Record<string, any>) {
+                        conditions.push(condition);
+                        return queryBuilder;
+                    },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    andWhere(condition: Record<string, any>) {
+                        conditions.push(condition);
+                        return queryBuilder;
+                    },
+                    orderBy() {
+                        return queryBuilder;
+                    },
+                    async getResultList() {
+                        queries.push(Object.assign({}, ...conditions));
+                        return nodes.filter((node) => conditions.every((condition) => matchesCondition(node, condition)));
+                    },
+                };
+                return queryBuilder;
+            };
+
+            return {
+                queries,
+                api: createReadApi({
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    pageTreeNodeRepository: { createQueryBuilder } as any,
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    attachedDocumentsRepository: {} as any,
+                }),
+            };
+        }
+
+        function nodeWithId(id: string) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            return tree.find((node) => node.id === id)!;
+        }
+
+        it("should load the children of multiple nodes with a single query", async () => {
+            const { api, queries } = createReadApiWithTree();
+
+            const [childNodesOfA, childNodesOfB] = await Promise.all([api.getChildNodes(nodeWithId("a")), api.getChildNodes(nodeWithId("b"))]);
+
+            expect(queries).toHaveLength(1);
+            expect(childNodesOfA.map((node) => node.id)).toEqual(["a1"]);
+            expect(childNodesOfB.map((node) => node.id)).toEqual(["b1"]);
+        });
+
+        it("should not load the children of the same node twice", async () => {
+            const { api, queries } = createReadApiWithTree();
+
+            await api.getChildNodes(nodeWithId("a"));
+            await api.getChildNodes(nodeWithId("a"));
+
+            expect(queries).toHaveLength(1);
+        });
+
+        it("should return an empty array for a node without children", async () => {
+            const { api, queries } = createReadApiWithTree();
+
+            await expect(api.getChildNodes(nodeWithId("a1x"))).resolves.toEqual([]);
+            expect(queries).toHaveLength(1);
+        });
+
+        it("should load root nodes together with child nodes", async () => {
+            const { api, queries } = createReadApiWithTree();
+
+            const [rootNodes, childNodesOfA] = await Promise.all([api.pageTreeRootNodeList({ scope }), api.getChildNodes(nodeWithId("a"))]);
+
+            expect(queries).toHaveLength(1);
+            expect(rootNodes.map((node) => node.id)).toEqual(["root"]);
+            expect(childNodesOfA.map((node) => node.id)).toEqual(["a1"]);
+        });
+
+        it("should still apply filters that are not part of the batch key", async () => {
+            const { api } = createReadApiWithTree();
+
+            const visibleChildNodes = await api.pageTreeRootNodeList({ scope, excludeHiddenInMenu: true, category: "main" });
+            const childNodesInMenu = await api.getChildNodes(nodeWithId("root"));
+
+            expect(visibleChildNodes.map((node) => node.id)).toEqual(["root"]);
+            // `b` is hidden in menu, so it is only returned when the filter is not applied
+            expect(childNodesInMenu.map((node) => node.id)).toEqual(["a", "b"]);
+        });
+
+        it("should load one query per tree level in getDescendants", async () => {
+            const { api, queries } = createReadApiWithTree();
+
+            const descendants = await api.getDescendants(nodeWithId("root"));
+
+            // one query per level: children of root, of a+b, of a1+b1, and of the deepest node a1x
+            expect(queries).toHaveLength(4);
+            expect(descendants.map((node) => node.id)).toEqual(["a", "b", "a1", "a1x", "b1"]);
+        });
+
+        it("should load one query per path segment when resolving multiple paths", async () => {
+            const { api, queries } = createReadApiWithTree();
+
+            const [first, second] = await Promise.all([api.getNodeByPath("/root/a/a1", { scope }), api.getNodeByPath("/root/b/b1", { scope })]);
+
+            expect(queries).toHaveLength(3);
+            expect(first?.id).toBe("a1");
+            expect(second?.id).toBe("b1");
+        });
+    });
+
     describe("sortPreloadedNodes", () => {
         it("should skip sorting if only sort criteria is by pos ascending", () => {
             const alreadySorted = [{ pos: 1 }, { pos: 2 }] as PageTreeNodeInterface[];

--- a/packages/api/cms-api/src/page-tree/page-tree-read-api.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree-read-api.ts
@@ -53,6 +53,15 @@ function scopeHash(scope: ScopeInterface | undefined): string {
     return JSON.stringify(scope);
 }
 
+interface ChildNodesKey {
+    scope: ScopeInterface | undefined;
+    parentId: string | null;
+}
+
+function childNodesKey({ scope, parentId }: ChildNodesKey): string {
+    return `${scopeHash(scope)}|${parentId ?? ""}`;
+}
+
 export function createReadApi(
     {
         pageTreeNodeRepository,
@@ -95,6 +104,58 @@ export function createReadApi(
         });
     });
 
+    // Batches "children of node X" lookups happening in the same tick into one query per scope. Without batching,
+    // walking a tree (menus, getDescendants, resolving a path segment by segment) causes one query per node.
+    const childNodesLoader = new DataLoader<ChildNodesKey, PageTreeNodeInterface[], string>(
+        async (keys) => {
+            return tracer.startActiveSpan("live query PageTree loadChildNodes", async (span) => {
+                span.setAttribute("keys count", keys.length);
+
+                const keysByScope = new Map<string, { scope: ScopeInterface | undefined; parentIds: Array<string | null> }>();
+                for (const key of keys) {
+                    const hash = scopeHash(key.scope);
+                    const group = keysByScope.get(hash) ?? { scope: key.scope, parentIds: [] };
+                    group.parentIds.push(key.parentId);
+                    keysByScope.set(hash, group);
+                }
+
+                const childNodesByKey = new Map<string, PageTreeNodeInterface[]>();
+                await Promise.all(
+                    Array.from(keysByScope.values()).map(async ({ scope, parentIds }) => {
+                        const qb = pageTreeNodeRepository.createQueryBuilder().where({ visibility: visibilityFilter });
+                        if (scope) {
+                            qb.andWhere({ scope });
+                        }
+
+                        // `parentId: null` (root nodes) can't be expressed inside `$in`, so it becomes its own condition
+                        const ids = parentIds.filter((parentId): parentId is string => parentId !== null);
+                        const parentConditions: Array<{ parentId: { $in: string[] } | null }> = [];
+                        if (ids.length > 0) {
+                            parentConditions.push({ parentId: { $in: ids } });
+                        }
+                        if (parentIds.includes(null)) {
+                            parentConditions.push({ parentId: null });
+                        }
+                        qb.andWhere({ $or: parentConditions });
+                        qb.orderBy({ pos: "ASC" });
+
+                        for (const node of await qb.getResultList()) {
+                            nodesById.set(node.id, node);
+                            const key = childNodesKey({ scope, parentId: node.parentId });
+                            const childNodes = childNodesByKey.get(key) ?? [];
+                            childNodes.push(node);
+                            childNodesByKey.set(key, childNodes);
+                        }
+                    }),
+                );
+
+                span.end();
+                return keys.map((key) => childNodesByKey.get(childNodesKey(key)) ?? []);
+            });
+        },
+        { cacheKeyFn: childNodesKey },
+    );
+
     const queryNodes = async (
         scope: ScopeInterface | undefined,
         where: PageTreeNodeFilterOptions,
@@ -118,6 +179,9 @@ export function createReadApi(
             }
 
             return nodes;
+        } else if (where.parentId !== undefined && sort === undefined && limit === undefined && offset === undefined) {
+            // Children of a node are batchable; the remaining filters are applied in memory, as for preloaded nodes
+            return filterPreloadedNodes(await childNodesLoader.load({ scope, parentId: where.parentId }), where);
         } else {
             return tracer.startActiveSpan("live query PageTree queryNodes", async (span) => {
                 span.setAttribute("scope", JSON.stringify(scope));
@@ -384,17 +448,12 @@ export function createReadApi(
         },
 
         async getDescendants(node: PageTreeNodeInterface): Promise<PageTreeNodeInterface[]> {
-            const descendants: PageTreeNodeInterface[] = [];
-
             const childNodes = await this.getChildNodes(node);
 
-            descendants.push(...childNodes);
+            // Descend into all children at once so each level of the tree is loaded in a single query
+            const descendantsPerChildNode = await Promise.all(childNodes.map((childNode) => this.getDescendants(childNode)));
 
-            for (const childNode of childNodes) {
-                descendants.push(...(await this.getDescendants(childNode)));
-            }
-
-            return descendants;
+            return [...childNodes, ...descendantsPerChildNode.flat()];
         },
 
         async getFirstNodeByAttachedPageId(pageId: string): Promise<PageTreeNodeInterface | null> {


### PR DESCRIPTION
depends on #6211

## Problem

Walking the page tree loads the children of one node per query. Rendering a three-level menu over 200 root nodes issues 612 `PageTreeNode` queries; `getDescendants()` and resolving a path segment by segment scale the same way.

## Reason

`getChildNodes()`, `getNodeByPath()` and `pageTreeRootNodeList()` all go through `queryNodes()`, which runs a live query per call whenever the scope has not been preloaded, so every node's children cost a round trip. `getDescendants()` additionally awaits one child after another, so those queries cannot even overlap.

## Fix

Lookups of the form "children of node X" go through a `DataLoader` keyed by scope and parent: all such lookups in the same tick collapse into one query per scope (`parentId in (…)`, with a separate condition for root nodes, which cannot be expressed inside `$in`). `getDescendants()` descends into all children of a level at once, so one query per tree level replaces one per node.

**Like the node loader in #6211, this loader and its cache are per request.** They live on the read API instance, and `PageTreeReadApiService` is request-scoped, so a batch is never shared between requests and there is nothing to invalidate when the tree changes.

Scopes that were preloaded still short-circuit before the loader, so resolvers calling `preloadNodes()` are unaffected. Lookups that are not keyed by a parent keep the previous live query — `getNodes()` filters by category and document type across a whole scope and supports sorting and pagination, which cannot share a batch.

## Decisions

- **Batches only lookups keyed by a parent, and only those without `sort`, `limit` and `offset`.** Callers passing different sorting or pagination cannot share a result set, so merging them into one batch would mean re-implementing pagination in memory. `getNodes()` is the only caller affected and stays on the live-query path.
- **Applies the remaining filters in memory instead of in SQL.** Because the batch key is scope + parent, a `category`, `slug` or `excludeHiddenInMenu` condition in the query would split the batch again. Children of a parent are therefore fetched in full and filtered afterwards through `filterPreloadedNodes()` — the same in-memory filtering the preload path already does, so the results are unchanged while a few more rows are read.

## Verification

Measured on the demo API against a page tree of 200 root nodes, each four levels deep, counting statements in the PostgreSQL log. The query is `topMenu { id childNodes { id childNodes { id childNodes { id } } } }`, chosen because `topMenu` deliberately does not preload:

|        | `PageTreeNode` queries | Response time |
| ------ | ---------------------- | ------------- |
| Before | 612                    | 609 ms        |
| After  | 4                      | 119 ms        |

The response is byte-identical before and after, as are the ten page tree queries checked in #6211 — among them `pageTreeNodeList`, `mainMenu`, `topMenu`, `parentNodes`, `pageTreeFullTextSearch`, `paginatedPageTreeNodes` and `paginatedRedirects`.

New unit tests cover the children of several nodes collapsing into one query, repeated lookups of the same node, nodes without children, root nodes batching together with child nodes, the remaining filters still being applied, one query per level in `getDescendants()`, and one query per segment when several paths are resolved concurrently.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-3137


---
_Generated by [Claude Code](https://claude.ai/code/session_01PrvQarKxE7b5obfJnS3kRJ)_