### PR TITLE
demo: Add table stress-test fixture pages

### DIFF
--- a/demo/api/src/db/fixtures/fixtures.command.ts
+++ b/demo/api/src/db/fixtures/fixtures.command.ts
@@ -24,12 +24,14 @@ import slugify from "slugify";
 
 import { DocumentGeneratorService } from "./generators/document-generator.service";
 import { DraftJsMigrationPageFixtureService } from "./generators/draft-js-migration-page-fixture.service";
+import { DraftJsTableStressTestPageFixtureService } from "./generators/draft-js-table-stress-test-page-fixture.service";
 import { FileUploadsFixtureService } from "./generators/file-uploads-fixture.service";
 import { ImageFixtureService } from "./generators/image-fixture.service";
 import { ManyImagesTestPageFixtureService } from "./generators/many-images-test-page-fixture.service";
 import { NewsFixtureService } from "./generators/news-fixture.service";
 import { ProductsFixtureService } from "./generators/products-fixture.service";
 import { RedirectsFixtureService } from "./generators/redirects-fixture.service";
+import { TipTapTableStressTestPageFixtureService } from "./generators/tip-tap-table-stress-test-page-fixture.service";
 import { VideoFixtureService } from "./generators/video-fixture.service";
 import { WelcomeEmailFixtureService } from "./generators/welcome-email-fixture.service";
 
@@ -69,6 +71,8 @@ export class FixturesCommand extends CommandRunner {
         private readonly videoFixtureService: VideoFixtureService,
         private readonly newsFixtureService: NewsFixtureService,
         private readonly draftJsMigrationPageFixtureService: DraftJsMigrationPageFixtureService,
+        private readonly draftJsTableStressTestPageFixtureService: DraftJsTableStressTestPageFixtureService,
+        private readonly tipTapTableStressTestPageFixtureService: TipTapTableStressTestPageFixtureService,
         private readonly welcomeEmailFixtureService: WelcomeEmailFixtureService,
     ) {
         super();
@@ -145,6 +149,10 @@ export class FixturesCommand extends CommandRunner {
         this.logger.log("Generate DraftJS Migration Demo Page...");
         await this.draftJsMigrationPageFixtureService.execute();
         this.logger.log("DraftJS Migration Demo Page created");
+
+        this.logger.log("Generate Table Stress Test Pages...");
+        await this.tipTapTableStressTestPageFixtureService.execute();
+        await this.draftJsTableStressTestPageFixtureService.execute();
 
         this.logger.log("Generate Lorem Ispum Fixtures...");
         const NUMBER_OF_DOMAINS_WITH_LORUM_IPSUM_CONTENT = 0; // Increase number to generate lorum ipsum fixtures

--- a/demo/api/src/db/fixtures/fixtures.module.ts
+++ b/demo/api/src/db/fixtures/fixtures.module.ts
@@ -54,6 +54,7 @@ import { TipTapRichTextBlockFixtureService } from "./generators/blocks/text-and-
 import { TipTapTableBlockFixtureService } from "./generators/blocks/text-and-content/tip-tap-table-block-fixture.service";
 import { DocumentGeneratorService } from "./generators/document-generator.service";
 import { DraftJsMigrationPageFixtureService } from "./generators/draft-js-migration-page-fixture.service";
+import { DraftJsTableStressTestPageFixtureService } from "./generators/draft-js-table-stress-test-page-fixture.service";
 import { FileUploadsFixtureService } from "./generators/file-uploads-fixture.service";
 import { ImageFileFixtureService } from "./generators/image-file-fixture.service";
 import { ImageFixtureService } from "./generators/image-fixture.service";
@@ -65,6 +66,7 @@ import { RedirectsFixtureService } from "./generators/redirects-fixture.service"
 import { SeoBlockFixtureService } from "./generators/seo-block-fixture.service";
 import { StageBlockFixtureService } from "./generators/stage-block-fixture.service";
 import { SvgImageFileFixtureService } from "./generators/svg-image-file-fixture.service";
+import { TipTapTableStressTestPageFixtureService } from "./generators/tip-tap-table-stress-test-page-fixture.service";
 import { VideoFixtureService } from "./generators/video-fixture.service";
 import { WelcomeEmailFixtureService } from "./generators/welcome-email-fixture.service";
 
@@ -91,6 +93,7 @@ import { WelcomeEmailFixtureService } from "./generators/welcome-email-fixture.s
         DamVideoBlockFixtureService,
         DocumentGeneratorService,
         DraftJsMigrationPageFixtureService,
+        DraftJsTableStressTestPageFixtureService,
         FileUploadsFixtureService,
         FullWidthImageBlockFixtureService,
         HeadingBlockFixtureService,
@@ -131,6 +134,7 @@ import { WelcomeEmailFixtureService } from "./generators/welcome-email-fixture.s
         TableBlockFixtureService,
         TipTapRichTextBlockFixtureService,
         TipTapTableBlockFixtureService,
+        TipTapTableStressTestPageFixtureService,
         WelcomeEmailFixtureService,
     ],
 })

