### PR TITLE
mail-react: Add a borderRadius prop to the image components

### DIFF
--- a/.changeset/image-border-radius-prop.md
+++ b/.changeset/image-border-radius-prop.md
@@ -1,0 +1,13 @@
+---
+"@dextinity/mail-react": minor
+---
+
+Add a `borderRadius` prop to `MjmlImage`, `HtmlImage`, `MjmlPixelImageBlock` and `HtmlPixelImageBlock`
+
+**Example**
+
+```tsx
+<MjmlImage src="https://example.com/image.jpg" alt="Example" width={520} borderRadius={16} />
+```
+
+A `style` prop passed by the caller wins over `borderRadius`.

--- a/packages/mail-react/src/blocks/pixelImage/HtmlPixelImageBlock.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/HtmlPixelImageBlock.tsx
@@ -1,11 +1,11 @@
 import clsx from "clsx";
-import type { ComponentProps, ReactNode } from "react";
+import type { ReactNode } from "react";
 
-import { HtmlImage } from "../../components/image/HtmlImage.js";
+import { HtmlImage, type HtmlImageProps } from "../../components/image/HtmlImage.js";
 import type { PixelImageBlockBaseProps } from "./common.js";
 import { usePixelImageBlockData } from "./usePixelImageBlockData.js";
 
-export type HtmlPixelImageBlockProps = Omit<ComponentProps<"img">, "src" | "width" | "height"> & PixelImageBlockBaseProps;
+export type HtmlPixelImageBlockProps = Omit<HtmlImageProps, "src" | "width" | "height"> & PixelImageBlockBaseProps;
 
 /**
  * Renders a pixel-image from the DAM as a raw `<img>` tag.

--- a/packages/mail-react/src/blocks/pixelImage/__stories__/HtmlPixelImageBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/__stories__/HtmlPixelImageBlock.stories.tsx
@@ -27,6 +27,7 @@ const config: Meta<typeof HtmlPixelImageBlock> = {
             control: "select",
             options: ["inherit", "16x9", "4x3", "3x2", "3x1", "2x1", "1x1", "1x2", "1x3", "2x3", "3x4", "9x16"],
         },
+        borderRadius: { control: "number" },
     },
     args: {
         data: exampleBlockData,
@@ -85,6 +86,41 @@ export const AspectRatioOverride: Story = {
                             <td>
                                 <HtmlPixelImageBlock {...args} />
                                 <HtmlPixelImageBlock {...args} aspectRatio="16x9" />
+                            </td>
+                        </tr>
+                    </MjmlRaw>
+                </MjmlColumn>
+            </MjmlSection>
+        </MjmlMailRoot>
+    ),
+};
+
+export const RoundedCorners: Story = {
+    args: {
+        borderRadius: 16,
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "Rounds the image corners through the `borderRadius` prop of `HtmlImage`.",
+            },
+        },
+    },
+    render: (args) => (
+        <MjmlMailRoot
+            config={{
+                pixelImageBlock: {
+                    validSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 2560, 3200, 3840],
+                    baseUrl: "",
+                },
+            }}
+        >
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlRaw>
+                        <tr>
+                            <td>
+                                <HtmlPixelImageBlock {...args} />
                             </td>
                         </tr>
                     </MjmlRaw>

--- a/packages/mail-react/src/blocks/pixelImage/__stories__/MjmlPixelImageBlock.stories.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/__stories__/MjmlPixelImageBlock.stories.tsx
@@ -27,6 +27,7 @@ const config: Meta<typeof MjmlPixelImageBlock> = {
             control: "select",
             options: ["inherit", "16x9", "4x3", "3x2", "3x1", "2x1", "1x1", "1x2", "1x3", "2x3", "3x4", "9x16"],
         },
+        borderRadius: { control: "number" },
     },
     args: {
         data: exampleBlockData,
@@ -76,6 +77,35 @@ export const AspectRatioOverride: Story = {
                 <MjmlColumn>
                     <MjmlPixelImageBlock {...args} />
                     <MjmlPixelImageBlock {...args} aspectRatio="16x9" />
+                </MjmlColumn>
+            </MjmlSection>
+        </MjmlMailRoot>
+    ),
+};
+
+export const RoundedCorners: Story = {
+    args: {
+        borderRadius: 16,
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "Rounds the image corners through the `borderRadius` prop of `MjmlImage`.",
+            },
+        },
+    },
+    render: (args) => (
+        <MjmlMailRoot
+            config={{
+                pixelImageBlock: {
+                    validSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 2560, 3200, 3840],
+                    baseUrl: "",
+                },
+            }}
+        >
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlPixelImageBlock {...args} />
                 </MjmlColumn>
             </MjmlSection>
         </MjmlMailRoot>

--- a/packages/mail-react/src/blocks/pixelImage/__tests__/HtmlPixelImageBlock.test.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/__tests__/HtmlPixelImageBlock.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { type Config, ConfigProvider } from "../../../config/ConfigProvider.js";
+import { createTheme } from "../../../theme/createTheme.js";
+import { ThemeProvider } from "../../../theme/ThemeProvider.js";
+import { exampleBlockData } from "../__stories__/exampleBlockData.js";
+import { HtmlPixelImageBlock } from "../HtmlPixelImageBlock.js";
+
+const config: Config = { pixelImageBlock: { validSizes: [640, 1280], baseUrl: "" } };
+
+describe("HtmlPixelImageBlock", () => {
+    it("forwards borderRadius to the image", () => {
+        const html = renderToStaticMarkup(
+            <ThemeProvider theme={createTheme()}>
+                <ConfigProvider config={config}>
+                    <HtmlPixelImageBlock data={exampleBlockData} width={300} borderRadius={8} />
+                </ConfigProvider>
+            </ThemeProvider>,
+        );
+
+        expect(html).toContain("border-radius:8px");
+    });
+});

--- a/packages/mail-react/src/blocks/pixelImage/__tests__/MjmlPixelImageBlock.test.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/__tests__/MjmlPixelImageBlock.test.tsx
@@ -1,0 +1,24 @@
+import { MjmlColumn } from "@faire/mjml-react";
+import { describe, expect, it } from "vitest";
+
+import { MjmlMailRoot } from "../../../components/mailRoot/MjmlMailRoot.js";
+import { MjmlSection } from "../../../components/section/MjmlSection.js";
+import { renderMailHtml } from "../../../server/renderMailHtml.js";
+import { exampleBlockData } from "../__stories__/exampleBlockData.js";
+import { MjmlPixelImageBlock } from "../MjmlPixelImageBlock.js";
+
+describe("MjmlPixelImageBlock", () => {
+    it("forwards borderRadius to the image", () => {
+        const { html } = renderMailHtml(
+            <MjmlMailRoot config={{ pixelImageBlock: { validSizes: [640, 1280], baseUrl: "" } }}>
+                <MjmlSection>
+                    <MjmlColumn>
+                        <MjmlPixelImageBlock data={exampleBlockData} width={300} borderRadius={8} />
+                    </MjmlColumn>
+                </MjmlSection>
+            </MjmlMailRoot>,
+        );
+
+        expect(html).toContain("border-radius:8px");
+    });
+});

--- a/packages/mail-react/src/components/image/HtmlImage.tsx
+++ b/packages/mail-react/src/components/image/HtmlImage.tsx
@@ -1,10 +1,13 @@
 import clsx from "clsx";
-import type { ComponentProps, ReactNode } from "react";
+import type { ComponentProps, CSSProperties, ReactNode } from "react";
 
 import { registerStyles } from "../../styles/registerStyles.js";
 import { css } from "../../utils/css.js";
 
-export type HtmlImageProps = ComponentProps<"img">;
+export type HtmlImageProps = ComponentProps<"img"> & {
+    /** Corner radius of the image. */
+    borderRadius?: CSSProperties["borderRadius"];
+};
 
 /**
  * Renders an `<img>` tag that adapts to its container width below the default
@@ -15,8 +18,8 @@ export type HtmlImageProps = ComponentProps<"img">;
  * Inside `MjmlRaw` in an `MjmlColumn`, place `HtmlImage` in a `<tr>` and `<td>` of its own.
  * For MJML context, use `MjmlImage`.
  */
