### PR TITLE
Add constant for system user name in API and site

### DIFF
--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -48,7 +48,8 @@ import { TranslationModule } from "@src/translation/translation.module";
 import { Request } from "express";
 
 import { AccessControlService } from "./auth/access-control.service";
-import { AuthModule, SYSTEM_USER_NAME } from "./auth/auth.module";
+import { AuthModule } from "./auth/auth.module";
+import { SYSTEM_USER_NAME } from "./auth/constants";
 import { UserService } from "./auth/user.service";
 import { DamScope } from "./dam/dto/dam-scope";
 import { DamFile } from "./dam/entities/dam-file.entity";

--- a/demo/api/src/auth/auth.module.ts
+++ b/demo/api/src/auth/auth.module.ts
@@ -16,6 +16,8 @@ import { AccessControlService } from "./access-control.service";
 import { staticUsers } from "./static-users";
 import { UserService } from "./user.service";
 
+// Must match SYSTEM_USER_NAME in demo/site/src/util/systemUser.ts.
+// When changing the name, it needs to be updated everywhere (api and site).
 export const SYSTEM_USER_NAME = "system-user";
 
 @Module({})

--- a/demo/api/src/auth/auth.module.ts
+++ b/demo/api/src/auth/auth.module.ts
@@ -13,12 +13,9 @@ import { JwtModule } from "@nestjs/jwt";
 import { Config } from "@src/config/config";
 
 import { AccessControlService } from "./access-control.service";
+import { SYSTEM_USER_NAME } from "./constants";
 import { staticUsers } from "./static-users";
 import { UserService } from "./user.service";
