### PR TITLE
Fix import path for createRichTextBlock in Storybook story

### DIFF
--- a/packages/mail-react/src/styles/__stories__/GmailCssCharacterLimit.stories.tsx
+++ b/packages/mail-react/src/styles/__stories__/GmailCssCharacterLimit.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ReactElement } from "react";
 import { expect } from "storybook/test";
 
-import { createRichTextBlock } from "../../blocks/richText/createRichTextBlock.js";
+import { createRichTextBlock } from "../../blocks/richText/draftJs/createRichTextBlock.js";
 import { renderMailHtml } from "../../client/renderMailHtml.js";
 import { MjmlMailRoot } from "../../components/mailRoot/MjmlMailRoot.js";
 import { MjmlSection } from "../../components/section/MjmlSection.js";


### PR DESCRIPTION
https://github.com/vivid-planet/dextinity/pull/6202 changed the folder structure, but https://github.com/vivid-planet/dextinity/pull/6226 still had the old import.

https://claude.ai/code/session_01H7XsnXDbGJSdXEwW45tGg1