### PR TITLE
mail-react: Inline the MjmlButton background image

### DIFF
--- a/.changeset/inline-mjml-button-background-image.md
+++ b/.changeset/inline-mjml-button-background-image.md
@@ -1,0 +1,5 @@
+---
+"@dextinity/mail-react": patch
+---
+
+Fix the `MjmlButton` background image not reaching clients that drop `<style>` blocks

--- a/packages/mail-react/src/components/button/MjmlButton.tsx
+++ b/packages/mail-react/src/components/button/MjmlButton.tsx
@@ -82,10 +82,9 @@ function getThemedProps(
     };
 }
 
-// The wrapped MJML button has no `background-image` prop, so a gradient goes in a `<style>`
-// rule over the solid `backgroundColor`; variant rules come after the base so they override it.
-// Only the static value lives here; responsive overrides flow through generateResponsiveButtonCss.
-function generateStaticBackgroundImageCss(theme: Theme): string {
+// The wrapped MJML button has no `background-image` prop, so the value can only come from CSS. The
+// `!important` beats the `background` shorthand the button writes inline, which would reset the gradient.
+export function generateInlineBackgroundImageCss(theme: Theme): string {
     const { variants, ...baseStyles } = theme.button;
     const cssChunks: string[] = [];
 
@@ -115,17 +114,14 @@ function generateStaticBackgroundImageCss(theme: Theme): string {
 }
 
 export function generateMjmlButtonStyles(theme: Theme): string {
-    return [
-        generateStaticBackgroundImageCss(theme),
-        generateResponsiveButtonCss(theme, {
-            styleSelector: (variantName) => `.mjmlButton--${variantName} a`,
-        }),
-    ]
-        .filter(Boolean)
-        .join("\n");
+    return generateResponsiveButtonCss(theme, {
+        styleSelector: (variantName) => `.mjmlButton--${variantName} a`,
+    });
 }
 
 registerStyles(generateMjmlButtonStyles);
+
+registerStyles(generateInlineBackgroundImageCss, { inline: true });
 
 // The cell is already full-width; this widens the anchor inside it so a gradient covers the
 // whole bar and the whole bar is clickable. Inlined so it survives clients that drop `<style>`.

--- a/packages/mail-react/src/components/button/__tests__/MjmlButton.test.tsx
+++ b/packages/mail-react/src/components/button/__tests__/MjmlButton.test.tsx
@@ -7,7 +7,7 @@ import { renderMailHtml } from "../../../server/renderMailHtml.js";
 import { createTheme } from "../../../theme/createTheme.js";
 import { MjmlMailRoot } from "../../mailRoot/MjmlMailRoot.js";
 import { MjmlSection } from "../../section/MjmlSection.js";
-import { generateMjmlButtonStyles, MjmlButton } from "../MjmlButton.js";
+import { generateInlineBackgroundImageCss, generateMjmlButtonStyles, MjmlButton } from "../MjmlButton.js";
 
 function renderInMailRoot(button: ReactNode, theme?: ReturnType<typeof createTheme>) {
     return renderMailHtml(
@@ -149,7 +149,7 @@ describe("MjmlButton", () => {
     });
 });
 
-describe("generateMjmlButtonStyles", () => {
+describe("MjmlButton styles", () => {
     it("returns empty CSS when no variants or base gradient are defined", () => {
         const theme = createTheme();
         expect(generateMjmlButtonStyles(theme)).toBe("");
@@ -158,7 +158,7 @@ describe("generateMjmlButtonStyles", () => {
     it("emits a base gradient rule on the anchor when theme.button.backgroundImage is set", () => {
         const theme = createTheme({ button: { backgroundImage: "linear-gradient(to right, red, blue)" } });
 
-        const result = generateMjmlButtonStyles(theme);
+        const result = generateInlineBackgroundImageCss(theme);
 
         expect(result).toContain(".mjmlButton a");
         expect(result).toContain("background-image: linear-gradient(to right, red, blue) !important");
@@ -169,7 +169,7 @@ describe("generateMjmlButtonStyles", () => {
             button: { variants: { primary: { backgroundImage: "linear-gradient(to right, red, blue)" } } },
         });
 
-        const result = generateMjmlButtonStyles(theme);
+        const result = generateInlineBackgroundImageCss(theme);
 
         expect(result).toContain(".mjmlButton--primary a");
         expect(result).toContain("background-image: linear-gradient(to right, red, blue) !important");


### PR DESCRIPTION
A theme's button background image reached the mail only as a `<style>` rule, so every client that drops `<style>` blocks rendered the flat background color instead. `HtmlButton` and the dividers already write the value into the `style` attribute.

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13468