### PR TITLE
Fix validation error for block inputs without validation annotations

### DIFF
--- a/.changeset/fix-block-input-without-validation-annotations.md
+++ b/.changeset/fix-block-input-without-validation-annotations.md
@@ -1,0 +1,9 @@
+---
+"@dextinity/cms-api": patch
+---
+
+Fix validation error for block inputs without validation annotations
+
+Saving a document failed with `an unknown value was passed to the validate function` as soon as it contained a block whose input class has no class-validator annotations at all, for instance a block without fields. class-validator rejects such classes since v0.14, where `forbidUnknownValues` is enabled by default. Affected were, among others, link blocks in rich text blocks (DraftJS and TipTap) as their links are validated with a direct `validate()` call.
+
+`BlockInput` now provides validation metadata, so block inputs validate as expected no matter which validation path is used.

--- a/packages/api/cms-api/src/blocks/block-input-validation.test.ts
+++ b/packages/api/cms-api/src/blocks/block-input-validation.test.ts
@@ -1,0 +1,121 @@
+import { ValidationPipe } from "@nestjs/common";
+import { Transform } from "class-transformer";
+import { validate, ValidateNested } from "class-validator";
+import { describe, expect, it } from "vitest";
+
+import { BlockData, BlockInput, BlockInputInterface, blockInputToData, createBlock } from "./block";
+import { createLinkBlock } from "./factories/createLinkBlock";
+import { createListBlock } from "./factories/createListBlock";
+import { createRichTextBlock } from "./factories/createRichTextBlock";
+import { createTipTapRichTextBlock } from "./tipTap/createTipTapRichTextBlock";
+
+// A block without any class-validator decorators, e.g. a block without fields.
+// class-validator's `forbidUnknownValues` (enabled by default since v0.14) rejects such classes unless they have validation metadata.
+class NoValidationBlockData extends BlockData {}
+
+class NoValidationBlockInput extends BlockInput {
+    transformToBlockData(): NoValidationBlockData {
+        return blockInputToData(NoValidationBlockData, this);
+    }
+}
+
+const NoValidationBlock = createBlock(NoValidationBlockData, NoValidationBlockInput, "NoValidation");
+
+const LinkBlock = createLinkBlock({ supportedBlocks: { noValidation: NoValidationBlock } }, "NoValidationLink");
+const linkData = { attachedBlocks: [{ type: "noValidation", props: {} }], activeType: "noValidation" };
+
+describe("block input without validation annotations", () => {
+    it("should validate", async () => {
+        const errors = await validate(NoValidationBlock.blockInputFactory({}), { forbidNonWhitelisted: true, whitelist: true });
+
+        expect(errors).toHaveLength(0);
+    });
+
+    // The property that provides the validation metadata is validated and therefore whitelisted. It must not be
+    // settable, otherwise clients could store arbitrary data in every block.
+    it("should reject the property that provides the validation metadata", async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const input = NoValidationBlock.blockInputFactory({ thisBlockInputNeedsValidationMetadata____: "any value" } as any);
+
+        const errors = await validate(input, { forbidNonWhitelisted: true, whitelist: true });
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].property).toBe("thisBlockInputNeedsValidationMetadata____");
+    });
+
+    // Covers the save path of an application: NestJS' ValidationPipe defaults `forbidUnknownValues` to false, so this
+    // path works even without validation metadata. It's covered nonetheless as applications may configure it themselves.
+    it("should validate when nested in another block passed through a ValidationPipe", async () => {
+        const LinkListBlock = createListBlock({ block: LinkBlock }, "NoValidationLinkList");
+
+        class TestInput {
+            @Transform(({ value }) => LinkListBlock.blockInputFactory(value), { toClassOnly: true })
+            @ValidateNested()
+            content: BlockInputInterface;
+        }
+
+        const pipe = new ValidationPipe({ transform: true, forbidNonWhitelisted: true, whitelist: true });
+        const value = { content: { blocks: [{ key: "1", visible: true, props: linkData }] } };
+
+        await expect(pipe.transform(value, { type: "body", metatype: TestInput })).resolves.toBeInstanceOf(TestInput);
+    });
+
+    it("should validate when used as link block of a DraftJS rich text block", async () => {
+        const RichTextBlock = createRichTextBlock({ link: LinkBlock }, "NoValidationRichText");
+        const input = RichTextBlock.blockInputFactory({
+            draftContent: {
+                blocks: [
+                    {
+                        key: "a",
+                        text: "click here",
+                        type: "unstyled",
+                        depth: 0,
+                        inlineStyleRanges: [],
+                        entityRanges: [{ offset: 0, length: 10, key: 0 }],
+                    },
+                ],
+                entityMap: { 0: { type: "LINK", mutability: "MUTABLE", data: linkData } },
+            },
+        });
+
+        const errors = await validate(input, { forbidNonWhitelisted: true, whitelist: true });
+
+        expect(errors).toHaveLength(0);
+    });
+
+    it("should validate when used as link block of a TipTap rich text block", async () => {
+        const TipTapRichTextBlock = createTipTapRichTextBlock({ link: LinkBlock }, "NoValidationTipTapLink");
+        const input = TipTapRichTextBlock.blockInputFactory({
+            tipTapContent: {
+                type: "doc",
+                content: [
+                    {
+                        type: "paragraph",
+                        content: [{ type: "text", marks: [{ type: "link", attrs: { data: linkData } }], text: "click here" }],
+                    },
+                ],
+            },
+        });
+
+        const errors = await validate(input, { forbidNonWhitelisted: true, whitelist: true });
+
+        expect(errors).toHaveLength(0);
+    });
+
+    it("should validate when used as child block of a TipTap rich text block", async () => {
+        const TipTapRichTextBlock = createTipTapRichTextBlock(
+            { childBlocks: { noValidation: { block: NoValidationBlock, display: "block" } } },
+            "NoValidationTipTapChildBlock",
+        );
+        const input = TipTapRichTextBlock.blockInputFactory({
+            tipTapContent: {
+                type: "doc",
+                content: [{ type: "cmsBlock", attrs: { blockType: "noValidation", data: {} } }],
+            },
+        });
+
+        const errors = await validate(input, { forbidNonWhitelisted: true, whitelist: true });
+
+        expect(errors).toHaveLength(0);
+    });
+});

