### PR TITLE
Narrow the findUsers result to a minimal UserListItem type

### DIFF
--- a/.changeset/narrow-find-users-return-type.md
+++ b/.changeset/narrow-find-users-return-type.md
@@ -1,0 +1,9 @@
+---
+"@dextinity/cms-api": minor
+---
+
+Narrow the `findUsers` result to a minimal `UserListItem` type
+
+`UserPermissionsUserServiceInterface.findUsers` (and `UserPermissionsService.findUsers`) now return `Pick<User, "id" | "name" | "email">` items instead of the full `User` type. The paginated user list only ever needs these three fields, so this avoids forcing consumers to expose project-specific `User` fields (added via declaration merging) just to satisfy the list contract.
+
+`UserResolver`'s permission-filter checks (`permissionAndFiltersApplies` / `permissionOrFiltersApplies`) now re-fetch the full `User` via `findUserOrThrow` before evaluating permissions, since `hasPermission` still requires the complete `User`.

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -25,6 +25,7 @@ import {
     UserPermissions,
     UserPermissionsOptions,
     UserPermissionsUserServiceInterface,
+    Users,
 } from "./user-permissions.types";
 
 @Injectable()
@@ -125,7 +126,7 @@ export class UserPermissionsService {
         throw new Error("For this functionality you need to define `findUserOrThrow` (or the deprecated `getUser`) in the userService.");
     }
 
-    async findUsers(args: FindUsersArgs): Promise<[User[], number]> {
+    async findUsers(args: FindUsersArgs): Promise<Users> {
         if (!this.userService) {
             throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
         }

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -15,7 +15,8 @@ export enum UserPermissions {
     allPermissions = "all-permissions",
 }
 
-export type Users = [User[], number];
+export type UserListItem = Pick<User, "id" | "name" | "email">;
+export type Users = [UserListItem[], number];
 
 export type SystemUser = string;
 

--- a/packages/api/cms-api/src/user-permissions/user.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user.resolver.ts
@@ -8,9 +8,9 @@ import { RequiredPermission } from "./decorators/required-permission.decorator";
 import { CurrentUser } from "./dto/current-user";
 import { FindUsersArgs, PermissionFilter } from "./dto/paginated-user-list";
 import { UserPermissionsUser } from "./dto/user";
-import { User } from "./interfaces/user";
 import { UserContentScopesLoaderService } from "./user-content-scopes-loader.service";
 import { UserPermissionsService } from "./user-permissions.service";
+import { UserListItem } from "./user-permissions.types";
 
 @ObjectType()
 class UserPermissionPaginatedUserList extends PaginatedResponseFactory.create(UserPermissionsUser) {}
@@ -40,9 +40,9 @@ export class UserResolver {
         if (permissionAndFilters && permissionAndFilters.length > 0) {
             await this.userService.warmupHasPermissionCache();
             // If a permission filter is provided, we need to get all users and filter them
-            const filteredUsers: User[] = [];
+            const filteredUsers: UserListItem[] = [];
             let offset = 0;
-            let users: User[] = [];
+            let users: UserListItem[] = [];
             do {
                 [users] = await this.userService.findUsers({ filter: args.filter, sort: args.sort, offset, limit: 100 });
                 for (let i = 0; i < users.length; i++) {
@@ -55,8 +55,8 @@ export class UserResolver {
             return new UserPermissionPaginatedUserList(filteredUsers.slice(args.offset, args.offset + args.limit), filteredUsers.length);
         } else if (permissionOrFilters && permissionOrFilters.length > 0) {
             await this.userService.warmupHasPermissionCache();
-            const matchedUsers = new Set<User>();
-            let users: User[] = [];
+            const matchedUsers = new Set<UserListItem>();
+            let users: UserListItem[] = [];
             // Add all users that match other than permission filters
             if (args.filter?.or?.some((f) => !f.permission)) {
                 let offset = 0;
@@ -86,12 +86,13 @@ export class UserResolver {
         }
     }
 
-    async permissionAndFiltersApplies(user: User, filters: PermissionFilter[]): Promise<boolean> {
+    async permissionAndFiltersApplies(user: UserListItem, filters: PermissionFilter[]): Promise<boolean> {
+        const fullUser = await this.userService.findUserOrThrow(user.id);
         for (const filter of filters) {
             if (
-                (filter.equal && !(await this.userService.hasPermission(user, filter.equal))) ||
-                (filter.isAnyOf && !(await this.userService.hasPermission(user, filter.isAnyOf))) ||
-                (filter.notEqual && (await this.userService.hasPermission(user, filter.notEqual)))
+                (filter.equal && !(await this.userService.hasPermission(fullUser, filter.equal))) ||
+                (filter.isAnyOf && !(await this.userService.hasPermission(fullUser, filter.isAnyOf))) ||
+                (filter.notEqual && (await this.userService.hasPermission(fullUser, filter.notEqual)))
             ) {
                 return false;
             }
@@ -99,12 +100,13 @@ export class UserResolver {
         return true;
     }
 
-    async permissionOrFiltersApplies(user: User, filters: PermissionFilter[]): Promise<boolean> {
+    async permissionOrFiltersApplies(user: UserListItem, filters: PermissionFilter[]): Promise<boolean> {
+        const fullUser = await this.userService.findUserOrThrow(user.id);
         for (const filter of filters) {
             if (
-                (filter.equal && (await this.userService.hasPermission(user, filter.equal))) ||
-                (filter.isAnyOf && (await this.userService.hasPermission(user, filter.isAnyOf))) ||
-                (filter.notEqual && !(await this.userService.hasPermission(user, filter.notEqual)))
+                (filter.equal && (await this.userService.hasPermission(fullUser, filter.equal))) ||
+                (filter.isAnyOf && (await this.userService.hasPermission(fullUser, filter.isAnyOf))) ||
+                (filter.notEqual && !(await this.userService.hasPermission(fullUser, filter.notEqual)))
             ) {
                 return true;
             }


### PR DESCRIPTION
## Problem
Some UserServices might provide an enhanced User type with additional information which can be useful in projects. However, in the findUsers-Request for performance reasons the additional information should not be mandatory.

## Solution
This PR makes it possible for a UserService to implement this behaviour by only require the core User fields in findUsers().