### PR TITLE
Add requireTextBlockStyle option to TipTap rich text block

### DIFF
--- a/.changeset/tiptap-max-text-blocks-trim-position.md
+++ b/.changeset/tiptap-max-text-blocks-trim-position.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/cms-admin": patch
+---
+
+Fix a `RangeError` when trimming excess text blocks in the TipTap rich text editor
+
+`maxTextBlocks`'s trim-on-paste logic computed the deletion range with an extra `+1` offset, on the assumption that `doc` content positions start after an opening token like other nodes. `doc` has no such token — its content starts at position 0 — so the offset pointed past the end of the document, most reliably reproducible with `maxTextBlocks: 1`.

--- a/.changeset/tiptap-require-text-block-style-api.md
+++ b/.changeset/tiptap-require-text-block-style-api.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/cms-api": minor
+---
+
+Add `requireTextBlockStyle` option to `createTipTapRichTextBlock`
+
+Mirrors the admin-side `requireTextBlockStyle` option: when `textBlockStyles` are configured, rejects stored content where a heading or paragraph has at least one applicable style but none set, consistent with how `maxTextBlocks` and `listLevelMax` are already enforced server-side rather than trusting client-only validation.

--- a/.changeset/tiptap-require-text-block-style.md
+++ b/.changeset/tiptap-require-text-block-style.md
@@ -1,0 +1,14 @@
+---
+"@dextinity/cms-admin": minor
+---
+
+Add `requireTextBlockStyle` option to `createTipTapRichTextBlock`
+
+When `textBlockStyles` are configured, the toolbar's style dropdown always offered an unstyled "Default" entry in addition to the configured styles. Passing `requireTextBlockStyle: true` removes that entry for headings and paragraphs that have at least one applicable style: the editor auto-assigns the first applicable style instead of leaving it unset.
+
+```ts
+createTipTapRichTextBlock({
+    textBlockStyles: [{ name: "large", label: "Large", element: LargeText }],
+    requireTextBlockStyle: true,
+});
+```

--- a/demo/api/src/common/blocks/tip-tap-rich-text.block.ts
+++ b/demo/api/src/common/blocks/tip-tap-rich-text.block.ts
@@ -22,6 +22,7 @@ export const TipTapRichTextBlock = createTipTapRichTextBlock(
             { name: "list300", appliesTo: ["ordered-list", "unordered-list"] },
             { name: "list200", appliesTo: ["ordered-list", "unordered-list"] },
         ],