--- a/demo/api/src/db/fixtures/generators/draft-js-table-stress-test-page-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/draft-js-table-stress-test-page-fixture.service.ts
@@ -1,0 +1,338 @@
+import { ExtractBlockInputFactoryProps, PageTreeNodeVisibility, PageTreeService } from "@dextinity/cms-api";
+import { EntityManager } from "@mikro-orm/postgresql";
+import { Injectable } from "@nestjs/common";
+import { LinkBlock } from "@src/common/blocks/link.block";
+import { RichTextBlock } from "@src/common/blocks/rich-text.block";
+import { TextAlignment } from "@src/common/blocks/standalone-rich-text.block";
+import { faker } from "@src/db/fixtures/faker";
+import { LinkBlockFixtureService } from "@src/db/fixtures/generators/blocks/navigation/link-block-fixture.service";
+import { PageContentBlock } from "@src/documents/pages/blocks/page-content.block";
+import { StageBlock } from "@src/documents/pages/blocks/stage.block";
+import { PageInput } from "@src/documents/pages/dto/page.input";
+import { Page } from "@src/documents/pages/entities/page.entity";
+import { PageTreeNodeCreateInput } from "@src/page-tree/dto/page-tree-node.input";
+import { PageTreeNodeScope } from "@src/page-tree/dto/page-tree-node-scope";
+import { PageTreeNodeCategory } from "@src/page-tree/page-tree-node-category";
+import { UserGroup } from "@src/user-groups/user-group";
+
+import { generateSeoBlock } from "./blocks/seo.generator";
+
+type RichTextInput = ExtractBlockInputFactoryProps<typeof RichTextBlock>;
+type LinkInput = ExtractBlockInputFactoryProps<typeof LinkBlock>;
+type DraftInlineStyle = "BOLD" | "ITALIC" | "SUB" | "SUP";
+type DraftBlockType =
+    | "paragraph-standard"
+    | "paragraph-small"
+    | "header-one"
+    | "header-two"
+    | "header-three"
+    | "unordered-list-item"
+    | "ordered-list-item";
+
+const COLUMN_COUNT = 12;
+const DATA_ROW_COUNT = 60;
+const LINK_POOL_SIZE = 8;
+const linkEntityKey = 0;
+
+const columnSizes = ["extraSmall", "small", "standard", "large", "extraLarge"];
+const headerTypes: DraftBlockType[] = ["header-one", "header-two", "header-three"];
+
+interface TextSegment {
+    text: string;
+    styles?: DraftInlineStyle[];
+    isLink?: boolean;
+}
+
+interface DraftBlock {
+    key: string;
+    text: string;
+    type: DraftBlockType;
+    depth: number;
+    inlineStyleRanges: { style: DraftInlineStyle; offset: number; length: number }[];
+    entityRanges: { offset: number; length: number; key: number }[];
+    data: Record<string, never>;
+}
+
+function createBlock(type: DraftBlockType, segments: TextSegment[]): DraftBlock {
+    let offset = 0;
+    let text = "";
+    const inlineStyleRanges: DraftBlock["inlineStyleRanges"] = [];
+    const entityRanges: DraftBlock["entityRanges"] = [];
+
+    for (const segment of segments) {
+        const length = segment.text.length;
+        for (const style of segment.styles ?? []) {
+            inlineStyleRanges.push({ style, offset, length });
+        }
+        if (segment.isLink) {
+            entityRanges.push({ offset, length, key: linkEntityKey });
+        }
+        text += segment.text;
+        offset += length;
+    }
+
+    return { key: faker.string.uuid(), text, type, depth: 0, inlineStyleRanges, entityRanges, data: {} };
+}
+
+function createRichText(blocks: DraftBlock[], link?: LinkInput): RichTextInput {
+    const entityMap: RichTextInput["draftContent"]["entityMap"] = link
+        ? { [linkEntityKey]: { type: "LINK", mutability: "MUTABLE", data: link } }
+        : {};
+
+    return { draftContent: { blocks, entityMap } };
+}
+
+const createPageBlock = <BlockType extends string, Props>(type: BlockType, props: Props) => ({
+    key: faker.string.uuid(),
+    visible: true,
+    type,
+    props,
+    userGroup: UserGroup.all,
+});
+
+const getHeaderType = (cellIndex: number): DraftBlockType => headerTypes[cellIndex % headerTypes.length];
+
+interface ContentMetrics {
+    cells: number;
+    blocks: number;
+    headers: number;
+    paragraphs: number;
+    listItems: number;
+    inlineStyleRanges: number;
+    links: number;
+    blockTypes: Set<string>;
+    inlineStyles: Set<string>;
+}
+
+function collectMetrics(cellContents: RichTextInput[]): ContentMetrics {
+    const metrics: ContentMetrics = {
+        cells: cellContents.length,
+        blocks: 0,
+        headers: 0,
+        paragraphs: 0,
+        listItems: 0,
+        inlineStyleRanges: 0,
+        links: 0,
+        blockTypes: new Set<string>(),
+        inlineStyles: new Set<string>(),
+    };
+
+    for (const cellContent of cellContents) {
+        metrics.links += Object.keys(cellContent.draftContent.entityMap).length;
+
+        for (const draftBlock of cellContent.draftContent.blocks) {
+            metrics.blocks++;
+            metrics.blockTypes.add(draftBlock.type);
+            metrics.inlineStyleRanges += draftBlock.inlineStyleRanges.length;
+            for (const range of draftBlock.inlineStyleRanges) {
+                metrics.inlineStyles.add(range.style);
+            }
+
+            if (draftBlock.type.startsWith("header-")) {
+                metrics.headers++;
+            } else if (draftBlock.type.endsWith("-list-item")) {
+                metrics.listItems++;
+            } else {
+                metrics.paragraphs++;
+            }
+        }
+    }
+
+    return metrics;
+}
+
+function createSummaryContent({
+    cellContents,
+    columnCount,
+    rowCount,
+}: {
+    cellContents: RichTextInput[];
+    columnCount: number;
+    rowCount: number;
+}): RichTextInput {
+    const metrics = collectMetrics(cellContents);
+    const sortedBlockTypes = Array.from(metrics.blockTypes).sort();
+    const sortedInlineStyles = Array.from(metrics.inlineStyles).sort();
+
+    const createMetricItem = (label: string, value: number | string): DraftBlock =>
+        createBlock("unordered-list-item", [{ text: `${label}: `, styles: ["BOLD"] }, { text: String(value) }]);
+
+    return createRichText([
+        createBlock("header-two", [{ text: "DraftJS table readonly stress test" }]),
+        createBlock("paragraph-standard", [
+            { text: "This page holds a single " },
+            { text: "Table", styles: ["BOLD"] },
+            { text: ` block. Every cell renders its own readonly DraftJS editor, so the admin has to mount ${metrics.cells} editors at once.` },
+        ]),
+        createMetricItem("Columns", columnCount),
+        createMetricItem("Rows (incl. header)", rowCount),
+        createMetricItem("Cells / readonly editors", metrics.cells),
+        createMetricItem("Draft blocks", metrics.blocks),
+        createMetricItem("Headers", metrics.headers),
+        createMetricItem("Paragraphs", metrics.paragraphs),
+        createMetricItem("List items", metrics.listItems),
+        createMetricItem("Inline style ranges", metrics.inlineStyleRanges),
+        createMetricItem("Link entities", metrics.links),
+        createMetricItem("Distinct block types", `${metrics.blockTypes.size} (${sortedBlockTypes.join(", ")})`),
+        createMetricItem("Distinct inline styles", `${metrics.inlineStyles.size} (${sortedInlineStyles.join(", ")})`),
+    ]);
+}
+
+function createHeaderCellContent(columnIndex: number): RichTextInput {
+    return createRichText([createBlock("paragraph-standard", [{ text: `Column ${columnIndex + 1}`, styles: ["BOLD"] }])]);
+}
+
+type CreateCellContent = (cell: { index: number; link: LinkInput }) => RichTextInput;
+
+const cellContentVariants: CreateCellContent[] = [
+    ({ index }) =>
+        createRichText([
+            createBlock(getHeaderType(index), [{ text: faker.commerce.productName() }]),
+            createBlock("paragraph-standard", [
+                { text: `${faker.lorem.sentence()} ` },
+                { text: faker.lorem.words(2), styles: ["BOLD"] },
+                { text: " " },
+                { text: faker.lorem.words(2), styles: ["ITALIC"] },
+            ]),
+        ]),
+    ({ link }) =>
+        createRichText(
+            [
+                createBlock("paragraph-standard", [
+                    { text: "bold ", styles: ["BOLD"] },
+                    { text: "italic ", styles: ["ITALIC"] },
+                    { text: "bold-italic ", styles: ["BOLD", "ITALIC"] },
+                    { text: "H" },
+                    { text: "2", styles: ["SUB"] },
+                    { text: "O, E=mc" },
+                    { text: "2", styles: ["SUP"] },
+                    { text: " " },
+                    { text: faker.lorem.words(2), isLink: true },
+                ]),
+            ],
+            link,
+        ),
+    () =>
+        createRichText([
+            createBlock("paragraph-small", [{ text: `${faker.lorem.words(3)} ` }, { text: faker.lorem.words(2), styles: ["BOLD", "ITALIC"] }]),
+        ]),
+    ({ link }) =>
+        createRichText(
+            [
+                createBlock("unordered-list-item", [{ text: faker.lorem.words(3), styles: ["BOLD"] }]),
+                createBlock("unordered-list-item", [{ text: faker.lorem.words(3), styles: ["ITALIC"] }]),
+                createBlock("unordered-list-item", [{ text: `${faker.lorem.words(2)} ` }, { text: "link", isLink: true }]),
+            ],
+            link,
+        ),
+    () =>
+        createRichText([
+            createBlock("ordered-list-item", [{ text: faker.lorem.words(3) }]),
+            createBlock("ordered-list-item", [{ text: faker.lorem.words(2), styles: ["ITALIC"] }]),
+            createBlock("ordered-list-item", [{ text: faker.lorem.words(3), styles: ["BOLD"] }]),
+        ]),
+    ({ link }) =>
+        createRichText(
+            [
+                createBlock("paragraph-standard", [{ text: faker.company.catchPhrase() }]),
+                createBlock("paragraph-small", [{ text: `${faker.lorem.sentence()} ` }, { text: "read more", isLink: true }]),
+            ],
+            link,
+        ),
+    ({ index }) =>
+        createRichText([
+            createBlock(getHeaderType(index), [{ text: faker.commerce.department() }]),
+            createBlock("paragraph-standard", [{ text: faker.lorem.sentence() }]),
+            createBlock("unordered-list-item", [{ text: faker.lorem.words(2) }]),
+            createBlock("unordered-list-item", [{ text: faker.lorem.words(3), styles: ["BOLD"] }]),
+        ]),
+    () =>
+        createRichText([
+            createBlock("paragraph-small", [{ text: "formula a" }, { text: "n", styles: ["SUB"] }, { text: " + x" }, { text: "2", styles: ["SUP"] }]),
+        ]),
+    () =>
+        createRichText([
+            createBlock("paragraph-standard", [{ text: faker.lorem.sentence() }]),
+            createBlock("paragraph-small", [{ text: faker.lorem.sentence() }]),
+            createBlock("paragraph-standard", [{ text: faker.lorem.words(3), styles: ["ITALIC"] }]),
+        ]),
+];
+
+function createCellContent(index: number, links: LinkInput[]): RichTextInput {
+    const variant = cellContentVariants[index % cellContentVariants.length];
+    return variant({ index, link: links[index % links.length] });
+}
+
+@Injectable()
+export class DraftJsTableStressTestPageFixtureService {
+    constructor(
+        private readonly entityManager: EntityManager,
+        private readonly pageTreeService: PageTreeService,
+        private readonly linkBlockFixtureService: LinkBlockFixtureService,
+    ) {}
+
+    async execute(): Promise<void> {
+        const documentId = "b8e4d2c3-1a5f-4d3b-9f2e-3e4d5c6b7a81";
+        const scope: PageTreeNodeScope = { domain: "main", language: "en" };
+
+        const createNodeInput: PageTreeNodeCreateInput = {
+            name: "Table Stresstest (DraftJS)",
+            slug: "table-stresstest-draftjs",
+            attachedDocument: { id: documentId, type: "Page" },
+            userGroup: UserGroup.all,
+        };
+
+        const node = await this.pageTreeService.createNode(createNodeInput, PageTreeNodeCategory.mainNavigation, scope);
+        await this.pageTreeService.updateNodeVisibility(node.id, PageTreeNodeVisibility.Published);
+
+        const links = await Promise.all(Array.from({ length: LINK_POOL_SIZE }, () => this.linkBlockFixtureService.generateBlockInput()));
+
+        const columns = Array.from({ length: COLUMN_COUNT }, (_, columnIndex) => ({
+            id: `column-${columnIndex}`,
+            size: columnSizes[columnIndex % columnSizes.length],
+            highlighted: columnIndex % 4 === 0,
+        }));
+
+        const headerRow = {
+            id: faker.string.uuid(),
+            highlighted: true,
+            cellValues: columns.map((column, columnIndex) => ({ columnId: column.id, value: createHeaderCellContent(columnIndex) })),
+        };
+
+        const dataRows = Array.from({ length: DATA_ROW_COUNT }, (_, rowIndex) => ({
+            id: faker.string.uuid(),
+            highlighted: rowIndex % 5 === 0,
+            cellValues: columns.map((column, columnIndex) => ({
+                columnId: column.id,
+                value: createCellContent(rowIndex * COLUMN_COUNT + columnIndex, links),
+            })),
+        }));
+
+        const rows = [headerRow, ...dataRows];
+        const cellContents = rows.flatMap((row) => row.cellValues.map((cellValue) => cellValue.value));
+
+        const pageInput = new PageInput();
+        pageInput.seo = generateSeoBlock();
+        pageInput.content = PageContentBlock.blockInputFactory({
+            blocks: [
+                createPageBlock("richtext", {
+                    richText: createSummaryContent({ cellContents, columnCount: columns.length, rowCount: rows.length }),
+                    textAlignment: TextAlignment.left,
+                }),
+                createPageBlock("table", { columns, rows }),
+            ],
+        });
+        pageInput.stage = StageBlock.blockInputFactory({ blocks: [] });
+
+        await this.entityManager.persistAndFlush(
+            this.entityManager.create(Page, {
+                id: documentId,
+                content: pageInput.content.transformToBlockData(),
+                seo: pageInput.seo.transformToBlockData(),
+                stage: pageInput.stage.transformToBlockData(),
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            }),
+        );
+    }
+}