-
-// Must match SYSTEM_USER_NAME in demo/site/src/util/systemUser.ts.
-// When changing the name, it needs to be updated everywhere (api and site).
-export const SYSTEM_USER_NAME = "system-user";
 
 @Module({})
 export class AuthModule {

--- a/demo/api/src/auth/constants.ts
+++ b/demo/api/src/auth/constants.ts
@@ -1,0 +1,3 @@
+// Must match SYSTEM_USER_NAME in demo/site/src/auth/constants.ts.
+// When changing the name, it needs to be updated everywhere (api and site).
+export const SYSTEM_USER_NAME = "system-user";

--- a/demo/site/src/app/[visibility]/[domain]/graphql/route.ts
+++ b/demo/site/src/app/[visibility]/[domain]/graphql/route.ts
@@ -1,5 +1,5 @@
 import { persistedQueryRoute } from "@dextinity/site-nextjs/server";
-import { SYSTEM_USER_NAME } from "@src/util/systemUser";
+import { SYSTEM_USER_NAME } from "@src/auth/constants";
 
 export const dynamic = "force-dynamic";
 

--- a/demo/site/src/app/[visibility]/[domain]/graphql/route.ts
+++ b/demo/site/src/app/[visibility]/[domain]/graphql/route.ts
@@ -1,4 +1,5 @@
 import { persistedQueryRoute } from "@dextinity/site-nextjs/server";
+import { SYSTEM_USER_NAME } from "@src/util/systemUser";
 
 export const dynamic = "force-dynamic";
 
@@ -6,7 +7,7 @@ async function handler(request: Request) {
     return persistedQueryRoute(request, {
         graphqlTarget: `${process.env.API_URL_INTERNAL}/graphql`,
         headers: {
-            authorization: `Basic ${Buffer.from(`system-user:${process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`,
+            authorization: `Basic ${Buffer.from(`${SYSTEM_USER_NAME}:${process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`,
         },
         persistedQueriesPath: ".next/persisted-queries.json",
         cacheMaxAge: 450, //Cache for 7.5 minutes (450 seconds) in CDNs and browsers

--- a/demo/site/src/auth/constants.ts
+++ b/demo/site/src/auth/constants.ts
@@ -1,3 +1,3 @@
-// Must match SYSTEM_USER_NAME in demo/api/src/auth/auth.module.ts.
+// Must match SYSTEM_USER_NAME in demo/api/src/auth/constants.ts.
 // When changing the name, it needs to be updated everywhere (api and site).
 export const SYSTEM_USER_NAME = "system-user";

--- a/demo/site/src/util/graphQLClient.ts
+++ b/demo/site/src/util/graphQLClient.ts
@@ -9,6 +9,7 @@ import {
 } from "@dextinity/site-nextjs";
 
 import { getVisibilityParam } from "./ServerContext";
+import { SYSTEM_USER_NAME } from "./systemUser";
 
 type Fetch = typeof fetch;
 
@@ -44,7 +45,7 @@ export function createGraphQLFetch({ fetch: passedFetch }: { fetch?: Fetch } = {
             createFetchWithDefaults(createFetchWithDefaultNextRevalidate(passedFetch || fetch, 7.5 * 60), {
                 cache: "force-cache",
                 headers: {
-                    authorization: `Basic ${Buffer.from(`system-user:${process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`,
+                    authorization: `Basic ${Buffer.from(`${SYSTEM_USER_NAME}:${process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`,
                     ...convertPreviewDataToHeaders(previewData),
                 },
             }),

--- a/demo/site/src/util/graphQLClient.ts
+++ b/demo/site/src/util/graphQLClient.ts
@@ -7,9 +7,9 @@ import {
     type GraphQLFetch,
     type SitePreviewData,
 } from "@dextinity/site-nextjs";
+import { SYSTEM_USER_NAME } from "@src/auth/constants";
 
 import { getVisibilityParam } from "./ServerContext";
-import { SYSTEM_USER_NAME } from "./systemUser";
 
 type Fetch = typeof fetch;
 

--- a/demo/site/src/util/graphQLClientMiddleware.ts
+++ b/demo/site/src/util/graphQLClientMiddleware.ts
@@ -1,5 +1,7 @@
 import { createFetchWithDefaults, createGraphQLFetch } from "@dextinity/site-nextjs";
 
+import { SYSTEM_USER_NAME } from "./systemUser";
+
 export function createGraphQLFetchMiddleware() {
     if (!process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD) {
         throw new Error("API_BASIC_AUTH_SYSTEM_USER_PASSWORD is not set");
@@ -11,7 +13,7 @@ export function createGraphQLFetchMiddleware() {
                 revalidate: 7.5 * 60,
             },
             headers: {
-                authorization: `Basic ${Buffer.from(`system-user:${process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`,
+                authorization: `Basic ${Buffer.from(`${SYSTEM_USER_NAME}:${process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`,
             },
         }),
         `${process.env.API_URL_INTERNAL}/graphql`,

--- a/demo/site/src/util/graphQLClientMiddleware.ts
+++ b/demo/site/src/util/graphQLClientMiddleware.ts
@@ -1,6 +1,5 @@
 import { createFetchWithDefaults, createGraphQLFetch } from "@dextinity/site-nextjs";
-
-import { SYSTEM_USER_NAME } from "./systemUser";
+import { SYSTEM_USER_NAME } from "@src/auth/constants";
 
 export function createGraphQLFetchMiddleware() {
     if (!process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD) {

--- a/demo/site/src/util/systemUser.ts
+++ b/demo/site/src/util/systemUser.ts
@@ -1,0 +1,3 @@
+// Must match SYSTEM_USER_NAME in demo/api/src/auth/auth.module.ts.
+// When changing the name, it needs to be updated everywhere (api and site).
+export const SYSTEM_USER_NAME = "system-user";


### PR DESCRIPTION
The system user name is used both by the API and the site. It was repeatedly forgotten to change in both places. This PR proposes a constant for the user name in the same place in both microservices (`src/auth/constants.ts`). A comment indicates that it needs to be changed in both places, which should be picked up by both humans and agents.

Other considered approaches:
- **Use an environment variable (https://github.com/vivid-planet/dextinity/pull/6137)**. Rejected because it's unnecessary and increases complexity.
- **Move to Dextinity config (https://github.com/vivid-planet/dextinity/pull/6228)**. Slightly better than the environment variable approach, but still very complex for a simple feature.
- **Have a `constants.ts` file in the api and symlink it to the site.** Basically the same as the Dextinity config approach, but introduces another "dependency".
- **Create a shared package.** Nope.

https://claude.ai/code/session_01SQi5FW8doiSEaA7MNoyV3s