-export function HtmlImage({ className, ...restProps }: HtmlImageProps): ReactNode {
-    return <img className={clsx("htmlImage", className)} {...restProps} />;
+export function HtmlImage({ className, borderRadius, style, ...restProps }: HtmlImageProps): ReactNode {
+    return <img className={clsx("htmlImage", className)} style={{ borderRadius, ...style }} {...restProps} />;
 }
 
 registerStyles(

--- a/packages/mail-react/src/components/image/MjmlImage.tsx
+++ b/packages/mail-react/src/components/image/MjmlImage.tsx
@@ -1,11 +1,14 @@
 import { type IMjmlImageProps, MjmlImage as BaseMjmlImage } from "@faire/mjml-react";
 import clsx from "clsx";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { registerStyles } from "../../styles/registerStyles.js";
 import { css } from "../../utils/css.js";
 
-export type MjmlImageProps = IMjmlImageProps;
+export type MjmlImageProps = Omit<IMjmlImageProps, "borderRadius"> & {
+    /** Corner radius of the image. */
+    borderRadius?: CSSProperties["borderRadius"];
+};
 
 /**
  * Renders an MJML image that adapts to the viewport width below the default breakpoint.
@@ -13,8 +16,8 @@ export type MjmlImageProps = IMjmlImageProps;
  * Must be placed within an `MjmlColumn`. For raw HTML context (e.g. inside `MjmlRaw`),
  * use `HtmlImage` instead.
  */
-export function MjmlImage({ className, ...restProps }: MjmlImageProps): ReactNode {
-    return <BaseMjmlImage className={clsx("mjmlImage", className)} {...restProps} />;
+export function MjmlImage({ className, borderRadius, ...restProps }: MjmlImageProps): ReactNode {
+    return <BaseMjmlImage className={clsx("mjmlImage", className)} borderRadius={borderRadius} {...restProps} />;
 }
 
 // MJML inlines a fixed `height` on the inner <img>; !important overrides it for responsive scaling.

--- a/packages/mail-react/src/components/image/__stories__/HtmlImage.stories.tsx
+++ b/packages/mail-react/src/components/image/__stories__/HtmlImage.stories.tsx
@@ -22,6 +22,7 @@ const config: Meta<typeof HtmlImage> = {
     },
     argTypes: {
         src: { control: false },
+        borderRadius: { control: "number" },
     },
 };
 
@@ -55,6 +56,32 @@ export const FullWidth: Story = {
                     <tr>
                         <td>
                             <HtmlImage {...args} src={`https://picsum.photos/seed/html-image-full-width/${args.width}/${args.height}`} />
+                        </td>
+                    </tr>
+                </MjmlRaw>
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const RoundedCorners: Story = {
+    args: {
+        borderRadius: 16,
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "Rounds the image corners through the `borderRadius` prop.",
+            },
+        },
+    },
+    render: (args) => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlRaw>
+                    <tr>
+                        <td>
+                            <HtmlImage {...args} src={`https://picsum.photos/seed/html-image-rounded/${args.width}/${args.height}`} />
                         </td>
                     </tr>
                 </MjmlRaw>

--- a/packages/mail-react/src/components/image/__stories__/MjmlImage.stories.tsx
+++ b/packages/mail-react/src/components/image/__stories__/MjmlImage.stories.tsx
@@ -22,6 +22,7 @@ const config: Meta<typeof MjmlImage> = {
     },
     argTypes: {
         src: { control: false },
+        borderRadius: { control: "number" },
     },
 };
 
@@ -46,6 +47,26 @@ export const FullWidth: Story = {
         <MjmlSection>
             <MjmlColumn>
                 <MjmlImage {...args} src={`https://picsum.photos/seed/mjml-image-full-width/${args.width}/${args.height}`} />
+            </MjmlColumn>
+        </MjmlSection>
+    ),
+};
+
+export const RoundedCorners: Story = {
+    args: {
+        borderRadius: 16,
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "Rounds the image corners through the `borderRadius` prop.",
+            },
+        },
+    },
+    render: (args) => (
+        <MjmlSection indent>
+            <MjmlColumn>
+                <MjmlImage {...args} src={`https://picsum.photos/seed/mjml-image-rounded/${args.width}/${args.height}`} />
             </MjmlColumn>
         </MjmlSection>
     ),