+        requireTextBlockStyle: true,
         inlineStyles: [{ name: "highlight" }, { name: "tag", appliesTo: ["paragraph"] }],
         migrateFromDraftJs: {
             // Map the DraftJS `blocktypeMap` entry `paragraph-small` (configured in the admin RichTextBlock)

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -165,6 +165,7 @@ export const TipTapToolbar = ({
     linkBlock,
     childBlocks,
     listLevelMax,
+    requireTextBlockStyle,
 }: {
     editor: Editor;
     supports: TipTapSupports[];
@@ -174,6 +175,7 @@ export const TipTapToolbar = ({
     linkBlock?: BlockInterface & LinkBlockInterface;
     childBlocks: Record<string, TipTapChildBlock>;
     listLevelMax?: number;
+    requireTextBlockStyle?: boolean;
 }) => {
     const intl = useIntl();
     const [moreAnchorEl, setMoreAnchorEl] = useState<null | HTMLElement>(null);
@@ -392,9 +394,11 @@ export const TipTapToolbar = ({
                             MenuProps={{ elevation: 1 }}
                             sx={selectSx}
                         >
-                            <MenuItem value="" dense>
-                                <FormattedMessage id="dextinity.blocks.tipTapRichText.textBlockStyle.default" defaultMessage="Default" />
-                            </MenuItem>
+                            {!requireTextBlockStyle && (
+                                <MenuItem value="" dense>
+                                    <FormattedMessage id="dextinity.blocks.tipTapRichText.textBlockStyle.default" defaultMessage="Default" />
+                                </MenuItem>
+                            )}
                             {applicableTextBlockStyles.map((style) => (
                                 <MenuItem key={style.name} value={style.name} dense>
                                     {style.label}

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -1091,3 +1091,76 @@ export const CombinedTextBlockAndInlineStyles: StoryObj<typeof CombinedStylesSto
         });
     },
 };
+
+const RequireTextBlockStyleBlock = createTipTapRichTextBlock({
+    textBlockStyles: [
+        {
+            name: "h2-large",
+            label: "H2 Large",
+            appliesTo: ["heading-2"],
+            element: (p) => <Typography sx={{ fontSize: 36, lineHeight: 1.2 }} variant="h2" {...p} />,
+        },
+        {
+            name: "h2-small",
+            label: "H2 Small",
+            appliesTo: ["heading-2"],
+            element: (p) => <Typography sx={{ fontSize: 24, lineHeight: 1.2 }} variant="h2" {...p} />,
+        },
+        {
+            name: "intro",
+            label: "Intro Text",
+            appliesTo: ["paragraph"],
+            element: (props: HTMLAttributes<HTMLElement>) => <p style={{ fontSize: 20, fontStyle: "italic" }} {...props} />,
+        },
+    ],
+    requireTextBlockStyle: true,
+});
+
+function RequireTextBlockStyleStory() {
+    const [state, setState] = useState<TipTapRichTextBlockState>(RequireTextBlockStyleBlock.defaultValues());
+
+    return (
+        <StoryWrapper state={state}>
+            <RequireTextBlockStyleBlock.AdminComponent state={state} updateState={setState} />
+        </StoryWrapper>
+    );
+}
+
+export const RequireTextBlockStyle: StoryObj<typeof RequireTextBlockStyleStory> = {
+    render: () => <RequireTextBlockStyleStory />,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("The initial paragraph already has a style selected — no 'Default' option is offered", async () => {
+            await waitFor(
+                () => {
+                    const comboboxes = canvas.getAllByRole("combobox");
+                    expect(comboboxes).toHaveLength(2);
+                    expect(comboboxes[1]).toHaveTextContent("Intro Text");
+                },
+                { timeout: 5000 },
+            );
+
+            await userEvent.click(canvas.getAllByRole("combobox")[1]);
+            await waitFor(() => {
+                expect(within(document.body).queryByRole("option", { name: "Default" })).not.toBeInTheDocument();
+            });
+            await userEvent.keyboard("{Escape}");
+        });
+
+        await step("Switching to Heading 2 auto-assigns its first applicable style instead of 'Default'", async () => {
+            const textBlockTypeSelect = canvas.getAllByRole("combobox")[0];
+            await userEvent.click(textBlockTypeSelect);
+
+            await waitFor(() => {
+                expect(within(document.body).getByText("Heading 2")).toBeInTheDocument();
+            });
+            await userEvent.click(within(document.body).getByText("Heading 2"));
+
+            await waitFor(
+                () => {
+                    expect(canvas.getAllByRole("combobox")[1]).toHaveTextContent("H2 Large");
+                },
+                { timeout: 3000 },
+            );
+        });
+    },
+};

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -22,6 +22,7 @@ import { TextBlockStyleHeading } from "./extensions/TextBlockStyleHeading";
 import { TextBlockStyleParagraph } from "./extensions/TextBlockStyleParagraph";
 import { InlineStyleContext } from "./InlineStyleContext";
 import { createListLevelMaxExtension, getListNestingDepthFromJson, trimListNesting } from "./listLevelMaxHelpers";
+import { createRequireTextBlockStyleExtension, getDefaultTextBlockStyleName } from "./requireTextBlockStyleHelpers";
 import { TextBlockStyleContext } from "./TextBlockStyleContext";
 import { TipTapToolbar } from "./TipTapToolbar";
 
@@ -141,6 +142,12 @@ interface TipTapRichTextBlockFactoryOptions {
      * A value of 1 means only a flat list (no nesting), 2 allows one level of sub-lists, etc.
      */
     listLevelMax?: number;
+    /**
+     * Requires every heading or paragraph that has at least one applicable entry in `textBlockStyles`
+     * to have one explicitly set. The toolbar no longer offers an unstyled "Default" option for such
+     * text block types, and one is auto-assigned wherever it would otherwise be missing.
+     */
+    requireTextBlockStyle?: boolean;
 }
 
 function getPlainTextFromContent(content: JSONContent): string {
@@ -340,6 +347,7 @@ const TipTapEditor = ({
     childBlocks,
     maxTextBlocks,
     listLevelMax,
+    requireTextBlockStyle,
     readOnly,
 }: {
     state: TipTapRichTextBlockState;
@@ -352,6 +360,7 @@ const TipTapEditor = ({
     childBlocks: Record<string, TipTapChildBlock>;
     maxTextBlocks?: number;
     listLevelMax?: number;
+    requireTextBlockStyle: boolean;
     readOnly?: boolean;
 }) => {
     const hasTextBlockStyles = textBlockStyles.length > 0;
@@ -392,6 +401,7 @@ const TipTapEditor = ({
             ...(hasInlineChildBlocks ? [CmsInlineBlock] : []),
             ...(maxTextBlocks !== undefined ? [createMaxTextBlocksExtension(maxTextBlocks)] : []),
             ...(listLevelMax !== undefined ? [createListLevelMaxExtension(listLevelMax)] : []),
+            ...(requireTextBlockStyle ? [createRequireTextBlockStyleExtension(textBlockStyles)] : []),
         ],
         content: state.tipTapContent,
         editable: !readOnly,
@@ -459,6 +469,7 @@ const TipTapEditor = ({
                                 linkBlock={linkBlock}
                                 childBlocks={childBlocks}
                                 listLevelMax={listLevelMax}
+                                requireTextBlockStyle={requireTextBlockStyle}
                             />
                             <Box sx={{ "& .tiptap": { minHeight: 200, p: "20px", outline: "none" } }}>{editorNode}</Box>
                         </Box>
@@ -486,13 +497,36 @@ export const createTipTapRichTextBlock = (options?: TipTapRichTextBlockFactoryOp
     const hasChildBlocks = Object.keys(childBlocks).length > 0;
     const maxTextBlocks = options?.maxTextBlocks;
     const listLevelMax = options?.listLevelMax;
+    const requireTextBlockStyle = options?.requireTextBlockStyle ?? false;
 
     // Auto-enable link support when a link block is provided
     if (linkBlock && !supports.includes("link")) {
         supports = [...supports, "link"];
     }
 
-    const sharedEditorProps = { supports, textBlockStyles, inlineStyles, placeholders, linkBlock, childBlocks, maxTextBlocks, listLevelMax };
+    const sharedEditorProps = {
+        supports,
+        textBlockStyles,
+        inlineStyles,
+        placeholders,
+        linkBlock,
+        childBlocks,
+        maxTextBlocks,
+        listLevelMax,
+        requireTextBlockStyle,
+    };
+
+    const initialContent: JSONContent = requireTextBlockStyle
+        ? {
+              type: "doc",
+              content: [
+                  {
+                      type: "paragraph",
+                      attrs: { textBlockStyle: getDefaultTextBlockStyleName("paragraph", textBlockStyles) },
+                  },
+              ],
+          }
+        : emptyContent;
 
     const TipTapRichTextBlock: TipTapRichTextBlockInterface = {
         ...createBlockSkeleton(),
@@ -501,7 +535,7 @@ export const createTipTapRichTextBlock = (options?: TipTapRichTextBlockFactoryOp
 
         displayName: <FormattedMessage id="dextinity.blocks.tipTapRichText" defaultMessage="Rich Text (TipTap)" />,
 
-        defaultValues: () => ({ tipTapContent: emptyContent }),
+        defaultValues: () => ({ tipTapContent: initialContent }),
 
         category: BlockCategory.TextAndContent,
 

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -410,14 +410,14 @@ const TipTapEditor = ({
                 // Remove excess text blocks (e.g. from paste)
                 const { tr } = editor.state;
                 const doc = editor.state.doc;
-                // Find the resolved position after the maxTextBlocks-th child
+                // Find the position after the maxTextBlocks-th child. Unlike other nodes, doc's own
+                // content positions start at 0 directly (it has no opening token to offset past).
                 let pos = 0;
                 for (let i = 0; i < maxTextBlocks; i++) {
                     pos += doc.child(i).nodeSize;
                 }
-                // In ProseMirror, doc content positions are offset by 1 (for the doc open token)
                 // Delete from after the last allowed text block to end of doc content
-                tr.delete(pos + 1, doc.content.size + 1);
+                tr.delete(pos, doc.content.size);
                 editor.view.dispatch(tr);
                 return;
             }

--- a/packages/admin/cms-admin/src/blocks/tipTap/requireTextBlockStyleHelpers.ts
+++ b/packages/admin/cms-admin/src/blocks/tipTap/requireTextBlockStyleHelpers.ts
@@ -1,0 +1,56 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey, type Transaction } from "@tiptap/pm/state";
+
+import type { TipTapTextBlockStyle, TipTapTextBlockType } from "./createTipTapRichTextBlock";
+
+function getTextBlockTypeForNode(nodeTypeName: string, level: number | undefined): TipTapTextBlockType | undefined {
+    if (nodeTypeName === "paragraph") {
+        return "paragraph";
+    }
+    if (nodeTypeName === "heading" && level) {
+        return `heading-${level}` as TipTapTextBlockType;
+    }
+    return undefined;
+}
+
+export function getDefaultTextBlockStyleName(textBlockType: TipTapTextBlockType, textBlockStyles: TipTapTextBlockStyle[]): string | null {
+    const applicableStyle = textBlockStyles.find((style) => !style.appliesTo || style.appliesTo.includes(textBlockType));
+    return applicableStyle?.name ?? null;
+}
+
+// Backfills textBlockStyle on any heading/paragraph that has an applicable style but none set, so a
+// "no style" state (which the toolbar no longer offers when requireTextBlockStyle is enabled) can't
+// persist — covers the toolbar, markdown input rules, keyboard shortcuts, and pasted content alike.
+export const createRequireTextBlockStyleExtension = (textBlockStyles: TipTapTextBlockStyle[]) =>
+    Extension.create({
+        name: "requireTextBlockStyle",
+        addProseMirrorPlugins() {
+            return [
+                new Plugin({
+                    key: new PluginKey("requireTextBlockStyle"),
+                    appendTransaction(transactions, _oldState, newState) {
+                        if (!transactions.some((transaction) => transaction.docChanged)) {
+                            return null;
+                        }
+
+                        let tr: Transaction | null = null;
+                        newState.doc.descendants((node, pos) => {
+                            if (node.attrs.textBlockStyle) {
+                                return;
+                            }
+                            const textBlockType = getTextBlockTypeForNode(node.type.name, node.attrs.level as number | undefined);
+                            if (!textBlockType) {
+                                return;
+                            }
+                            const defaultStyleName = getDefaultTextBlockStyleName(textBlockType, textBlockStyles);
+                            if (!defaultStyleName) {
+                                return;
+                            }
+                            tr = (tr ?? newState.tr).setNodeAttribute(pos, "textBlockStyle", defaultStyleName);
+                        });
+                        return tr;
+                    },
+                }),
+            ];
+        },
+    });

--- a/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
@@ -135,6 +135,12 @@ export interface CreateTipTapRichTextBlockOptions {
      */
     listLevelMax?: number;
     /**
+     * Requires every heading or paragraph that has at least one applicable entry in `textBlockStyles`
+     * to have one explicitly set. Content missing a required style will be rejected during validation.
+     * Requires a non-empty `textBlockStyles` array.
+     */
+    requireTextBlockStyle?: boolean;
+    /**
      * Enables best-effort migration of DraftJS-based RichTextBlock data
      * (`{ draftContent: { blocks, entityMap } }`) into TipTap data.
      *
@@ -333,6 +339,26 @@ function getTextBlockTypeFromNode(node: JSONContent): TipTapTextBlockType | unde
     return undefined;
 }
 
+function containsMissingTextBlockStyle(content: JSONContent, textBlockStyles: TipTapTextBlockStyle[]): boolean {
+    const textBlockType = getTextBlockTypeFromNode(content);
+    if (textBlockType) {
+        const hasApplicableStyle = textBlockStyles.some((style) => !style.appliesTo || style.appliesTo.includes(textBlockType));
+        if (hasApplicableStyle && !content.attrs?.textBlockStyle) {
+            return true;
+        }
+    }
+
+    if (Array.isArray(content.content)) {
+        for (const child of content.content) {
+            if (containsMissingTextBlockStyle(child, textBlockStyles)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 function containsInvalidInlineStyleMarks(
     content: JSONContent,
     inlineStyles: TipTapInlineStyle[],
@@ -372,6 +398,8 @@ function IsTipTapContent(
         maxTextBlocks,
         allowedPlaceholderNames,
         listLevelMax,
+        textBlockStyles,
+        requireTextBlockStyle,
     }: {
         inlineStyles: TipTapInlineStyle[];
         linkBlock?: Block;
@@ -379,6 +407,8 @@ function IsTipTapContent(
         maxTextBlocks?: number;
         allowedPlaceholderNames?: string[];
         listLevelMax?: number;
+        textBlockStyles: TipTapTextBlockStyle[];
+        requireTextBlockStyle?: boolean;
     },
     validationOptions?: ValidationOptions,
 ) {
@@ -421,6 +451,11 @@ function IsTipTapContent(
                             if (depth > listLevelMax) {
                                 return false;
                             }
+                        }
+
+                        // Enforce requireTextBlockStyle: reject headings/paragraphs missing a style that applies to them
+                        if (requireTextBlockStyle && containsMissingTextBlockStyle(value as JSONContent, textBlockStyles)) {
+                            return false;
                         }
 
                         // Validate link mark data
@@ -515,12 +550,17 @@ export function createTipTapRichTextBlock(
         childBlocks: childBlocksConfig = {},
         maxTextBlocks,
         listLevelMax,
+        requireTextBlockStyle = false,
         migrateFromDraftJs = false,
     }: CreateTipTapRichTextBlockOptions = {},
     nameOrOptions: BlockFactoryNameOrOptions = "TipTapRichText",
 ): Block<TipTapRichTextBlockDataInterface, TipTapRichTextBlockInputInterface> {
     const blockName = typeof nameOrOptions === "string" ? nameOrOptions : nameOrOptions.name;
     const baseMigrate = typeof nameOrOptions !== "string" && nameOrOptions.migrate ? nameOrOptions.migrate : { migrations: [], version: 0 };
+
+    if (requireTextBlockStyle && textBlockStyles.length === 0) {
+        throw new Error("requireTextBlockStyle requires a non-empty textBlockStyles array");
+    }
 
     const hasLink = !!LinkBlock;
     const childBlocks: Record<string, Block> = Object.fromEntries(Object.entries(childBlocksConfig).map(([key, { block }]) => [key, block]));
@@ -624,6 +664,8 @@ export function createTipTapRichTextBlock(
             maxTextBlocks,
             allowedPlaceholderNames,
             listLevelMax,
+            textBlockStyles,
+            requireTextBlockStyle,
         })
         @BlockField({ type: "tipTapRichTextBlock", childBlocks })
         tipTapContent: JSONContent;


### PR DESCRIPTION
## Summary
- When `textBlockStyles` are configured on `createTipTapRichTextBlock`, the toolbar's style dropdown always offered an unstyled "Default" entry alongside the configured styles, even for setups where every heading/paragraph should always carry one of them.
- Add a `requireTextBlockStyle` option that removes that entry for text block types with at least one applicable style. The editor auto-assigns the first applicable style wherever one would otherwise be missing (toolbar changes, markdown input rules, keyboard shortcuts, pasted content), via a ProseMirror `appendTransaction` plugin so no path can leave a node unstyled. The API package rejects stored content missing a required style during validation, consistent with how `maxTextBlocks`/`listLevelMax` are already enforced server-side.
- Enabled the option on the demo's general-purpose rich text block as a usage example (not just a heading-only case).

Prompted by [PHSB2C-13678](https://vivid-planet.atlassian.net/browse/PHSB2C-13678): the TipTap-based Headline block always showed a "Default" style state that didn't exist in the previous Draft.js implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PHSB2C-13678]: https://vivid-planet.atlassian.net/browse/PHSB2C-13678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