### PR TITLE
mail-react: Reorder the Storybook sections

### DIFF
--- a/packages/mail-react/.storybook/preview.ts
+++ b/packages/mail-react/.storybook/preview.ts
@@ -7,7 +7,7 @@ export const parameters = {
     layout: "fullscreen",
     options: {
         storySort: {
-            order: ["Docs", "*"],
+            order: ["Docs", "Examples", "Layout Patterns", "Components", "Blocks", "*"],
         },
     },
     docs: {

--- a/packages/mail-react/src/blocks/pixelImage/__stories__/HtmlPixelImageBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/__stories__/HtmlPixelImageBlock.stories.tsx
@@ -9,7 +9,7 @@ import { exampleBlockData } from "./exampleBlockData.js";
 type Story = StoryObj<typeof HtmlPixelImageBlock>;
 
 const config: Meta<typeof HtmlPixelImageBlock> = {
-    title: "Components/Blocks/HtmlPixelImageBlock",
+    title: "Blocks/HtmlPixelImageBlock",
     component: HtmlPixelImageBlock,
     tags: ["autodocs"],
     parameters: {

--- a/packages/mail-react/src/blocks/pixelImage/__stories__/MjmlPixelImageBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/__stories__/MjmlPixelImageBlock.stories.tsx
@@ -9,7 +9,7 @@ import { exampleBlockData } from "./exampleBlockData.js";
 type Story = StoryObj<typeof MjmlPixelImageBlock>;
 
 const config: Meta<typeof MjmlPixelImageBlock> = {
-    title: "Components/Blocks/MjmlPixelImageBlock",
+    title: "Blocks/MjmlPixelImageBlock",
     component: MjmlPixelImageBlock,
     tags: ["autodocs"],
     parameters: {

--- a/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/HtmlRichTextBlock.stories.tsx
@@ -24,7 +24,7 @@ const { HtmlRichTextBlock } = createRichTextBlock();
 type Story = StoryObj<typeof HtmlRichTextBlock>;
 
 const config: Meta<typeof HtmlRichTextBlock> = {
-    title: "Components/Blocks/HtmlRichTextBlock",
+    title: "Blocks/HtmlRichTextBlock",
     component: HtmlRichTextBlock,
     tags: ["autodocs"],
     parameters: {

--- a/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/richText/__stories__/MjmlRichTextBlock.stories.tsx
@@ -24,7 +24,7 @@ const { MjmlRichTextBlock } = createRichTextBlock();
 type Story = StoryObj<typeof MjmlRichTextBlock>;
 
 const config: Meta<typeof MjmlRichTextBlock> = {
-    title: "Components/Blocks/MjmlRichTextBlock",
+    title: "Blocks/MjmlRichTextBlock",
     component: MjmlRichTextBlock,
     tags: ["autodocs"],
     parameters: {


### PR DESCRIPTION
Moving the block stories out of `Components` changes their story IDs, so old deep links to them break.