--- a/packages/mail-react/src/components/image/__tests__/HtmlImage.test.tsx
+++ b/packages/mail-react/src/components/image/__tests__/HtmlImage.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { HtmlImage } from "../HtmlImage.js";
+
+describe("HtmlImage", () => {
+    it("writes borderRadius into the style attribute", () => {
+        const html = renderToStaticMarkup(<HtmlImage src="image.jpg" alt="" borderRadius={8} />);
+
+        expect(html).toMatch(/<img[^>]*style="[^"]*border-radius:8px/);
+    });
+
+    it("lets a caller-supplied style win over the borderRadius prop", () => {
+        const html = renderToStaticMarkup(<HtmlImage src="image.jpg" alt="" borderRadius={8} style={{ borderRadius: 2 }} />);
+
+        expect(html).toContain("border-radius:2px");
+        expect(html).not.toContain("border-radius:8px");
+    });
+});

--- a/packages/mail-react/src/components/image/__tests__/MjmlImage.test.tsx
+++ b/packages/mail-react/src/components/image/__tests__/MjmlImage.test.tsx
@@ -1,0 +1,32 @@
+import { MjmlColumn } from "@faire/mjml-react";
+import { describe, expect, it } from "vitest";
+
+import { MjmlMailRoot } from "../../../components/mailRoot/MjmlMailRoot.js";
+import { MjmlSection } from "../../../components/section/MjmlSection.js";
+import { renderMailHtml } from "../../../server/renderMailHtml.js";
+import { MjmlImage } from "../MjmlImage.js";
+
+describe("MjmlImage", () => {
+    it("writes borderRadius into the style attribute of the compiled <img>", () => {
+        const { html } = renderMailHtml(
+            <MjmlMailRoot>
+                <MjmlSection>
+                    <MjmlColumn>
+                        <MjmlImage src="image.jpg" alt="" width={100} borderRadius={8} />
+                    </MjmlColumn>
+                </MjmlSection>
+            </MjmlMailRoot>,
+        );
+
+        expect(findImageTag(html)).toContain("border-radius:8px");
+    });
+});
+
+function findImageTag(html: string): string {
+    const imageTag = html.replace(/\s+/g, " ").match(/<img[^>]*>/);
+
+    if (imageTag === null) {
+        throw new Error("Rendered mail contains no <img> tag");
+    }
+    return imageTag[0];
+}


### PR DESCRIPTION
A follow-up PR will give classic Windows Outlook rounded corners with a VML fallback, which needs the radius as a prop it can read at render time.

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13469