### PR TITLE
mail-react: Document switching content by breakpoint

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/6-layout-patterns.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/6-layout-patterns.md
@@ -339,6 +339,92 @@ The inline width compensation still needs to be neutralized so columns render at
 /* column rules identical to Responsive Stacking */
 ```
 
+## Breakpoint Content Switch
+
+Sometimes you cannot make both views from the same HTML, because the mobile view needs a different structure than the desktop view. Then put both layouts in the email and hide one of them.
+
+:::tip
+First try to make one layout that works at each width. Two layouts make twice as much markup, and columns already stack below `theme.breakpoints.mobile`.
+:::
+
+The switch has two parts:
+
+- The **default layout** is not hidden. It shows if the email client removes the `<style>` block, so make it the complete layout.
+- The **mobile layout** is hidden with inline styles. A media query then hides the default layout and shows the mobile layout.
+
+### The Pattern
+
+Make a component for each layout, and start it at its `MjmlSection`. Then the call site shows only the switch. Put the hiding styles on a `<div>` around the section: a section becomes a table, and `max-height` does not work on a table.
+
+```tsx
+<MailHeaderDefaultLayout className="mailHeader__defaultLayout" />
+
+<MjmlHtml html={`<div class="mailHeader__mobileLayout" style="display:none;max-height:0;overflow:hidden;font-size:0;line-height:0;">`} />
+<MailHeaderMobileLayout />
+<MjmlHtml html="</div>" />
+```
+
+Each of these properties stops a different email client:
+
+| Property                          | Client                                                        |
+| --------------------------------- | ------------------------------------------------------------- |
+| `display: none`                   | Apple Mail, modern webmail, and the new Outlook               |
+| `max-height: 0; overflow: hidden` | Yahoo Mail and old Gmail, which remove inline `display: none` |
+| `font-size: 0; line-height: 0`    | A client that still shows the text                            |
+| `mso-hide: all` on each element   | Classic Outlook on Windows                                    |
+
+### Hiding in Classic Outlook
+
+Classic Outlook shows both layouts if only the `<div>` has the hiding styles. Add `mso-hide: all` to each element in the mobile layout, and write it inline. `{ inline: true }` tells MJML to write the property into each `style` attribute.
+
+```ts
+registerStyles(
+    css`
+        .mailHeader__mobileLayout,
+        .mailHeader__mobileLayout * {
+            mso-hide: all;
+        }
+    `,
+    { inline: true },
+);
+```
+
+Write only `mso-hide: all` on those elements. `display: none` there breaks the tables, because the media query must then set `display` again on each `<tr>` and `<td>`.
+
+:::warning
+Do not use a conditional comment (`<!--[if !mso]>`) to hide a layout. MJML puts its own `[if mso]` comments around each section, and their `<![endif]-->` closes your comment too early. `MjmlConditionalComment` selects an email client, not a screen width.
+:::
+
+### Showing the Mobile Layout
+
+Put the media query in a second `registerStyles` call, because MJML cannot inline a media query.
+
+```ts
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .mailHeader__defaultLayout {
+                display: none !important;
+            }
+
+            .mailHeader__mobileLayout {
+                display: block !important;
+                max-height: none !important;
+                overflow: visible !important;
+                font-size: inherit !important;
+                line-height: inherit !important;
+            }
+        }
+    `,
+);
+```
+
+:::warning
+The media query must cancel each hiding style. `display: block` with `max-height: 0` still shows nothing. `overflow: visible` is also necessary, because Yahoo Mail adds `overflow-x` and `overflow-y` if it finds `max-height`.
+:::
+
+Do not put the switch breakpoint below `theme.breakpoints.mobile`. The default layout then stacks its columns before the media query hides it. If you must, add `disableResponsiveBehavior` to its section. For `belowMediaQuery`, see [The `belowMediaQuery` Pattern](./5-customization.md#the-belowmediaquery-pattern).
+
 ## Grouping Sections with a Shared Background
 
 When multiple sections need to share a background — for example, a multi-row footer with its own color — wrap them in `MjmlWrapper`. The wrapper owns the background; inner `MjmlSection`s suppress their own theme-default `backgroundColor` so the wrapper's color shows through.

--- a/packages/mail-react/src/__stories__/layout-patterns/BreakpointContentSwitch.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/BreakpointContentSwitch.stories.tsx
@@ -1,0 +1,131 @@
+import { MjmlColumn, MjmlSpacer } from "@faire/mjml-react";
+import { MjmlHtml } from "@faire/mjml-react/extensions/index.js";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+
+import { MjmlImage } from "../../components/image/MjmlImage.js";
+import { MjmlSection } from "../../components/section/MjmlSection.js";
+import { MjmlText } from "../../components/text/MjmlText.js";
+import { registerStyles } from "../../styles/registerStyles.js";
+import { createTheme } from "../../theme/createTheme.js";
+import { getDefaultFromResponsiveValue } from "../../theme/responsiveValue.js";
+import { css } from "../../utils/css.js";
+
+const config: Meta = {
+    title: "Layout Patterns/Breakpoint Content Switch",
+    decorators: [
+        (Story) => (
+            <>
+                <MjmlSection indent>
+                    <MjmlColumn>
+                        <MjmlSpacer height={30} />
+                        <MjmlText variant="heading" bottomSpacing>
+                            Breakpoint content switch
+                        </MjmlText>
+                        <MjmlText>
+                            The header below has two layouts. Make the canvas more narrow than 600px to see the switch. Exactly one layout shows at
+                            each width.
+                        </MjmlText>
+                        <MjmlSpacer height={30} />
+                    </MjmlColumn>
+                </MjmlSection>
+
+                <Story />
+
+                <MjmlSection indent>
+                    <MjmlColumn>
+                        <MjmlSpacer height={30} />
+                    </MjmlColumn>
+                </MjmlSection>
+            </>
+        ),
+    ],
+};
+
+export default config;
+
+const theme = createTheme({
+    text: {
+        defaultVariant: "body",
+        variants: {
+            heading: { fontSize: "22px", lineHeight: "28px", fontWeight: "bold" },
+            body: { fontSize: "14px", lineHeight: "20px" },
+        },
+    },
+});
+
+const sectionIndent = getDefaultFromResponsiveValue(theme.sizes.contentIndentation);
+const textColumnWidth = theme.sizes.bodyWidth - 2 * sectionIndent - 120;
+
+const mobileLayoutHideStyles = "display:none;max-height:0;overflow:hidden;font-size:0;line-height:0;";
+
+registerStyles(
+    css`
+        .mailHeader__mobileLayout,
+        .mailHeader__mobileLayout * {
+            mso-hide: all;
+        }
+    `,
+    { inline: true },
+);
+
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .mailHeader__defaultLayout {
+                display: none !important;
+            }
+
+            .mailHeader__mobileLayout {
+                display: block !important;
+                max-height: none !important;
+                overflow: visible !important;
+                font-size: inherit !important;
+                line-height: inherit !important;
+            }
+        }
+    `,
+);
+
+function MailHeaderDefaultLayout({ className }: { className?: string }): ReactNode {
+    return (
+        <MjmlSection indent className={className}>
+            <MjmlColumn width="120px" verticalAlign="middle">
+                <MjmlImage src="https://picsum.photos/seed/4/240/80" alt="Logo" align="left" width={120} />
+            </MjmlColumn>
+            <MjmlColumn width={`${textColumnWidth}px`} verticalAlign="middle">
+                <MjmlText align="right">
+                    <strong style={{ fontWeight: "bold" }}>DESKTOP</strong> — this text shows only at 600px and wider.
+                </MjmlText>
+            </MjmlColumn>
+        </MjmlSection>
+    );
+}
+
+function MailHeaderMobileLayout(): ReactNode {
+    return (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlImage src="https://picsum.photos/seed/5/240/80" alt="Logo" align="center" width={120} />
+                <MjmlSpacer height={16} />
+                <MjmlText align="center">
+                    <strong style={{ fontWeight: "bold" }}>MOBILE</strong> — this text shows only below 600px.
+                </MjmlText>
+            </MjmlColumn>
+        </MjmlSection>
+    );
+}
+
+export const Default: StoryObj = {
+    parameters: { theme },
+    render: () => (
+        <>
+            <MailHeaderDefaultLayout className="mailHeader__defaultLayout" />
+
+            {/* The hiding styles must go on a `<div>`: a section compiles to a table, and `max-height` has no effect on a table. */}
+            <MjmlHtml html={`<div class="mailHeader__mobileLayout" style="${mobileLayoutHideStyles}">`} />
+            <MailHeaderMobileLayout />
+            <MjmlHtml html="</div>" />
+        </>
+    ),
+};

--- a/skills/dextinity-mail-react/SKILL.md
+++ b/skills/dextinity-mail-react/SKILL.md
@@ -121,6 +121,14 @@ Always use `theme.breakpoints.*.belowMediaQuery` inside `registerStyles` instead
 
 → For the full `registerStyles` API, `css` helper, and custom component patterns, read [`references/styling-and-customization.md`](references/styling-and-customization.md).
 
+### Switching Content by Breakpoint
+
+Sometimes you cannot make both views from the same HTML, because the mobile view needs a different structure than the desktop view. Then put both layouts in the email and hide one of them: inline styles hide the mobile layout, and a media query in `registerStyles` switches the two.
+
+Two layouts make twice as much markup, so first try to make one layout that works at each width. Columns already stack on mobile.
+
+→ For the hiding styles, the extra step classic Outlook needs, and what to avoid, read [`references/layout-patterns.md`](references/layout-patterns.md) → Breakpoint Content Switch.
+
 ---
 
 ## Common Pitfalls

--- a/skills/dextinity-mail-react/references/layout-patterns.md
+++ b/skills/dextinity-mail-react/references/layout-patterns.md
@@ -289,6 +289,78 @@ When using `direction="rtl"`:
 
 ---
 
+## Breakpoint Content Switch
+
+Sometimes you cannot make both views from the same HTML, because the mobile view needs a different structure than the desktop view. Then put both layouts in the email and hide one of them.
+
+Two layouts make twice as much markup, so first try to make one layout that works at each width. Columns already stack below `theme.breakpoints.mobile`.
+
+- The **default layout** is not hidden. It shows if the email client removes the `<style>` block, so make it the complete layout.
+- The **mobile layout** is hidden with inline styles. A media query then hides the default layout and shows the mobile layout.
+
+Make a component for each layout, and start it at its `MjmlSection`. Then the call site shows only the switch. Put the hiding styles on a `<div>` around the section: a section becomes a table, and `max-height` does not work on a table.
+
+```tsx
+<MailHeaderDefaultLayout className="mailHeader__defaultLayout" />
+
+<MjmlHtml html={`<div class="mailHeader__mobileLayout" style="display:none;max-height:0;overflow:hidden;font-size:0;line-height:0;">`} />
+<MailHeaderMobileLayout />
+<MjmlHtml html="</div>" />
+```
+
+Each of these properties stops a different email client:
+
+| Property                          | Client                                                        |
+| --------------------------------- | ------------------------------------------------------------- |
+| `display: none`                   | Apple Mail, modern webmail, and the new Outlook               |
+| `max-height: 0; overflow: hidden` | Yahoo Mail and old Gmail, which remove inline `display: none` |
+| `font-size: 0; line-height: 0`    | A client that still shows the text                            |
+| `mso-hide: all` on each element   | Classic Outlook on Windows                                    |
+
+Classic Outlook shows both layouts if only the `<div>` has the hiding styles. Add `mso-hide: all` to each element in the mobile layout, and write it inline with `{ inline: true }`. The media query needs a separate `registerStyles` call, because MJML cannot inline a media query.
+
+```tsx
+registerStyles(
+    css`
+        .mailHeader__mobileLayout,
+        .mailHeader__mobileLayout * {
+            mso-hide: all;
+        }
+    `,
+    { inline: true },
+);
+
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .mailHeader__defaultLayout {
+                display: none !important;
+            }
+
+            .mailHeader__mobileLayout {
+                display: block !important;
+                max-height: none !important;
+                overflow: visible !important;
+                font-size: inherit !important;
+                line-height: inherit !important;
+            }
+        }
+    `,
+);
+```
+
+Write only `mso-hide: all` on those elements. `display: none` there breaks the tables, because the media query must then set `display` again on each `<tr>` and `<td>`.
+
+The media query must cancel each hiding style. `display: block` with `max-height: 0` still shows nothing. `overflow: visible` is also necessary, because Yahoo Mail adds `overflow-x` and `overflow-y` if it finds `max-height`.
+
+Do not put the switch breakpoint below `theme.breakpoints.mobile`. The default layout then stacks its columns before the media query hides it. If you must, add `disableResponsiveBehavior` to its section.
+
+Do not use a conditional comment (`<!--[if !mso]>`) to hide a layout. MJML puts its own `[if mso]` comments around each section, and their `<![endif]-->` closes your comment too early. `MjmlConditionalComment` selects an email client, not a screen width.
+
+Storybook: _Layout Patterns/Breakpoint Content Switch_.
+
+---
+
 ## Grouping Sections with a Shared Background
 
 When multiple sections need to share a background — for example, a multi-row footer with its own color — wrap them in `MjmlWrapper`. The wrapper owns the background; inner `MjmlSection`s suppress their own theme-default `backgroundColor` so the wrapper's color shows through.


### PR DESCRIPTION
A project that consumes the package hid one layout with a `<style>` rule alone and shipped an email that showed both, because Gmail with a non-Google account and other clients remove embedded styles.
The package had no example and no written guidance, so each project derives the pattern again.