### PR TITLE
mail-react: Minify the registered styles

### DIFF
--- a/.changeset/minify-registered-styles.md
+++ b/.changeset/minify-registered-styles.md
@@ -1,0 +1,5 @@
+---
+"@dextinity/mail-react": patch
+---
+
+Minify the registered styles, so Gmail is less likely to drop a mail's CSS

--- a/packages/mail-react/package.json
+++ b/packages/mail-react/package.json
@@ -43,6 +43,7 @@
     "dependencies": {
         "@faire/mjml-react": "^3.5.4",
         "clsx": "^2.1.1",
+        "csso": "^5.0.5",
         "mjml": "^4.18.0",
         "mjml-browser": "^4.18.0",
         "redraft": "^0.10.2"
@@ -53,6 +54,7 @@
         "@storybook/addon-docs": "^10.3.5",
         "@storybook/addon-vitest": "10.3.5",
         "@storybook/react-vite": "^10.3.5",
+        "@types/csso": "^5.0.5",
         "@types/mjml": "^4.7.4",
         "@types/mjml-browser": "^4.15.0",
         "@types/react": "^19.2.15",

--- a/packages/mail-react/src/server/renderMailHtml.test.tsx
+++ b/packages/mail-react/src/server/renderMailHtml.test.tsx
@@ -56,7 +56,7 @@ describe("server/renderMailHtml", () => {
         );
 
         expect(html).toContain(".myComponent");
-        expect(html).toContain("color: red");
+        expect(html).toContain("color:red");
     });
 
     it("includes function-style registered styles resolved with the theme", () => {
@@ -79,7 +79,43 @@ describe("server/renderMailHtml", () => {
         );
 
         expect(html).toContain(".themed");
-        expect(html).toContain("width: 600px");
+        expect(html).toContain("width:600px");
+    });
+
+    it("minifies the registered styles", () => {
+        registerStyles(css`
+            .minifyMe {
+                color: red;
+                padding-bottom: 8px;
+            }
+        `);
+
+        const { html } = renderMailHtml(
+            <MjmlMailRoot>
+                <MjmlSection>
+                    <MjmlColumn>
+                        <MjmlText>Hello</MjmlText>
+                    </MjmlColumn>
+                </MjmlSection>
+            </MjmlMailRoot>,
+        );
+
+        expect(html).toContain(".minifyMe{color:red;padding-bottom:8px}");
+    });
+
+    it("keeps the Outlook properties that MJML writes", () => {
+        const { html } = renderMailHtml(
+            <MjmlMailRoot>
+                <MjmlSection>
+                    <MjmlColumn>
+                        <MjmlText>Hello</MjmlText>
+                    </MjmlColumn>
+                </MjmlSection>
+            </MjmlMailRoot>,
+        );
+
+        // A minifier would write `0pt` as `0`, which Outlook does not read.
+        expect(html).toContain("mso-table-lspace:0pt");
     });
 
     it("renders the head slot content inside <mj-head>", () => {

--- a/packages/mail-react/src/server/renderMailHtml.test.tsx
+++ b/packages/mail-react/src/server/renderMailHtml.test.tsx
@@ -100,7 +100,8 @@ describe("server/renderMailHtml", () => {
             </MjmlMailRoot>,
         );
 
-        expect(html).toContain(".minifyMe{color:red;padding-bottom:8px}");
+        expect(html).toContain(".minifyMe");
+        expect(html).toContain("color:red;padding-bottom:8px");
     });
 
     it("keeps the Outlook properties that MJML writes", () => {

--- a/packages/mail-react/src/styles/Styles.tsx
+++ b/packages/mail-react/src/styles/Styles.tsx
@@ -2,6 +2,7 @@ import { MjmlStyle } from "@faire/mjml-react";
 import type { ReactNode } from "react";
 
 import { useTheme } from "../theme/ThemeProvider.js";
+import { minifyHeadCss } from "./minifyHeadCss.js";
 import { getRegisteredStyles, type StylesPayload } from "./registerStyles.js";
 
 /** Internal component that renders the styles registry into `<MjmlStyle>` elements. */
@@ -23,7 +24,7 @@ export function Styles(): ReactNode {
 
     return (
         <>
-            {combinedStyleTagCss ? <MjmlStyle>{combinedStyleTagCss}</MjmlStyle> : null}
+            {combinedStyleTagCss ? <MjmlStyle>{minifyHeadCss(combinedStyleTagCss)}</MjmlStyle> : null}
             {entriesToInline.map((entry, index) => (
                 <MjmlStyle key={index} {...entry.mjmlStyleProps}>
                     {resolveCss(entry.styles)}

--- a/packages/mail-react/src/styles/Styles.tsx
+++ b/packages/mail-react/src/styles/Styles.tsx
@@ -2,26 +2,33 @@ import { MjmlStyle } from "@faire/mjml-react";
 import type { ReactNode } from "react";
 
 import { useTheme } from "../theme/ThemeProvider.js";
-import { getRegisteredStyles } from "./registerStyles.js";
+import { getRegisteredStyles, type StylesPayload } from "./registerStyles.js";
 
-/**
- * Internal component that iterates the styles registry and renders one
- * `<MjmlStyle>` element per entry.
- */
+/** Internal component that renders the styles registry into `<MjmlStyle>` elements. */
 export function Styles(): ReactNode {
     const theme = useTheme();
     const entries = Array.from(getRegisteredStyles().values());
 
+    function resolveCss(styles: StylesPayload): string {
+        return typeof styles === "function" ? styles(theme) : styles;
+    }
+
+    const combinedStyleTagCss = entries
+        .filter((entry) => !entry.mjmlStyleProps?.inline)
+        .map((entry) => resolveCss(entry.styles))
+        .filter(Boolean)
+        .join("\n");
+
+    const entriesToInline = entries.filter((entry) => entry.mjmlStyleProps?.inline);
+
     return (
         <>
-            {entries.map((entry, index) => {
-                const cssString = typeof entry.styles === "function" ? entry.styles(theme) : entry.styles;
-                return (
-                    <MjmlStyle key={index} {...entry.mjmlStyleProps}>
-                        {cssString}
-                    </MjmlStyle>
-                );
-            })}
+            {combinedStyleTagCss ? <MjmlStyle>{combinedStyleTagCss}</MjmlStyle> : null}
+            {entriesToInline.map((entry, index) => (
+                <MjmlStyle key={index} {...entry.mjmlStyleProps}>
+                    {resolveCss(entry.styles)}
+                </MjmlStyle>
+            ))}
         </>
     );
 }

--- a/packages/mail-react/src/styles/__stories__/GmailCssCharacterLimit.stories.tsx
+++ b/packages/mail-react/src/styles/__stories__/GmailCssCharacterLimit.stories.tsx
@@ -86,8 +86,12 @@ const renderedTokens = {
 /** Only what the mail renders, which keeps the head CSS below Gmail's limit. */
 const trimmedTheme = createTheme(renderedTokens);
 
-/** The variants a branded design system defines, which puts the head CSS above Gmail's limit. */
-const brandTheme = createTheme({
+/** The variants that push the theme's head CSS above the limit. */
+const fillerVariants: Record<string, TextVariantStyles> = Object.fromEntries(
+    Array.from({ length: 20 }, (unused, index) => [`filler${index}`, textVariant(16 + index, 15 + index)]),
+);
+
+const aboveLimitTheme = createTheme({
     ...renderedTokens,
     text: {
         ...renderedTokens.text,
@@ -102,6 +106,7 @@ const brandTheme = createTheme({
             bodySmall: textVariant(14, 13),
             legal: textVariant(11, 10, { color: "#999999" }),
             quote: textVariant(22, 18, { fontStyle: "italic" }),
+            ...fillerVariants,
         },
     },
 });
@@ -174,7 +179,7 @@ function CssCharacterLimitMail({ theme, headCssLength }: { theme: Theme; headCss
 }
 
 const trimmedHeadCssLength = measureHeadCssLength(<CssCharacterLimitMail theme={trimmedTheme} headCssLength={0} />);
-const brandHeadCssLength = measureHeadCssLength(<CssCharacterLimitMail theme={brandTheme} headCssLength={0} />);
+const aboveLimitHeadCssLength = measureHeadCssLength(<CssCharacterLimitMail theme={aboveLimitTheme} headCssLength={0} />);
 
 export const BelowCssCharacterLimit: Story = {
     render: () => <CssCharacterLimitMail theme={trimmedTheme} headCssLength={trimmedHeadCssLength} />,
@@ -184,8 +189,8 @@ export const BelowCssCharacterLimit: Story = {
 };
 
 export const AboveCssCharacterLimit: Story = {
-    render: () => <CssCharacterLimitMail theme={brandTheme} headCssLength={brandHeadCssLength} />,
+    render: () => <CssCharacterLimitMail theme={aboveLimitTheme} headCssLength={aboveLimitHeadCssLength} />,
     play: () => {
-        expect(brandHeadCssLength).toBeGreaterThan(gmailCssCharacterLimit);
+        expect(aboveLimitHeadCssLength).toBeGreaterThan(gmailCssCharacterLimit);
     },
 };

--- a/packages/mail-react/src/styles/minifyHeadCss.ts
+++ b/packages/mail-react/src/styles/minifyHeadCss.ts
@@ -1,0 +1,17 @@
+import { syntax } from "csso";
+
+/**
+ * Minifies CSS for a `<style>` tag in the mail head.
+ *
+ * Gmail discards a mail's `<style>` content once the tags together pass 16,384 characters.
+ */
+export function minifyHeadCss(css: string): string {
+    const parseErrors: string[] = [];
+    const styleSheet = syntax.parse(css, { onParseError: (error) => parseErrors.push(error.message) });
+
+    if (parseErrors.length > 0) {
+        throw new Error(`The registered styles do not parse, so they cannot be minified: ${parseErrors.join("; ")}`);
+    }
+
+    return syntax.generate(syntax.compress(styleSheet).ast);
+}

--- a/packages/mail-react/src/styles/registerStyles.ts
+++ b/packages/mail-react/src/styles/registerStyles.ts
@@ -3,7 +3,7 @@ import type { IMjmlStyleProps } from "@faire/mjml-react";
 import type { Theme } from "../theme/themeTypes.js";
 import type { css } from "../utils/css.js";
 
-type StylesPayload = ReturnType<typeof css> | ((theme: Theme) => ReturnType<typeof css>);
+export type StylesPayload = ReturnType<typeof css> | ((theme: Theme) => ReturnType<typeof css>);
 type MjmlStyleOptions = Partial<Omit<IMjmlStyleProps, "children">>;
 
 interface StyleRegistryEntry {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2467,6 +2467,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      csso:
+        specifier: ^5.0.5
+        version: 5.0.5
       mjml:
         specifier: ^4.18.0
         version: 4.18.0
@@ -2492,6 +2495,9 @@ importers:
       '@storybook/react-vite':
         specifier: ^10.3.5
         version: 10.3.5(esbuild@0.27.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(supports-color@8.1.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.13.3)(jiti@2.7.0)(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3))(webpack@5.106.2(@swc/core@1.15.41)(esbuild@0.27.4)(uglify-js@3.19.3))
+      '@types/csso':
+        specifier: ^5.0.5
+        version: 5.0.5
       '@types/mjml':
         specifier: ^4.7.4
         version: 4.7.4
@@ -8501,6 +8507,12 @@ packages:
 
   '@types/cookies@0.9.2':
     resolution: {integrity: sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==}
+
+  '@types/css-tree@2.3.11':
+    resolution: {integrity: sha512-aEokibJOI77uIlqoBOkVbaQGC9zII0A+JH1kcTNKW2CwyYWD8KM6qdo+4c77wD3wZOQfJuNWAr9M4hdk+YhDIg==}
+
+  '@types/csso@5.0.5':
+    resolution: {integrity: sha512-Et/B3W1/1XMjG9SxwitiokWDabA9N8otVoTBJF2RmZ8itU0c5h7qmuZcTpp17BqfAnsdfkGQ3hwizff3nJvWSQ==}
 
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
@@ -25011,6 +25023,12 @@ snapshots:
       '@types/express': 5.0.6
       '@types/keygrip': 1.0.6
       '@types/node': 24.13.3
+
+  '@types/css-tree@2.3.11': {}
+
+  '@types/csso@5.0.5':
+    dependencies:
+      '@types/css-tree': 2.3.11
 
   '@types/d3-array@3.2.1': {}
 


### PR DESCRIPTION
Gmail drops a mail's `<style>` content once the tags together pass 16,384 characters: https://github.com/hteumeuleu/email-bugs/issues/90

The head CSS grows with the number of text variants a theme defines.
A mail whose theme defines 13 of them carried 20,478 characters of style content and now carries 8,709.

Minifying put the `AboveCssCharacterLimit` story below the limit it demonstrates, so its theme grows to stay above.

`csso` last released in August 2022. Even so, it writes the smallest CSS of the candidates and so leaves a mail the most room below Gmail's limit. `Styles` also runs in the browser. A minifier that cannot run there cannot be used.

| minifier              | head CSS | cut    | runs in the browser      |
| --------------------- | -------- | ------ | ------------------------ |
| none                  |   20,478 | —      | —                        |
| `csso` 5.0.5          |    8,709 | -57.5% | yes                      |
| `lightningcss` 1.33.0 |   10,000 | -51.2% | only as a wasm payload   |
| `cssnano` 9.0.1       |   10,009 | -51.1% | no, crashes in a browser bundle                      |
| `clean-css` 5.3.3     |   10,009 | -51.1% | no, needs Node built-ins |
| `esbuild` 0.28.2      |   12,006 | -41.4% | no, Node only            |

_Measured by rendering the same mail once for each minifier and counting the characters in its `<style>` tags._

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13467