### PR TITLE
Stop buffering form file uploads in the site's memory

### DIFF
--- a/demo/site/src/app/[visibility]/[domain]/[language]/api/file-upload/route.tsx
+++ b/demo/site/src/app/[visibility]/[domain]/[language]/api/file-upload/route.tsx
@@ -3,27 +3,56 @@ import { assessRecaptchaToken } from "@src/util/recaptcha/assessRecaptchaToken";
 import { getSiteConfigForDomain } from "@src/util/siteConfig";
 import { type NextRequest, NextResponse } from "next/server";
 
+// The multipart envelope (boundaries and part headers) adds a few hundred bytes on top of the file itself.
+const multipartOverheadBytes = 4 * 1024;
+const maxRequestSizeBytes = maxFileSizeBytes + multipartOverheadBytes;
+
+// Counts the bytes flowing through and aborts as soon as the limit is exceeded. Keeps the hard size limit
+// in place without ever holding the upload in memory, even when Content-Length is missing or forged.
+const createSizeLimitedStream = (maxSizeBytes: number, onLimitExceeded: () => void) => {
+    let bytesRead = 0;
+
+    return new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+            bytesRead += chunk.byteLength;
+
+            if (bytesRead > maxSizeBytes) {
+                onLimitExceeded();
+                controller.error(new Error("File exceeds the maximum size"));
+                return;
+            }
+
+            controller.enqueue(chunk);
+        },
+    });
+};
+
 export async function POST(request: NextRequest, context: RouteContext<"/[visibility]/[domain]/[language]/api/file-upload">) {
     const { domain } = await context.params;
-    const formData = await request.formData();
 
-    const file = formData.get("file");
-    const recaptchaToken = formData.get("recaptchaToken");
-
-    if (!(file instanceof File)) {
-        return NextResponse.json({ message: "Missing file" }, { status: 400 });
+    // Reject oversized requests before touching the body. Content-Length may be missing or forged, so the
+    // byte counter on the stream below is the binding second barrier.
+    if (Number(request.headers.get("content-length")) > maxRequestSizeBytes) {
+        return NextResponse.json({ message: "File too large" }, { status: 413 });
     }
 
-    if (typeof recaptchaToken !== "string") {
+    // The reCAPTCHA token and the file type travel in headers instead of the multipart body, so an invalid
+    // request is rejected without reading a single byte of the upload.
+    const recaptchaToken = request.headers.get("x-recaptcha-token");
+    const fileType = request.headers.get("x-file-type");
+
+    if (!recaptchaToken) {
         return NextResponse.json({ message: "Missing recaptchaToken" }, { status: 400 });
     }
 
-    if (!acceptedFileTypes.includes(file.type)) {
-        return NextResponse.json({ message: `File type not allowed: ${file.name}` }, { status: 400 });
+    if (!fileType || !acceptedFileTypes.includes(fileType)) {
+        return NextResponse.json({ message: "File type not allowed" }, { status: 415 });
     }
 
-    if (file.size > maxFileSizeBytes) {
-        return NextResponse.json({ message: `File too large: ${file.name}` }, { status: 400 });
+    const requestBody = request.body;
+
+    if (requestBody === null) {
+        return NextResponse.json({ message: "Missing file" }, { status: 400 });
     }
 
     const siteConfig = getSiteConfigForDomain(domain);
@@ -43,23 +72,46 @@ export async function POST(request: NextRequest, context: RouteContext<"/[visibi
         return NextResponse.json({ message: "Something went wrong processing the file upload" }, { status: 500 });
     }
 
-    try {
-        const uploadBody = new FormData();
-        uploadBody.append("file", file, file.name);
+    let sizeLimitExceeded = false;
 
-        const uploadResponse = await fetch(`${process.env.API_URL_INTERNAL}/file-uploads/upload`, {
+    try {
+        // The body is piped through to the API untouched instead of being parsed into memory. The original
+        // content type carries the multipart boundary, so the API can separate the fields itself.
+        const body = requestBody.pipeThrough(
+            createSizeLimitedStream(maxRequestSizeBytes, () => {
+                sizeLimitExceeded = true;
+            }),
+        );
+
+        // duplex is required when streaming a request body, but is not part of the fetch types yet.
+        const requestInit: RequestInit & { duplex: "half" } = {
             method: "POST",
-            body: uploadBody,
-        });
+            headers: { "content-type": request.headers.get("content-type") ?? "" },
+            body,
+            duplex: "half",
+        };
+
+        const uploadResponse = await fetch(`${process.env.API_URL_INTERNAL}/file-uploads/upload`, requestInit);
 
         if (!uploadResponse.ok) {
-            console.error(`File upload failed for ${file.name}: ${uploadResponse.status} ${await uploadResponse.text()}`);
-            return NextResponse.json({ message: `File upload failed for ${file.name}` }, { status: 502 });
+            console.error(`File upload failed: ${uploadResponse.status} ${await uploadResponse.text()}`);
+
+            // The API validates size and mime type against the file contents itself. Pass its rejections
+            // through, so the user learns that the file was rejected instead of seeing a generic error.
+            if (uploadResponse.status >= 400 && uploadResponse.status < 500) {
+                return NextResponse.json({ message: "File was rejected" }, { status: uploadResponse.status });
+            }
+
+            return NextResponse.json({ message: "File upload failed" }, { status: 502 });
         }
 
         const uploaded = (await uploadResponse.json()) as { id: string };
         return NextResponse.json({ id: uploaded.id }, { status: 200 });
     } catch (e) {
+        if (sizeLimitExceeded) {
+            return NextResponse.json({ message: "File too large" }, { status: 413 });
+        }
+
         console.error(e);
         return NextResponse.json({ message: "Something went wrong processing the file upload" }, { status: 500 });
     }

--- a/demo/site/src/common/components/form/FileUploadField.tsx
+++ b/demo/site/src/common/components/form/FileUploadField.tsx
@@ -88,10 +88,15 @@ export const FileUploadField = <TFieldValues extends FieldValues>({
 
         const body = new FormData();
         body.append("file", file, file.name);
-        body.append("recaptchaToken", recaptchaToken);
 
+        // The reCAPTCHA token and the file type go into headers instead of the body, so the route can reject
+        // an invalid upload before reading any of the file.
         const response = await fetch(`/${language}/api/file-upload`, {
             method: "POST",
+            headers: {
+                "x-recaptcha-token": recaptchaToken,
+                "x-file-type": file.type,
+            },
             body,
         });
 

--- a/docs/docs/4-guides/6-implementing-recaptcha-for-a-form/index.md
+++ b/docs/docs/4-guides/6-implementing-recaptcha-for-a-form/index.md
@@ -300,3 +300,98 @@ export async function POST(
     // Process the form submission...
 }
 ```
+
+## Protecting file uploads
+
+A file upload cannot follow the pattern above. Reading the reCAPTCHA token from the request body means calling
+`request.formData()`, which buffers the entire file in the site's heap before the token is even looked at. Every
+request — including those from bots with an invalid token — then costs as much memory as the file is large, which
+makes the route an easy way to exhaust the site's memory.
+
+Send the reCAPTCHA token in a request header instead, so the route can reject the request before reading the body:
+
+```tsx title="src/common/components/form/FileUploadField.tsx"
+const recaptchaToken = await getRecaptchaToken("file_upload", recaptchaSiteKey);
+
+const body = new FormData();
+body.append("file", file, file.name);
+
+const response = await fetch(`/${language}/api/file-upload`, {
+    method: "POST",
+    headers: {
+        "x-recaptcha-token": recaptchaToken,
+        "x-file-type": file.type,
+    },
+    body,
+});
+```
+
+In the route, validate everything that is available in the headers first, then pipe the body straight through to the
+API instead of parsing it. Because `Content-Length` may be missing or forged, count the bytes flowing through the
+stream as a second barrier:
+
+```ts title="src/app/.../api/file-upload/route.ts"
+// The multipart envelope (boundaries and part headers) adds a few hundred bytes on top of the file itself.
+const multipartOverheadBytes = 4 * 1024;
+const maxRequestSizeBytes = maxFileSizeBytes + multipartOverheadBytes;
+
+const createSizeLimitedStream = (maxSizeBytes: number, onLimitExceeded: () => void) => {
+    let bytesRead = 0;
+
+    return new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+            bytesRead += chunk.byteLength;
+
+            if (bytesRead > maxSizeBytes) {
+                onLimitExceeded();
+                controller.error(new Error("File exceeds the maximum size"));
+                return;
+            }
+
+            controller.enqueue(chunk);
+        },
+    });
+};
+
+export async function POST(
+    request: NextRequest,
+    context: RouteContext<"/[visibility]/[domain]/[language]/api/file-upload">,
+) {
+    if (Number(request.headers.get("content-length")) > maxRequestSizeBytes) {
+        return NextResponse.json({ message: "File too large" }, { status: 413 });
+    }
+
+    const recaptchaToken = request.headers.get("x-recaptcha-token");
+    // Validate the token, the file type and the presence of the body before touching the upload...
+
+    let sizeLimitExceeded = false;
+
+    const body = requestBody.pipeThrough(
+        createSizeLimitedStream(maxRequestSizeBytes, () => {
+            sizeLimitExceeded = true;
+        }),
+    );
+
+    // duplex is required when streaming a request body, but is not part of the fetch types yet.
+    const requestInit: RequestInit & { duplex: "half" } = {
+        method: "POST",
+        // The original content type carries the multipart boundary, so the API can separate the fields itself.
+        headers: { "content-type": request.headers.get("content-type") ?? "" },
+        body,
+        duplex: "half",
+    };
+
+    const uploadResponse = await fetch(
+        `${process.env.API_URL_INTERNAL}/file-uploads/upload`,
+        requestInit,
+    );
+
+    // Handle the response, and turn a rejected stream into a 413 when sizeLimitExceeded is set...
+}
+```
+
+The route no longer sees the parsed file, so it cannot validate the file's contents. That validation belongs to the
+API anyway: `FileUploadsModule` checks the size and the mime type of the uploaded file. Pass its `4xx` rejections
+through to the user, so a rejected file does not surface as a generic error.
+
+See `FileUploadField` and the `api/file-upload` route in the demo site for a full implementation.


### PR DESCRIPTION
## Problem

The demo site's file upload route reads the reCAPTCHA token from the multipart body. Getting to it requires `request.formData()`, which buffers the entire file in the site's heap — before the token has been looked at. Every request therefore costs as much memory as the file is large, whether or not it carries a valid token, and concurrent requests add up. A handful of parallel uploads with a bogus token is enough to push the site into an out-of-memory restart, which makes the route the cheapest way to take the site down.

## Cause

The token travelled in the same multipart body as the file, so the route could not check it without parsing the body first. Handing the file on to the API then cost a second copy, because the parsed `File` was re-encoded into a fresh `FormData`.

## Fix

- The client sends the reCAPTCHA token and the file type as `x-recaptcha-token` and `x-file-type` headers, so the route rejects an invalid request before reading a single byte of it.
- The route pipes the request body straight through to the API instead of parsing it, forwarding the original `content-type` so the API can separate the multipart fields itself.
- The size limit is enforced twice: a `content-length` pre-check, plus a byte counter on the stream that aborts the upload mid-flight. `Content-Length` may be missing or forged, so the counter is the binding barrier.
- Validating the file's contents stays with the API, which checks size and mime type against the stored file. Its `4xx` rejections are passed through, so a rejected file does not surface as a generic error.

The reCAPTCHA guide gains a section on this, since a file upload cannot put the token in the request body the way the guide's JSON forms do.

## Decisions

- **The file type is validated from a header instead of from the parsed multipart part.** Streaming means the route never sees the parsed file, so its accept list would otherwise become a client-side hint only. A declared type in a header is exactly as trustworthy as the part's `Content-Type` was — the client sets both — so no strength is lost and the rejection now happens before the body is read. The alternative, dropping the check and relying on the API alone, would have widened what the site accepts: the API's accepted mime types are a superset of the site's.
- **The stream is capped at the site's limit plus a 4 KB multipart allowance, not at the file size exactly.** Without parsing the body, the envelope's bytes cannot be told apart from the file's, so a file can exceed the limit by up to that allowance before the counter trips. The API's own limit remains the exact barrier.
- **Passing the body through means the API now receives whatever multipart fields the client sends.** Rebuilding the body used to strip everything but the file, including `FileUploadBody`'s `expiresIn`, which overrides the configured retention. The demo's upload endpoint is public, so this is not a new capability there — but a project that guards the endpoint should validate `expiresIn` on the API side rather than rely on the site dropping it.

## Verification

Checked against a `multer` stand-in for the API's upload endpoint, configured like `FileUploadsFileInterceptor` (same disk storage, size limit and mime filter):

- a valid file arrives byte-identical, with its filename (umlauts included) and mime type intact
- an invalid token yields `403` and the API never sees the request
- a missing token and a disallowed mime type short-circuit before the reCAPTCHA assessment runs
- an oversized `content-length` and a chunked request with no `content-length` at all both end in `413`, and the aborted upload is not stored
- an API `4xx` reaches the client as a rejection rather than a generic error

Memory: 12 concurrent 8 MB uploads with lazily streamed bodies peak at ~230 MB of heap+external on the old route against ~87 MB on the new one. The remainder on the new route is in-flight buffering between the two sockets, not a copy of the file, and it does not grow with the file size the way the old route's did.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-3140