--- a/demo/api/src/db/fixtures/generators/tip-tap-table-stress-test-page-fixture.service.ts
+++ b/demo/api/src/db/fixtures/generators/tip-tap-table-stress-test-page-fixture.service.ts
@@ -1,0 +1,375 @@
+import { ExtractBlockInputFactoryProps, PageTreeNodeVisibility, PageTreeService, TipTapRichTextBlockContent } from "@dextinity/cms-api";
+import { EntityManager } from "@mikro-orm/postgresql";
+import { Injectable } from "@nestjs/common";
+import { LinkBlock } from "@src/common/blocks/link.block";
+import { TipTapRichTextBlock } from "@src/common/blocks/tip-tap-rich-text.block";
+import { faker } from "@src/db/fixtures/faker";
+import { LinkBlockFixtureService } from "@src/db/fixtures/generators/blocks/navigation/link-block-fixture.service";
+import { PageContentBlock } from "@src/documents/pages/blocks/page-content.block";
+import { StageBlock } from "@src/documents/pages/blocks/stage.block";
+import { PageInput } from "@src/documents/pages/dto/page.input";
+import { Page } from "@src/documents/pages/entities/page.entity";
+import { PageTreeNodeCreateInput } from "@src/page-tree/dto/page-tree-node.input";
+import { PageTreeNodeScope } from "@src/page-tree/dto/page-tree-node-scope";
+import { PageTreeNodeCategory } from "@src/page-tree/page-tree-node-category";
+import { UserGroup } from "@src/user-groups/user-group";
+
+import { generateSeoBlock } from "./blocks/seo.generator";
+
+type RichTextInput = ExtractBlockInputFactoryProps<typeof TipTapRichTextBlock>;
+type LinkInput = ExtractBlockInputFactoryProps<typeof LinkBlock>;
+type TipTapNode = TipTapRichTextBlockContent;
+type TipTapMark = NonNullable<TipTapNode["marks"]>[number];
+type TextBlockStyle = "paragraph300" | "paragraph200" | "eyebrow600" | "eyebrow550" | "eyebrow500" | "eyebrow450";
+type ListStyle = "list300" | "list200";
+
+const COLUMN_COUNT = 12;
+const DATA_ROW_COUNT = 60;
+const LINK_POOL_SIZE = 8;
+const HEADING_LEVEL_COUNT = 6;
+
+const columnSizes = ["extraSmall", "small", "standard", "large", "extraLarge"];
+const eyebrowStyles: TextBlockStyle[] = ["eyebrow600", "eyebrow550", "eyebrow500", "eyebrow450"];
+
+const bold: TipTapMark = { type: "bold" };
+const italic: TipTapMark = { type: "italic" };
+const strike: TipTapMark = { type: "strike" };
+const subscript: TipTapMark = { type: "subscript" };
+const superscript: TipTapMark = { type: "superscript" };
+const highlight: TipTapMark = { type: "inlineStyle", attrs: { type: "highlight" } };
+const tag: TipTapMark = { type: "inlineStyle", attrs: { type: "tag" } };
+const createLinkMark = (data: LinkInput): TipTapMark => ({ type: "link", attrs: { data } });
+
+const nonBreakingSpace: TipTapNode = { type: "nonBreakingSpace" };
+const softHyphen: TipTapNode = { type: "softHyphen" };
+
+const createText = (value: string, marks?: TipTapMark[]): TipTapNode => ({ type: "text", text: value, ...(marks?.length ? { marks } : {}) });
+
+const createParagraph = (content: TipTapNode[], textBlockStyle?: TextBlockStyle | ListStyle): TipTapNode => ({
+    type: "paragraph",
+    ...(textBlockStyle ? { attrs: { textBlockStyle } } : {}),
+    content,
+});
+
+const createHeading = (level: number, content: TipTapNode[]): TipTapNode => ({ type: "heading", attrs: { level }, content });
+
+const createListItem = (content: TipTapNode[], listStyle: ListStyle): TipTapNode => ({
+    type: "listItem",
+    content: [createParagraph(content, listStyle)],
+});
+
+const createBulletList = (items: TipTapNode[][], listStyle: ListStyle): TipTapNode => ({
+    type: "bulletList",
+    content: items.map((item) => createListItem(item, listStyle)),
+});
+
+const createOrderedList = (items: TipTapNode[][], listStyle: ListStyle): TipTapNode => ({
+    type: "orderedList",
+    content: items.map((item) => createListItem(item, listStyle)),
+});
+
+const createDocument = (content: TipTapNode[]): RichTextInput => ({ tipTapContent: { type: "doc", content } });
+
+const createPageBlock = <BlockType extends string, Props>(type: BlockType, props: Props) => ({
+    key: faker.string.uuid(),
+    visible: true,
+    type,
+    props,
+    userGroup: UserGroup.all,
+});
+
+const getHeadingLevel = (cellIndex: number): number => (cellIndex % HEADING_LEVEL_COUNT) + 1;
+
+const getEyebrowStyle = (cellIndex: number): TextBlockStyle => eyebrowStyles[cellIndex % eyebrowStyles.length];
+
+interface ContentMetrics {
+    cells: number;
+    paragraphs: number;
+    headings: number;
+    lists: number;
+    listItems: number;
+    textNodes: number;
+    markApplications: number;
+    textBlockStyles: Set<string>;
+    marks: Set<string>;
+}
+
+function tallyNode(node: TipTapNode, metrics: ContentMetrics): void {
+    switch (node.type) {
+        case "paragraph":
+            metrics.paragraphs++;
+            break;
+        case "heading":
+            metrics.headings++;
+            break;
+        case "bulletList":
+        case "orderedList":
+            metrics.lists++;
+            break;
+        case "listItem":
+            metrics.listItems++;
+            break;
+        case "text":
+            metrics.textNodes++;
+            break;
+    }
+
+    const textBlockStyle = node.attrs?.textBlockStyle;
+    if (typeof textBlockStyle === "string") {
+        metrics.textBlockStyles.add(textBlockStyle);
+    }
+
+    for (const mark of node.marks ?? []) {
+        metrics.markApplications++;
+        const inlineStyleType = mark.attrs?.type;
+        metrics.marks.add(mark.type === "inlineStyle" && typeof inlineStyleType === "string" ? `inlineStyle:${inlineStyleType}` : mark.type);
+    }
+
+    for (const child of node.content ?? []) {
+        tallyNode(child, metrics);
+    }
+}
+
+function collectMetrics(cellContents: RichTextInput[]): ContentMetrics {
+    const metrics: ContentMetrics = {
+        cells: cellContents.length,
+        paragraphs: 0,
+        headings: 0,
+        lists: 0,
+        listItems: 0,
+        textNodes: 0,
+        markApplications: 0,
+        textBlockStyles: new Set<string>(),
+        marks: new Set<string>(),
+    };
+
+    for (const cellContent of cellContents) {
+        tallyNode(cellContent.tipTapContent, metrics);
+    }
+
+    return metrics;
+}
+
+function createSummaryContent({
+    cellContents,
+    columnCount,
+    rowCount,
+}: {
+    cellContents: RichTextInput[];
+    columnCount: number;
+    rowCount: number;
+}): RichTextInput {
+    const metrics = collectMetrics(cellContents);
+    const sortedStyles = Array.from(metrics.textBlockStyles).sort();
+    const sortedMarks = Array.from(metrics.marks).sort();
+
+    const createMetricItem = (label: string, value: number | string): TipTapNode[] => [createText(`${label}: `, [bold]), createText(String(value))];
+
+    return createDocument([
+        createHeading(2, [createText("TipTap table readonly stress test")]),
+        createParagraph(
+            [
+                createText("This page holds a single "),
+                createText("Table (TipTap)", [bold]),
+                createText(" block. Every cell renders its own readonly TipTap editor, so the admin has to mount "),
+                createText(`${metrics.cells} editors`, [highlight]),
+                createText(" at once."),
+            ],
+            "paragraph300",
+        ),
+        createBulletList(
+            [
+                createMetricItem("Columns", columnCount),
+                createMetricItem("Rows (incl. header)", rowCount),
+                createMetricItem("Cells / readonly editors", metrics.cells),
+                createMetricItem("Paragraphs", metrics.paragraphs),
+                createMetricItem("Headings", metrics.headings),
+                createMetricItem("Lists", metrics.lists),
+                createMetricItem("List items", metrics.listItems),
+                createMetricItem("Text nodes", metrics.textNodes),
+                createMetricItem("Mark applications", metrics.markApplications),
+                createMetricItem("Distinct text block styles", `${metrics.textBlockStyles.size} (${sortedStyles.join(", ")})`),
+                createMetricItem("Distinct marks / inline styles", `${metrics.marks.size} (${sortedMarks.join(", ")})`),
+            ],
+            "list300",
+        ),
+    ]);
+}
+
+function createHeaderCellContent(columnIndex: number): RichTextInput {
+    return createDocument([createParagraph([createText(`Column ${columnIndex + 1} `, [bold]), createText("★", [highlight])], "eyebrow600")]);
+}
+
+type CreateCellContent = (cell: { index: number; link: LinkInput }) => RichTextInput;
+
+const cellContentVariants: CreateCellContent[] = [
+    ({ index }) =>
+        createDocument([
+            createHeading(getHeadingLevel(index), [createText(faker.commerce.productName())]),
+            createParagraph(
+                [
+                    createText(`${faker.lorem.sentence()} `),
+                    createText(faker.lorem.words(2), [bold]),
+                    createText(" "),
+                    createText(faker.lorem.words(2), [italic]),
+                ],
+                "paragraph300",
+            ),
+        ]),
+    ({ link: currentLink }) =>
+        createDocument([
+            createParagraph(
+                [
+                    createText("bold ", [bold]),
+                    createText("italic ", [italic]),
+                    createText("strike ", [strike]),
+                    createText("H"),
+                    createText("2", [subscript]),
+                    createText("O, E=mc"),
+                    createText("2", [superscript]),
+                    createText(" "),
+                    createText("highlighted ", [highlight]),
+                    createText(faker.lorem.words(2), [createLinkMark(currentLink)]),
+                    createText(" "),
+                    nonBreakingSpace,
+                    createText("no"),
+                    softHyphen,
+                    createText("break"),
+                ],
+                "paragraph300",
+            ),
+        ]),
+    () =>
+        createDocument([
+            createParagraph(
+                [createText(`${faker.lorem.words(3)} `), createText("tagged", [tag]), createText(" and "), createText("highlighted", [highlight])],
+                "paragraph200",
+            ),
+        ]),
+    ({ link: currentLink }) =>
+        createDocument([
+            createBulletList(
+                [
+                    [createText(faker.lorem.words(3), [bold])],
+                    [createText(faker.lorem.words(3), [italic])],
+                    [createText(`${faker.lorem.words(2)} `), createText("link", [createLinkMark(currentLink)])],
+                ],
+                "list300",
+            ),
+        ]),
+    () =>
+        createDocument([
+            createOrderedList(
+                [[createText(faker.lorem.words(3))], [createText(faker.lorem.words(2), [highlight])], [createText(faker.lorem.words(3), [strike])]],
+                "list200",
+            ),
+        ]),
+    ({ index, link: currentLink }) =>
+        createDocument([
+            createParagraph([createText(faker.company.catchPhrase())], getEyebrowStyle(index)),
+            createParagraph([createText(`${faker.lorem.sentence()} `), createText("read more", [createLinkMark(currentLink)])], "paragraph200"),
+        ]),
+    ({ index }) =>
+        createDocument([
+            createHeading(getHeadingLevel(index), [createText(faker.commerce.department())]),
+            createParagraph([createText(faker.lorem.sentence())], "paragraph300"),
+            createBulletList([[createText(faker.lorem.words(2))], [createText(faker.lorem.words(3), [bold])]], "list300"),
+        ]),
+    () =>
+        createDocument([
+            createParagraph(
+                [
+                    createText("formula a"),
+                    createText("n", [subscript]),
+                    createText(" + x"),
+                    createText("2", [superscript]),
+                    createText(" "),
+                    nonBreakingSpace,
+                    createText(faker.lorem.words(2), [highlight]),
+                ],
+                "paragraph200",
+            ),
+        ]),
+    ({ index }) =>
+        createDocument([
+            createParagraph([createText(faker.lorem.sentence())], "paragraph300"),
+            createParagraph([createText(faker.lorem.sentence())], "paragraph200"),
+            createParagraph([createText(faker.lorem.words(3))], getEyebrowStyle(index)),
+        ]),
+];
+
+function createCellContent(index: number, links: LinkInput[]): RichTextInput {
+    const variant = cellContentVariants[index % cellContentVariants.length];
+    return variant({ index, link: links[index % links.length] });
+}
+
+@Injectable()
+export class TipTapTableStressTestPageFixtureService {
+    constructor(
+        private readonly entityManager: EntityManager,
+        private readonly pageTreeService: PageTreeService,
+        private readonly linkBlockFixtureService: LinkBlockFixtureService,
+    ) {}
+
+    async execute(): Promise<void> {
+        const documentId = "a7f3c1d2-9b4e-4c2a-8e1f-2d3c4b5a6f70";
+        const scope: PageTreeNodeScope = { domain: "main", language: "en" };
+
+        const createNodeInput: PageTreeNodeCreateInput = {
+            name: "Table Stresstest (TipTap)",
+            slug: "table-stresstest-tiptap",
+            attachedDocument: { id: documentId, type: "Page" },
+            userGroup: UserGroup.all,
+        };
+
+        const node = await this.pageTreeService.createNode(createNodeInput, PageTreeNodeCategory.mainNavigation, scope);
+        await this.pageTreeService.updateNodeVisibility(node.id, PageTreeNodeVisibility.Published);
+
+        const links = await Promise.all(Array.from({ length: LINK_POOL_SIZE }, () => this.linkBlockFixtureService.generateBlockInput()));
+
+        const columns = Array.from({ length: COLUMN_COUNT }, (_, columnIndex) => ({
+            id: `column-${columnIndex}`,
+            size: columnSizes[columnIndex % columnSizes.length],
+            highlighted: columnIndex % 4 === 0,
+        }));
+
+        const headerRow = {
+            id: faker.string.uuid(),
+            highlighted: true,
+            cellValues: columns.map((column, columnIndex) => ({ columnId: column.id, value: createHeaderCellContent(columnIndex) })),
+        };
+
+        const dataRows = Array.from({ length: DATA_ROW_COUNT }, (_, rowIndex) => ({
+            id: faker.string.uuid(),
+            highlighted: rowIndex % 5 === 0,
+            cellValues: columns.map((column, columnIndex) => ({
+                columnId: column.id,
+                value: createCellContent(rowIndex * COLUMN_COUNT + columnIndex, links),
+            })),
+        }));
+
+        const rows = [headerRow, ...dataRows];
+        const cellContents = rows.flatMap((row) => row.cellValues.map((cellValue) => cellValue.value));
+
+        const pageInput = new PageInput();
+        pageInput.seo = generateSeoBlock();
+        pageInput.content = PageContentBlock.blockInputFactory({
+            blocks: [
+                createPageBlock("tipTapRichText", createSummaryContent({ cellContents, columnCount: columns.length, rowCount: rows.length })),
+                createPageBlock("tipTapTable", { columns, rows }),
+            ],
+        });
+        pageInput.stage = StageBlock.blockInputFactory({ blocks: [] });
+
+        await this.entityManager.persistAndFlush(
+            this.entityManager.create(Page, {
+                id: documentId,
+                content: pageInput.content.transformToBlockData(),
+                seo: pageInput.seo.transformToBlockData(),
+                stage: pageInput.stage.transformToBlockData(),
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            }),
+        );
+    }
+}


### PR DESCRIPTION
One page per rich-text editor, TipTap and DraftJS, each with a table of 12 columns and 60 data rows plus a header row, whose cells cycle through the block types and styles that editor supports. Either page mounts one readonly editor per cell, 732 in all.

---

Task: https://vivid-planet.atlassian.net/browse/COM-3096