### PR TITLE
cms-admin: Allow restricting selectable heading levels in TipTap rich text block

### DIFF
--- a/.changeset/tiptap-heading-levels.md
+++ b/.changeset/tiptap-heading-levels.md
@@ -1,0 +1,14 @@
+---
+"@dextinity/cms-admin": minor
+---
+
+Allow restricting selectable heading levels in the TipTap rich text block via a new `headingLevels` option
+
+`createTipTapRichTextBlock` accepts a new `headingLevels?: number[]` option to limit which heading levels (1-6) are selectable. Defaults to `[1, 2, 3, 4, 5, 6]`, so existing usages are unaffected.
+
+```tsx
+createTipTapRichTextBlock({
+    supports: ["heading"],
+    headingLevels: [2, 3, 4],
+});
+```

--- a/.changeset/tiptap-heading-levels.md
+++ b/.changeset/tiptap-heading-levels.md
@@ -4,7 +4,7 @@
 
 Allow restricting selectable heading levels in the TipTap rich text block via a new `headingLevels` option
 
-`createTipTapRichTextBlock` accepts a new `headingLevels?: number[]` option to limit which heading levels (1-6) are selectable. Defaults to `[1, 2, 3, 4, 5, 6]`, so existing usages are unaffected.
+`createTipTapRichTextBlock` accepts a new `headingLevels?: number[]` option to limit which heading levels (1-6) are selectable. Defaults to `[1, 2, 3, 4, 5, 6]`, so existing usages are unaffected. Must be a non-empty array of unique integers between 1 and 6, otherwise an error is thrown.
 
 ```tsx
 createTipTapRichTextBlock({

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -165,6 +165,7 @@ export const TipTapToolbar = ({
     linkBlock,
     childBlocks,
     listLevelMax,
+    headingLevels = [1, 2, 3, 4, 5, 6],
 }: {
     editor: Editor;
     supports: TipTapSupports[];
@@ -174,6 +175,7 @@ export const TipTapToolbar = ({
     linkBlock?: BlockInterface & LinkBlockInterface;
     childBlocks: Record<string, TipTapChildBlock>;
     listLevelMax?: number;
+    headingLevels?: number[];
 }) => {
     const intl = useIntl();
     const [moreAnchorEl, setMoreAnchorEl] = useState<null | HTMLElement>(null);
@@ -368,7 +370,7 @@ export const TipTapToolbar = ({
                             <MenuItem value="paragraph" dense>
                                 <FormattedMessage id="dextinity.blocks.tipTapRichText.textBlockType.paragraph" defaultMessage="Paragraph" />
                             </MenuItem>
-                            {([1, 2, 3, 4, 5, 6] as const).map((level) => (
+                            {headingLevels.map((level) => (
                                 <MenuItem key={level} value={String(level)} dense>
                                     <FormattedMessage
                                         id="dextinity.blocks.tipTapRichText.textBlockType.heading"

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -1108,6 +1108,19 @@ export const HeadingLevels: StoryObj<typeof HeadingLevelsStory> = {
     },
 };
 
+export const InvalidHeadingLevels: Story = {
+    render: () => <div />,
+    play: async ({ step }) => {
+        await step("Invalid headingLevels throw instead of silently creating a broken heading", async () => {
+            expect(() => createTipTapRichTextBlock({ headingLevels: [] })).toThrow();
+            expect(() => createTipTapRichTextBlock({ headingLevels: [0, 2, 3] })).toThrow();
+            expect(() => createTipTapRichTextBlock({ headingLevels: [1, 7] })).toThrow();
+            expect(() => createTipTapRichTextBlock({ headingLevels: [1, 1, 2] })).toThrow();
+            expect(() => createTipTapRichTextBlock({ headingLevels: [1.5, 2] })).toThrow();
+        });
+    },
+};
+
 const CombinedStylesBlock = createTipTapRichTextBlock({
     textBlockStyles: [
         {

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -1039,6 +1039,75 @@ export const ListLevelMax: StoryObj<typeof ListLevelMaxStory> = {
     },
 };
 
+const HeadingLevelsBlock = createTipTapRichTextBlock({ headingLevels: [2, 3, 4] });
+
+function HeadingLevelsStory() {
+    const [state, setState] = useState<TipTapRichTextBlockState>(HeadingLevelsBlock.defaultValues());
+
+    return (
+        <StoryWrapper state={state}>
+            <HeadingLevelsBlock.AdminComponent state={state} updateState={setState} />
+        </StoryWrapper>
+    );
+}
+
+export const HeadingLevels: StoryObj<typeof HeadingLevelsStory> = {
+    render: () => <HeadingLevelsStory />,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Editor is ready", async () => {
+            await waitFor(
+                () => {
+                    expect(canvas.getByRole("textbox")).toBeInTheDocument();
+                },
+                { timeout: 5000 },
+            );
+        });
+
+        await step("Heading dropdown only offers Heading 2-4, not 1, 5 or 6", async () => {
+            const textBlockTypeSelect = canvas.getByRole("combobox");
+            await userEvent.click(textBlockTypeSelect);
+
+            await waitFor(
+                () => {
+                    const body = within(document.body);
+                    expect(body.getByText("Heading 2")).toBeInTheDocument();
+                    expect(body.getByText("Heading 3")).toBeInTheDocument();
+                    expect(body.getByText("Heading 4")).toBeInTheDocument();
+                    expect(body.queryByText("Heading 1")).not.toBeInTheDocument();
+                    expect(body.queryByText("Heading 5")).not.toBeInTheDocument();
+                    expect(body.queryByText("Heading 6")).not.toBeInTheDocument();
+                },
+                { timeout: 3000 },
+            );
+
+            await userEvent.click(within(document.body).getByText("Heading 2"));
+        });
+
+        await step("Selected heading level is applied", async () => {
+            await waitFor(
+                () => {
+                    expect(canvas.getByRole("heading", { level: 2 })).toBeInTheDocument();
+                },
+                { timeout: 3000 },
+            );
+        });
+
+        await step("Keyboard shortcut for a disallowed level (Mod-Alt-1) does not apply Heading 1", async () => {
+            const editor = canvas.getByRole("textbox");
+            await userEvent.click(editor);
+            const mod = /Mac/i.test(navigator.platform) ? "Meta" : "Control";
+            await userEvent.keyboard(`{${mod}>}{Alt>}1{/Alt}{/${mod}}`);
+
+            await waitFor(
+                () => {
+                    expect(canvas.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+                },
+                { timeout: 3000 },
+            );
+        });
+    },
+};
+
 const CombinedStylesBlock = createTipTapRichTextBlock({
     textBlockStyles: [
         {

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -2,6 +2,7 @@ import { greyPalette } from "@dextinity/admin";
 import { Box } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { Extension } from "@tiptap/core";
+import type { Level as HeadingLevel } from "@tiptap/extension-heading";
 import Subscript from "@tiptap/extension-subscript";
 import Superscript from "@tiptap/extension-superscript";
 import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
@@ -141,6 +142,10 @@ interface TipTapRichTextBlockFactoryOptions {
      * A value of 1 means only a flat list (no nesting), 2 allows one level of sub-lists, etc.
      */
     listLevelMax?: number;
+    /**
+     * Limits the selectable heading levels (1-6). Defaults to all levels ([1, 2, 3, 4, 5, 6]).
+     */
+    headingLevels?: number[];
 }
 
 function getPlainTextFromContent(content: JSONContent): string {
@@ -340,6 +345,7 @@ const TipTapEditor = ({
     childBlocks,
     maxTextBlocks,
     listLevelMax,
+    headingLevels,
     readOnly,
 }: {
     state: TipTapRichTextBlockState;
@@ -352,6 +358,7 @@ const TipTapEditor = ({
     childBlocks: Record<string, TipTapChildBlock>;
     maxTextBlocks?: number;
     listLevelMax?: number;
+    headingLevels?: number[];
     readOnly?: boolean;
 }) => {
     const hasTextBlockStyles = textBlockStyles.length > 0;
@@ -370,7 +377,13 @@ const TipTapEditor = ({
                 italic: supports.includes("italic") ? {} : false,
                 underline: supports.includes("underline") ? {} : false,
                 strike: supports.includes("strike") ? {} : false,
-                heading: supports.includes("heading") ? (hasTextBlockStyles ? false : {}) : false,
+                heading: supports.includes("heading")
+                    ? hasTextBlockStyles
+                        ? false
+                        : headingLevels
+                          ? { levels: headingLevels as HeadingLevel[] }
+                          : {}
+                    : false,
                 paragraph: hasTextBlockStyles ? false : undefined,
                 orderedList: supports.includes("ordered-list") ? {} : false,
                 bulletList: supports.includes("unordered-list") ? {} : false,
@@ -380,7 +393,9 @@ const TipTapEditor = ({
                 link: false,
             }),
             ...(hasTextBlockStyles ? [TextBlockStyleParagraph] : []),
-            ...(hasTextBlockStyles && supports.includes("heading") ? [TextBlockStyleHeading] : []),
+            ...(hasTextBlockStyles && supports.includes("heading")
+                ? [TextBlockStyleHeading.configure(headingLevels ? { levels: headingLevels as HeadingLevel[] } : {})]
+                : []),
             ...(hasInlineStyles ? [InlineStyleMark] : []),
             ...(supports.includes("sup") ? [Superscript] : []),
             ...(supports.includes("sub") ? [Subscript] : []),
@@ -459,6 +474,7 @@ const TipTapEditor = ({
                                 linkBlock={linkBlock}
                                 childBlocks={childBlocks}
                                 listLevelMax={listLevelMax}
+                                headingLevels={headingLevels}
                             />
                             <Box sx={{ "& .tiptap": { minHeight: 200, p: "20px", outline: "none" } }}>{editorNode}</Box>
                         </Box>
@@ -486,13 +502,24 @@ export const createTipTapRichTextBlock = (options?: TipTapRichTextBlockFactoryOp
     const hasChildBlocks = Object.keys(childBlocks).length > 0;
     const maxTextBlocks = options?.maxTextBlocks;
     const listLevelMax = options?.listLevelMax;
+    const headingLevels = options?.headingLevels;
 
     // Auto-enable link support when a link block is provided
     if (linkBlock && !supports.includes("link")) {
         supports = [...supports, "link"];
     }
 
-    const sharedEditorProps = { supports, textBlockStyles, inlineStyles, placeholders, linkBlock, childBlocks, maxTextBlocks, listLevelMax };
+    const sharedEditorProps = {
+        supports,
+        textBlockStyles,
+        inlineStyles,
+        placeholders,
+        linkBlock,
+        childBlocks,
+        maxTextBlocks,
+        listLevelMax,
+        headingLevels,
+    };
 
     const TipTapRichTextBlock: TipTapRichTextBlockInterface = {
         ...createBlockSkeleton(),

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -144,6 +144,7 @@ interface TipTapRichTextBlockFactoryOptions {
     listLevelMax?: number;
     /**
      * Limits the selectable heading levels (1-6). Defaults to all levels ([1, 2, 3, 4, 5, 6]).
+     * Must be a non-empty array of unique integers between 1 and 6, otherwise an error is thrown.
      */
     headingLevels?: number[];
 }
@@ -503,6 +504,15 @@ export const createTipTapRichTextBlock = (options?: TipTapRichTextBlockFactoryOp
     const maxTextBlocks = options?.maxTextBlocks;
     const listLevelMax = options?.listLevelMax;
     const headingLevels = options?.headingLevels;
+
+    if (
+        headingLevels &&
+        (headingLevels.length === 0 ||
+            new Set(headingLevels).size !== headingLevels.length ||
+            headingLevels.some((level) => !Number.isInteger(level) || level < 1 || level > 6))
+    ) {
+        throw new Error("headingLevels must be a non-empty array of unique integers between 1 and 6");
+    }
 
     // Auto-enable link support when a link block is provided
     if (linkBlock && !supports.includes("link")) {


### PR DESCRIPTION
## Summary
- Add a new `headingLevels?: number[]` option to `createTipTapRichTextBlock` to restrict which heading levels (1-6) are selectable in the toolbar dropdown, markdown input rules, and keyboard shortcuts. Defaults to `[1, 2, 3, 4, 5, 6]`, so existing usages are unaffected.
- Validate `headingLevels` at block-creation time (non-empty, unique integers 1-6) so a typo fails fast instead of producing an invalid heading tag at runtime.

Needed for an upcoming Headline block migration to TipTap, which should only offer H2-H4 (no H1/H5/H6), matching the previous Draft.js implementation.

## Test plan
- [x] `pnpm run lint:fix` passes
- [x] `tsc --noEmit` passes
- [x] New Storybook stories: `HeadingLevels` (dropdown restricted to H2-H4, keyboard shortcut for a disallowed level is blocked) and `InvalidHeadingLevels` (invalid configs throw)
- [x] Added changeset (`@dextinity/cms-admin`, minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