--- a/packages/api/cms-api/src/blocks/block.ts
+++ b/packages/api/cms-api/src/blocks/block.ts
@@ -1,5 +1,6 @@
 import type { Type } from "@nestjs/common";
 import { type ClassConstructor, instanceToPlain, plainToInstance } from "class-transformer";
+import { Equals } from "class-validator";
 import type { WarningSeverity as WarningSeverityEnum } from "src/warnings/entities/warning-severity.enum";
 
 import { AnnotationBlockMeta, getBlockFieldData, getFieldKeys } from "./decorators/field";
@@ -179,6 +180,14 @@ export interface BlockInputInterface<
 
 export type SimpleBlockInputInterface<BlockType extends BlockDataInterface = BlockDataInterface> = BlockInputInterface<BlockType, undefined>;
 export abstract class BlockInput<BlockType extends BlockDataInterface = BlockDataInterface> implements BlockInputInterface<BlockType, undefined> {
+    // class-validator rejects classes without any validation metadata, as `forbidUnknownValues` is enabled by default
+    // since v0.14. Block inputs that don't validate a single field (e.g. a block without fields) would therefore always
+    // fail to validate. This property exists so that every block input has at least one validation metadata.
+    // It must never be set: a validated property is whitelisted, so without `@Equals(undefined)` it could be sent by a
+    // client and would end up in the saved block data. As it is never set, it shows up in neither `toPlain()` nor the block meta.
+    @Equals(undefined)
+    thisBlockInputNeedsValidationMetadata____?: never;
+
     abstract transformToBlockData(): BlockType;
 
     toPlain(): CreateToPlainReturn<this> {


### PR DESCRIPTION
## Problem

A document cannot be saved as soon as it contains a block whose input class has no class-validator annotation at all — for instance a block without fields. Saving fails with:

> an unknown value was passed to the validate function

Both rich text variants are affected, as they validate their link and child blocks with a direct `validate()` call: `createRichTextBlock` (DraftJS) and `createTipTapRichTextBlock` (link marks and child blocks).

## Cause

class-validator enables `forbidUnknownValues` by default since v0.14. A class without any validation metadata is treated as an unknown value and rejected — even though there is nothing to validate. `BlockInput` carries no validation metadata itself, so a block input without own decorators has none at all.

## Fix

`BlockInput` provides a property that carries validation metadata, so every block input has metadata regardless of its own fields. This works for every validation path without applications having to adapt their `ValidationPipe`.

The property is never set: it doesn't show up in `toPlain()`, in the block meta, or in the saved block data.

## Decisions

- **Give `BlockInput` validation metadata instead of passing `forbidUnknownValues: false` to the `validate()` calls.** Setting the option only fixes the call sites in the core, so any application validating a block input itself would run into the same error again. It also matches the existing precedent in #3620, which gave `EmptyDamScope` an annotated dummy field for the same reason.
- **The property is annotated with `@Equals(undefined)` rather than `@Allow()`.** An annotated property is whitelisted, so with `@Allow()` a client could send `thisBlockInputNeedsValidationMetadata____` on any block and the value would end up in the saved block data — today `forbidNonWhitelisted` rejects unknown properties, and that stays intact.
- **The property is public.** As `private`/`protected`, declaration emit fails with `TS4094` for the anonymous input classes returned by the block factories (e.g. `createBlocksBlock`).

### Similar workarounds in the codebase

A dummy property named `…____` is the established way to satisfy a framework that rejects a class without members. It exists today for two reasons:

- **class-validator needs at least one validation metadata** — [`EmptyDamScope`](https://github.com/vivid-planet/dextinity/blob/a53e8e4d6f4b9dd216958a5b4c25033699f2d0eb/packages/api/cms-api/src/dam/files/dto/empty-dam-scope.ts#L13) (`@IsUndefinable()` on `thisScopeHasNoFields____`, added in #3620). Same cause as this fix.
- **GraphQL needs at least one field** to interpret a class as object/input type — [`EmptyPageTreeNodeScope`](``https://github.com/vivid-planet/dextinity/blob/a53e8e4d6f4b9dd216958a5b4c25033699f2d0eb/packages/api/cms-api/src/page-tree/dto/empty-page-tree-node-scope.ts#L11)`` and [`EmptyRedirectScope`](``https://github.com/vivid-planet/dextinity/blob/a53e8e4d6f4b9dd216958a5b4c25033699f2d0eb/packages/api/cms-api/src/redirects/dto/empty-redirect-scope.ts#L11``) in `cms-api`, [`EmailCampaignScope`](https://github.com/vivid-planet/dextinity/blob/a53e8e4d6f4b9dd216958a5b4c25033699f2d0eb/packages/api/brevo-api/generate-schema.ts#L32) and [`BrevoContactFilterAttributes`](https://github.com/vivid-planet/dextinity/blob/a53e8e4d6f4b9dd216958a5b4c25033699f2d0eb/packages/api/brevo-api/generate-schema.ts#L44) in `brevo-api`. These carry no validation annotation.

Unlike all of them, the property added here is not part of a GraphQL type, so it is annotated as unsettable instead of nullable.

## Verification

`block-input-validation.test.ts` covers a block input without any annotation:

- validated directly
- as link block of a DraftJS rich text block
- as link block of a TipTap rich text block
- as child block of a TipTap rich text block
- nested in a list block passed through a `ValidationPipe`
- rejected when a client sends the property that provides the metadata

All of them fail without the change, except the `ValidationPipe` one — NestJS' `ValidationPipe` defaults `forbidUnknownValues` to `false` itself, so that path was never broken. It is covered nonetheless, as applications may configure the option themselves.

`block-meta.json` was regenerated in `cms-api` and in Demo and is unchanged.

### Manual verification in the Demo admin

Reproduced and verified in the running Demo admin, as the reported case comes from an application. The Demo has no annotation-free link block, so a temporary one was added to `LinkBlock` for the test — it is not part of this PR.

Inserting a link of that type in a `Rich Text` block, then saving the page:

- **with the fix** — the page saves, and the link is still there after reloading
- **with the fix reverted** — saving fails with the admin's "Validation failed" error dialog, `savePage` returns `BAD_REQUEST`

The same applies to a link in a `Rich Text (TipTap)` block.

Adding a `Contact Form` block — which is annotation-free too, but sits in the page content and is therefore validated by the application's `ValidationPipe` — saves in both cases, which confirms that path was never broken.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-3136
