### PR TITLE
Support heading-only TipTap rich text blocks

### DIFF
--- a/.changeset/tiptap-empty-heading-preview-skeleton.md
+++ b/.changeset/tiptap-empty-heading-preview-skeleton.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/site-react": patch
+---
+
+Treat a document with only empty headings as empty in `hasTipTapRichTextContent`
+
+An empty heading renders nothing, just like an empty paragraph, so a heading-only TipTap rich text block now shows the preview skeleton while it has no text.

--- a/.changeset/tiptap-heading-only-block.md
+++ b/.changeset/tiptap-heading-only-block.md
@@ -1,0 +1,24 @@
+---
+"@dextinity/cms-admin": minor
+"@dextinity/cms-api": minor
+---
+
+Support heading-only TipTap rich text blocks
+
+`paragraph` is now a feature of `createTipTapRichTextBlock` like the other text block types, enabled by default. Turning it off results in a heading-only block (e.g. a headline): the text block type select only offers headings, the editor starts with a heading instead of a paragraph, and content containing a paragraph is rejected during validation.
+
+The `heading` options gain a `defaultLevel`, the level a newly created heading gets. It defaults to the lowest allowed level and must be one of them. `migrateFromDraftJs` uses it for Draft.js blocks that don't carry a heading level, so migrated content doesn't fall back to paragraphs the schema doesn't allow.
+
+**Example**
+
+A headline block that only offers H2-H4 and starts with an H3:
+
+```tsx
+createTipTapRichTextBlock({
+    paragraph: false,
+    heading: { levels: [2, 3, 4], defaultLevel: 3 },
+    maxTextBlocks: 1,
+});
+```
+
+Lists are disabled in a heading-only block, because a list item's content starts with a paragraph. Enabling one explicitly throws, as does turning off `paragraph` and `heading` together, which would leave no text block type at all.

--- a/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
+++ b/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
@@ -52,6 +52,7 @@ Most features of the Draft.js `RichTextBlock` have a direct equivalent in the Ti
 | `rte.supports` (`SupportedThings[]`)            | one option per feature ([Features](#features))                                               |
 | `bold`, `italic`, `strikethrough`, `sub`, `sup` | `bold`, `italic`, `strike`, `sub`, `sup`                                                     |
 | `header-one` … `header-six`                     | `heading` + the [text-block-type select](#text-block-type-and-styling-selects) (Heading 1–6) |
+| `rte.standardBlockType`                         | [`heading: { defaultLevel }`](#heading-only-blocks)                                          |
 | `ordered-list`, `unordered-list`                | `orderedList`, `unorderedList`                                                               |
 | `history`                                       | `undoRedoButtons` (Admin only)                                                               |
 | `link`, `links-remove`                          | `link` (pass the link block)                                                                 |
@@ -164,6 +165,7 @@ Every editor feature has its own option in the root options object, similar to [
 | `strike`           | `true`  | API + Admin  |
 | `sub`              | `true`  | API + Admin  |
 | `sup`              | `true`  | API + Admin  |
+| `paragraph`        | `true`  | API + Admin  |
 | `heading`          | `true`  | API + Admin  |
 | `orderedList`      | `true`  | API + Admin  |
 | `unorderedList`    | `true`  | API + Admin  |
@@ -171,7 +173,7 @@ Every editor feature has its own option in the root options object, similar to [
 | `softHyphen`       | `true`  | API + Admin  |
 | `undoRedoButtons`  | `true`  | Admin only   |
 
-`heading` can be configured further by passing an options object instead of `true`, which limits the allowed `levels`.
+`heading` can be configured further by passing an options object instead of `true`, which limits the allowed `levels` and sets the `defaultLevel` of new headings. Turning `paragraph` off results in a [heading-only block](#heading-only-blocks).
 
 Links are the exception to the boolean options: `link` takes the link block that is used for links, and passing it enables the feature. Links are disabled by default.
 
@@ -365,6 +367,39 @@ const nodeMapping: Record<string, TipTapNodeHandler> = {
     ),
 };
 ```
+
+### Heading-only blocks
+
+Turning the `paragraph` feature off leaves a block that only holds headings — the TipTap equivalent of the Draft.js pattern of a `RichTextBlock` restricted to `header-*` block types with a `standardBlockType`, for instance the headline part of a heading block:
+
+```ts title="tip-tap-headline.block.ts (API)"
+export const TipTapHeadlineBlock = createTipTapRichTextBlock(
+    {
+        paragraph: false,
+        heading: { levels: [2, 3, 4], defaultLevel: 3 },
+        maxTextBlocks: 1,
+    },
+    { name: "TipTapHeadline" },
+);
+```
+
+```tsx title="TipTapHeadlineBlock.tsx (Admin)"
+export const TipTapHeadlineBlock = createTipTapRichTextBlock({
+    paragraph: false,
+    heading: { levels: [2, 3, 4], defaultLevel: 3 },
+    maxTextBlocks: 1,
+});
+```
+
+The editor starts with an H3, the text block type select only offers _Heading 2_ – _Heading 4_, and `Mod-Alt-2/3/4` switch between them (levels outside `levels` have no shortcut). `defaultLevel` also applies to a block that keeps its paragraphs: it is the level a new heading gets, and defaults to the lowest allowed level.
+
+Lists are disabled in a heading-only block, because a list item's content starts with a paragraph. Enabling one explicitly (`orderedList: true`) throws, as does turning off `paragraph` and `heading` together — that would leave no text block type at all.
+
+:::caution Existing content
+
+The API rejects content that the configuration doesn't allow: a heading level outside the allowed `levels`, or a paragraph in a block without the `paragraph` feature. Narrowing these options for a block that already holds content therefore requires a [migration](./5-migrations.mdx). For content coming from the Draft.js block, the built-in [`migrateFromDraftJs`](#migrating-existing-content) migration already converts Draft.js blocks without a heading level into a heading with `defaultLevel`.
+
+:::
 
 ### Child blocks
 

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -193,6 +193,7 @@ export const TipTapToolbar = ({
     const specialChars = resolvedOptions.nonBreakingSpace || resolvedOptions.softHyphen;
     const hasLink = resolvedOptions.link && !!linkBlock;
     const headingLevels = resolvedOptions.heading ? resolvedOptions.heading.levels : [];
+    const hasParagraph = resolvedOptions.paragraph;
     const hasPlaceholders = placeholders.length > 0;
     const hasChildBlocks = Object.keys(childBlocks).length > 0;
 
@@ -205,7 +206,7 @@ export const TipTapToolbar = ({
                         return String(level);
                     }
                 }
-                return "paragraph";
+                return hasParagraph || resolvedOptions.heading === false ? "paragraph" : String(resolvedOptions.heading.defaultLevel);
             })();
             const activeTipTapTextBlockType: TipTapTextBlockType = (() => {
                 if (e.isActive("orderedList")) {
@@ -221,10 +222,11 @@ export const TipTapToolbar = ({
                 }
                 return "paragraph";
             })();
-            const attrs = e.isActive("heading") ? e.getAttributes("heading") : e.getAttributes("paragraph");
+            const attrs = e.isActive("heading") || !hasParagraph ? e.getAttributes("heading") : e.getAttributes("paragraph");
 
-            // Calculate current list nesting depth for listLevelMax enforcement
-            let canIndent = e.can().sinkListItem("listItem");
+            // Calculate current list nesting depth for listLevelMax enforcement.
+            // The list item node only exists in the schema when lists are enabled.
+            let canIndent = lists && e.can().sinkListItem("listItem");
             if (canIndent && listLevelMax !== undefined) {
                 const { $from } = e.state.selection;
                 let listDepth = 0;
@@ -246,7 +248,7 @@ export const TipTapToolbar = ({
                 canUndo: e.can().undo(),
                 canRedo: e.can().redo(),
                 canIndent,
-                canDedent: e.can().liftListItem("listItem"),
+                canDedent: lists && e.can().liftListItem("listItem"),
                 isBoldActive: e.isActive("bold"),
                 isItalicActive: e.isActive("italic"),
                 isUnderlineActive: e.isActive("underline"),
@@ -372,7 +374,7 @@ export const TipTapToolbar = ({
 
     const handleTextBlockStyleChange = (e: SelectChangeEvent) => {
         const value = e.target.value || null;
-        const nodeType = editor.isActive("heading") ? "heading" : "paragraph";
+        const nodeType = editor.isActive("heading") || !hasParagraph ? "heading" : "paragraph";
         editor.chain().focus().updateAttributes(nodeType, { textBlockStyle: value }).run();
     };
 
@@ -419,9 +421,11 @@ export const TipTapToolbar = ({
                             MenuProps={{ elevation: 1 }}
                             sx={selectSx}
                         >
-                            <MenuItem value="paragraph" dense>
-                                <FormattedMessage id="dextinity.blocks.tipTapRichText.textBlockType.paragraph" defaultMessage="Paragraph" />
-                            </MenuItem>
+                            {hasParagraph && (
+                                <MenuItem value="paragraph" dense>
+                                    <FormattedMessage id="dextinity.blocks.tipTapRichText.textBlockType.paragraph" defaultMessage="Paragraph" />
+                                </MenuItem>
+                            )}
                             {headingLevels.map((level) => (
                                 <MenuItem key={level} value={String(level)} dense>
                                     <FormattedMessage

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -1071,3 +1071,154 @@ export const StickyToolbar: StoryObj<typeof StickyToolbarStory> = {
         });
     },
 };
+
+const HeadingOnlyBlock = createTipTapRichTextBlock({
+    paragraph: false,
+    heading: { levels: [2, 3, 4], defaultLevel: 3 },
+    nonBreakingSpace: false,
+    softHyphen: false,
+});
+
+function HeadingOnlyStory() {
+    const [state, setState] = useState<TipTapRichTextBlockState>(HeadingOnlyBlock.defaultValues());
+
+    return (
+        <StoryWrapper state={state}>
+            <HeadingOnlyBlock.AdminComponent state={state} updateState={setState} />
+        </StoryWrapper>
+    );
+}
+
+export const HeadingOnly: StoryObj<typeof HeadingOnlyStory> = {
+    render: () => <HeadingOnlyStory />,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Editor starts with a heading of the default level", async () => {
+            await waitFor(
+                () => {
+                    expect(canvas.getByRole("heading", { level: 3 })).toBeInTheDocument();
+                },
+                { timeout: 5000 },
+            );
+        });
+
+        await step("Text block type dropdown only offers headings, no paragraph", async () => {
+            await userEvent.click(canvas.getByRole("combobox"));
+
+            await waitFor(
+                () => {
+                    const body = within(document.body);
+                    expect(body.getAllByRole("option").map((option) => option.textContent)).toEqual(["Heading 2", "Heading 3", "Heading 4"]);
+                },
+                { timeout: 3000 },
+            );
+
+            await userEvent.click(within(document.body).getByRole("option", { name: "Heading 2" }));
+        });
+
+        await step("Selected heading level is applied", async () => {
+            await waitFor(
+                () => {
+                    expect(canvas.getByRole("heading", { level: 2 })).toBeInTheDocument();
+                },
+                { timeout: 3000 },
+            );
+        });
+
+        await step("Keyboard shortcut switches the heading level instead of toggling to a paragraph", async () => {
+            const editor = canvas.getByRole("textbox");
+            await userEvent.click(editor);
+            const mod = /Mac/i.test(navigator.platform) ? "Meta" : "Control";
+            await userEvent.keyboard(`{${mod}>}{Alt>}4{/Alt}{/${mod}}`);
+
+            await waitFor(
+                () => {
+                    expect(canvas.getByRole("heading", { level: 4 })).toBeInTheDocument();
+                },
+                { timeout: 3000 },
+            );
+        });
+
+        await step("Typing into the heading works", async () => {
+            await userEvent.keyboard("Headline");
+
+            await waitFor(
+                () => {
+                    expect(canvas.getByRole("heading", { level: 4 })).toHaveTextContent("Headline");
+                },
+                { timeout: 3000 },
+            );
+        });
+    },
+};
+
+const HeadingOnlyWithTextBlockStylesBlock = createTipTapRichTextBlock({
+    paragraph: false,
+    heading: { levels: [2, 3, 4], defaultLevel: 3 },
+    textBlockStyles: [
+        {
+            name: "headline550",
+            label: "Size 550",
+            appliesTo: ["heading-2", "heading-3", "heading-4"],
+            element: (props: HTMLAttributes<HTMLElement>) => <h2 style={{ fontSize: 40, lineHeight: 1.2 }} {...props} />,
+        },
+    ],
+});
+
+function HeadingOnlyWithTextBlockStylesStory() {
+    const [state, setState] = useState<TipTapRichTextBlockState>(HeadingOnlyWithTextBlockStylesBlock.defaultValues());
+
+    return (
+        <StoryWrapper state={state}>
+            <HeadingOnlyWithTextBlockStylesBlock.AdminComponent state={state} updateState={setState} />
+        </StoryWrapper>
+    );
+}
+
+export const HeadingOnlyWithTextBlockStyles: StoryObj<typeof HeadingOnlyWithTextBlockStylesStory> = {
+    render: () => <HeadingOnlyWithTextBlockStylesStory />,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Editor starts with a heading of the default level", async () => {
+            await waitFor(
+                () => {
+                    expect(canvas.getByRole("heading", { level: 3 })).toBeInTheDocument();
+                },
+                { timeout: 5000 },
+            );
+        });
+
+        await step("Applying a text block style keeps the heading", async () => {
+            const comboboxes = canvas.getAllByRole("combobox");
+            expect(comboboxes[0]).toHaveTextContent("Heading 3");
+            await userEvent.click(comboboxes[1]);
+
+            await waitFor(
+                () => {
+                    expect(within(document.body).getByRole("option", { name: "Size 550" })).toBeInTheDocument();
+                },
+                { timeout: 3000 },
+            );
+
+            await userEvent.click(within(document.body).getByRole("option", { name: "Size 550" }));
+
+            await waitFor(
+                () => {
+                    expect(canvas.getByText("Size 550")).toBeInTheDocument();
+                },
+                { timeout: 3000 },
+            );
+        });
+
+        await step("Typing into the styled heading works", async () => {
+            const editor = canvas.getByRole("textbox");
+            await userEvent.click(editor);
+            await userEvent.keyboard("Headline");
+
+            await waitFor(
+                () => {
+                    expect(editor).toHaveTextContent("Headline");
+                },
+                { timeout: 3000 },
+            );
+        });
+    },
+};

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.test.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.test.tsx
@@ -14,6 +14,25 @@ describe("createTipTapRichTextBlock", () => {
         expect(() => createTipTapRichTextBlock({ heading: { levels: [1.5, 2] } })).toThrow();
     });
 
+    it("should throw when the heading defaultLevel is not one of the allowed levels", () => {
+        expect(() => createTipTapRichTextBlock({ heading: { levels: [2, 3, 4], defaultLevel: 1 } })).toThrow();
+        expect(() => createTipTapRichTextBlock({ heading: { defaultLevel: 7 } })).toThrow();
+    });
+
+    it("should throw when paragraphs are disabled and no other text block type is left", () => {
+        expect(() => createTipTapRichTextBlock({ paragraph: false, heading: false })).toThrow();
+    });
+
+    it("should throw when lists are enabled without paragraphs", () => {
+        expect(() => createTipTapRichTextBlock({ paragraph: false, unorderedList: true })).toThrow();
+        expect(() => createTipTapRichTextBlock({ paragraph: false, orderedList: true })).toThrow();
+    });
+
+    it("should start heading-only content with a heading of the default level", () => {
+        const block = createTipTapRichTextBlock({ paragraph: false, heading: { levels: [2, 3, 4], defaultLevel: 3 } });
+        expect(block.defaultValues()).toEqual({ tipTapContent: { type: "doc", content: [{ type: "heading", attrs: { level: 3 } }] } });
+    });
+
     describe("translateContent", () => {
         // The HTML round trip only needs to leave non-text data byte-for-byte identical; whether
         // translation itself changes the surrounding text is exercised separately below, so an

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -2,7 +2,7 @@ import { greyPalette, useContentTranslationService, useErrorDialog } from "@dext
 import { Box, type SvgIconProps } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { Extension, type Extensions } from "@tiptap/core";
-import type { Level as HeadingLevel } from "@tiptap/extension-heading";
+import { Heading, type Level as HeadingLevel } from "@tiptap/extension-heading";
 import Subscript from "@tiptap/extension-subscript";
 import Superscript from "@tiptap/extension-superscript";
 import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
@@ -44,6 +44,11 @@ interface TipTapHeadingOptions {
      * Must be a non-empty array of unique integers between 1 and 6, otherwise an error is thrown.
      */
     levels?: number[];
+    /**
+     * Heading level used for newly created headings. Defaults to the lowest allowed level.
+     * Must be one of `levels`, otherwise an error is thrown.
+     */
+    defaultLevel?: number;
 }
 
 /**
@@ -57,7 +62,8 @@ export interface TipTapResolvedOptions {
     strike: boolean;
     sub: boolean;
     sup: boolean;
-    heading: false | { levels: HeadingLevel[] };
+    paragraph: boolean;
+    heading: false | { levels: HeadingLevel[]; defaultLevel: HeadingLevel };
     orderedList: boolean;
     unorderedList: boolean;
     nonBreakingSpace: boolean;
@@ -84,18 +90,35 @@ function resolveTipTapOptions({
     strike = true,
     sub = true,
     sup = true,
+    paragraph = true,
     heading = true,
-    orderedList = true,
-    unorderedList = true,
+    orderedList,
+    unorderedList,
     nonBreakingSpace = true,
     softHyphen = true,
     link,
     contentTranslation = true,
 }: TipTapRichTextBlockFactoryOptions = {}): TipTapResolvedOptions {
-    const headingLevels = (heading !== false && heading !== true ? heading.levels : undefined) ?? allHeadingLevels;
+    const headingOptions = heading !== false && heading !== true ? heading : {};
+    const headingLevels = headingOptions.levels ?? allHeadingLevels;
 
     if (!isValidHeadingLevels(headingLevels)) {
         throw new Error("heading levels must be a non-empty array of unique integers between 1 and 6");
+    }
+
+    if (headingOptions.defaultLevel !== undefined && !headingLevels.includes(headingOptions.defaultLevel as HeadingLevel)) {
+        throw new Error(`heading defaultLevel must be one of the allowed levels (${headingLevels.join(", ")})`);
+    }
+
+    const defaultHeadingLevel = (headingOptions.defaultLevel ?? Math.min(...headingLevels)) as HeadingLevel;
+
+    if (!paragraph) {
+        if (heading === false) {
+            throw new Error("paragraph: false requires headings, otherwise no text block type is left");
+        }
+        if (orderedList || unorderedList) {
+            throw new Error("Lists require paragraphs, because a list item's content starts with a paragraph");
+        }
     }
 
     return {
@@ -106,9 +129,11 @@ function resolveTipTapOptions({
         strike,
         sub,
         sup,
-        heading: heading === false ? false : { levels: headingLevels },
-        orderedList,
-        unorderedList,
+        paragraph,
+        heading: heading === false ? false : { levels: headingLevels, defaultLevel: defaultHeadingLevel },
+        // Lists are enabled by default, but cannot exist without a paragraph to build their items from.
+        orderedList: orderedList ?? paragraph,
+        unorderedList: unorderedList ?? paragraph,
         nonBreakingSpace,
         softHyphen,
         link: !!link,
@@ -209,8 +234,16 @@ interface TipTapRichTextBlockFactoryOptions {
      */
     sup?: boolean;
     /**
+     * Enables paragraphs. Defaults to `true`.
+     *
+     * Pass `false` for a heading-only block (e.g. a headline): the editor starts with a heading
+     * instead of a paragraph and the text block type select only offers headings. Requires
+     * headings, and disables lists, because a list item's content starts with a paragraph.
+     */
+    paragraph?: boolean;
+    /**
      * Enables headings. Defaults to `true` (all levels).
-     * Pass an options object to limit the selectable heading `levels`.
+     * Pass an options object to limit the selectable heading `levels` or to set the `defaultLevel`.
      */
     heading?: boolean | TipTapHeadingOptions;
     /**
@@ -280,7 +313,54 @@ function getPlainTextFromContent(content: JSONContent): string {
     return text;
 }
 
-const emptyContent: JSONContent = { type: "doc", content: [{ type: "paragraph" }] };
+// TipTap's own priority for the paragraph extension, which makes the paragraph the schema's first
+// block node and therefore ProseMirror's default block type.
+const paragraphPriority = 1000;
+
+const buildEmptyContent = (resolvedOptions: TipTapResolvedOptions): JSONContent => ({
+    type: "doc",
+    content: [
+        resolvedOptions.paragraph || resolvedOptions.heading === false
+            ? { type: "paragraph" }
+            : { type: "heading", attrs: { level: resolvedOptions.heading.defaultLevel } },
+    ],
+});
+
+/**
+ * Sets the default heading level and, for heading-only blocks, makes the heading the schema's
+ * default block type (the position paragraphs would otherwise take, by priority) and replaces the
+ * heading keyboard shortcuts, which would otherwise toggle back to a paragraph.
+ */
+const buildHeadingExtension = ({
+    base,
+    levels,
+    defaultLevel,
+    hasParagraph,
+}: {
+    base: typeof Heading;
+    levels: HeadingLevel[];
+    defaultLevel: HeadingLevel;
+    hasParagraph: boolean;
+}) =>
+    base
+        .extend({
+            ...(hasParagraph
+                ? {}
+                : {
+                      priority: paragraphPriority,
+                      addKeyboardShortcuts() {
+                          return Object.fromEntries(levels.map((level) => [`Mod-Alt-${level}`, () => this.editor.commands.setHeading({ level })]));
+                      },
+                  }),
+            addAttributes() {
+                return {
+                    ...this.parent?.(),
+                    // `rendered: false` keeps TipTap from adding a `level` HTML attribute, the level is the tag name.
+                    level: { default: defaultLevel, rendered: false },
+                };
+            },
+        })
+        .configure({ levels });
 
 const isCmsBlockNode = (content: JSONContent): boolean => content.type === "cmsBlock" || content.type === "cmsInlineBlock";
 
@@ -459,17 +539,30 @@ function buildTipTapExtensions({
             italic: resolvedOptions.italic ? {} : false,
             underline: resolvedOptions.underline ? {} : false,
             strike: resolvedOptions.strike ? {} : false,
-            heading: resolvedOptions.heading && !hasTextBlockStyles ? { levels: resolvedOptions.heading.levels } : false,
-            paragraph: hasTextBlockStyles ? false : undefined,
+            // The heading extension is added separately below to set the default heading level.
+            heading: false,
+            paragraph: resolvedOptions.paragraph && !hasTextBlockStyles ? undefined : false,
             orderedList: resolvedOptions.orderedList ? {} : false,
             bulletList: resolvedOptions.unorderedList ? {} : false,
+            // A list item's content starts with a paragraph, so lists cannot exist without one.
+            listItem: resolvedOptions.paragraph ? undefined : false,
+            listKeymap: resolvedOptions.paragraph ? undefined : false,
             blockquote: false,
             code: false,
             codeBlock: false,
             link: false,
         }),
-        ...(hasTextBlockStyles ? [TextBlockStyleParagraph] : []),
-        ...(hasTextBlockStyles && resolvedOptions.heading ? [TextBlockStyleHeading.configure({ levels: resolvedOptions.heading.levels })] : []),
+        ...(resolvedOptions.paragraph && hasTextBlockStyles ? [TextBlockStyleParagraph] : []),
+        ...(resolvedOptions.heading
+            ? [
+                  buildHeadingExtension({
+                      base: hasTextBlockStyles ? TextBlockStyleHeading : Heading,
+                      levels: resolvedOptions.heading.levels,
+                      defaultLevel: resolvedOptions.heading.defaultLevel,
+                      hasParagraph: resolvedOptions.paragraph,
+                  }),
+              ]
+            : []),
         ...(hasInlineStyles ? [InlineStyleMark] : []),
         ...(resolvedOptions.sup ? [Superscript] : []),
         ...(resolvedOptions.sub ? [Subscript] : []),
@@ -689,6 +782,7 @@ export const createTipTapRichTextBlock = (options: TipTapRichTextBlockFactoryOpt
     const maxTextBlocks = options.maxTextBlocks;
     const listLevelMax = options.listLevelMax;
     const minHeight = options.minHeight;
+    const emptyContent = buildEmptyContent(resolvedOptions);
 
     const sharedEditorProps = {
         resolvedOptions,

--- a/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.test.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.test.ts
@@ -6,6 +6,7 @@ import { createLinkBlock } from "../factories/createLinkBlock";
 import {
     createTipTapRichTextBlock,
     type CreateTipTapRichTextBlockOptions,
+    resolveTipTapOptions,
     type TipTapRichTextBlockContent,
     type TipTapRichTextBlockDataInterface,
     type TipTapRichTextBlockInputInterface,
@@ -1306,6 +1307,67 @@ describe("createTipTapRichTextBlock validation", () => {
             });
             const errors = await validate(input);
             expect(errors).toHaveLength(0);
+        });
+    });
+
+    describe("heading-only schema (paragraph: false)", () => {
+        const block = createTipTapRichTextBlock(
+            onlyFeatures({ paragraph: false, heading: { levels: [2, 3, 4], defaultLevel: 3 }, bold: true }),
+            "TestHeadingOnly",
+        );
+
+        it("should accept a heading within the allowed levels", async () => {
+            const input = block.blockInputFactory({
+                tipTapContent: {
+                    type: "doc",
+                    content: [{ type: "heading", attrs: { level: 3 }, content: [{ type: "text", text: "Headline" }] }],
+                },
+            });
+            const errors = await validate(input);
+            expect(errors).toHaveLength(0);
+        });
+
+        it("should reject a paragraph", async () => {
+            const input = block.blockInputFactory({
+                tipTapContent: {
+                    type: "doc",
+                    content: [{ type: "paragraph", content: [{ type: "text", text: "Text" }] }],
+                },
+            });
+            const errors = await validate(input);
+            expect(errors).toHaveLength(1);
+            expect(errors[0].property).toBe("tipTapContent");
+        });
+
+        it("should reject a heading level outside the allowed levels", async () => {
+            const input = block.blockInputFactory({
+                tipTapContent: {
+                    type: "doc",
+                    content: [{ type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "Headline" }] }],
+                },
+            });
+            const errors = await validate(input);
+            expect(errors).toHaveLength(1);
+        });
+
+        it("should throw when the heading defaultLevel is not one of the allowed levels", () => {
+            expect(() => createTipTapRichTextBlock({ heading: { levels: [2, 3, 4], defaultLevel: 1 } }, "TestInvalidDefaultHeadingLevel")).toThrow();
+        });
+
+        it("should throw when paragraphs are disabled without headings", () => {
+            expect(() => createTipTapRichTextBlock(onlyFeatures({ paragraph: false }), "TestNoTextBlockTypeLeft")).toThrow();
+        });
+
+        it("should throw when lists are enabled without paragraphs", () => {
+            expect(() => createTipTapRichTextBlock({ paragraph: false, orderedList: true }, "TestHeadingOnlyWithOrderedList")).toThrow();
+            expect(() => createTipTapRichTextBlock({ paragraph: false, unorderedList: true }, "TestHeadingOnlyWithUnorderedList")).toThrow();
+        });
+
+        it("should disable lists by default when paragraphs are disabled", () => {
+            const resolvedOptions = resolveTipTapOptions({ paragraph: false });
+            expect(resolvedOptions.orderedList).toBe(false);
+            expect(resolvedOptions.unorderedList).toBe(false);
+            expect(resolvedOptions.heading).toEqual({ levels: [1, 2, 3, 4, 5, 6], defaultLevel: 1 });
         });
     });
 

--- a/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
@@ -1,5 +1,5 @@
 import { type Extensions, getSchema, type JSONContent } from "@tiptap/core";
-import type { Level as HeadingLevel } from "@tiptap/extension-heading";
+import { Heading, type Level as HeadingLevel } from "@tiptap/extension-heading";
 import Subscript from "@tiptap/extension-subscript";
 import Superscript from "@tiptap/extension-superscript";
 import { Node as ProseMirrorNode, type Schema } from "@tiptap/pm/model";
@@ -45,6 +45,11 @@ interface TipTapHeadingOptions {
      * Content with a heading level outside this set will be rejected during validation.
      */
     levels?: number[];
+    /**
+     * Heading level used for headings that don't specify one. Defaults to the lowest allowed level.
+     * Must be one of `levels`, otherwise an error is thrown.
+     */
+    defaultLevel?: number;
 }
 
 /**
@@ -57,7 +62,8 @@ export interface TipTapResolvedOptions {
     strike: boolean;
     sub: boolean;
     sup: boolean;
-    heading: false | { levels: HeadingLevel[] };
+    paragraph: boolean;
+    heading: false | { levels: HeadingLevel[]; defaultLevel: HeadingLevel };
     orderedList: boolean;
     unorderedList: boolean;
     nonBreakingSpace: boolean;
@@ -104,6 +110,10 @@ interface TipTapInlineStyle {
 
 const allHeadingLevels: HeadingLevel[] = [1, 2, 3, 4, 5, 6];
 
+// TipTap's own priority for the paragraph extension, which makes the paragraph the schema's first
+// block node and therefore ProseMirror's default block type.
+const paragraphPriority = 1000;
+
 function isValidHeadingLevels(headingLevels: number[]): headingLevels is HeadingLevel[] {
     return (
         headingLevels.length > 0 &&
@@ -142,8 +152,16 @@ export interface CreateTipTapRichTextBlockOptions {
      */
     sup?: boolean;
     /**
+     * Enables paragraphs. Defaults to `true`.
+     *
+     * Pass `false` for a heading-only block (e.g. a headline): content containing a paragraph is
+     * rejected during validation. Requires headings, and disables lists, because a list item's
+     * content starts with a paragraph.
+     */
+    paragraph?: boolean;
+    /**
      * Enables headings. Defaults to `true` (all levels).
-     * Pass an options object to limit the allowed heading `levels`.
+     * Pass an options object to limit the allowed heading `levels` or to set the `defaultLevel`.
      */
     heading?: boolean | TipTapHeadingOptions;
     /**
@@ -218,17 +236,34 @@ export function resolveTipTapOptions({
     strike = true,
     sub = true,
     sup = true,
+    paragraph = true,
     heading = true,
-    orderedList = true,
-    unorderedList = true,
+    orderedList,
+    unorderedList,
     nonBreakingSpace = true,
     softHyphen = true,
     link,
 }: CreateTipTapRichTextBlockOptions = {}): TipTapResolvedOptions {
-    const headingLevels = (heading !== false && heading !== true ? heading.levels : undefined) ?? allHeadingLevels;
+    const headingOptions = heading !== false && heading !== true ? heading : {};
+    const headingLevels = headingOptions.levels ?? allHeadingLevels;
 
     if (!isValidHeadingLevels(headingLevels)) {
         throw new Error("heading levels must be a non-empty array of unique integers between 1 and 6");
+    }
+
+    if (headingOptions.defaultLevel !== undefined && !headingLevels.includes(headingOptions.defaultLevel as HeadingLevel)) {
+        throw new Error(`heading defaultLevel must be one of the allowed levels (${headingLevels.join(", ")})`);
+    }
+
+    const defaultHeadingLevel = (headingOptions.defaultLevel ?? Math.min(...headingLevels)) as HeadingLevel;
+
+    if (!paragraph) {
+        if (heading === false) {
+            throw new Error("paragraph: false requires headings, otherwise no text block type is left");
+        }
+        if (orderedList || unorderedList) {
+            throw new Error("Lists require paragraphs, because a list item's content starts with a paragraph");
+        }
     }
 
     return {
@@ -238,13 +273,44 @@ export function resolveTipTapOptions({
         strike,
         sub,
         sup,
-        heading: heading === false ? false : { levels: headingLevels },
-        orderedList,
-        unorderedList,
+        paragraph,
+        heading: heading === false ? false : { levels: headingLevels, defaultLevel: defaultHeadingLevel },
+        // Lists are enabled by default, but cannot exist without a paragraph to build their items from.
+        orderedList: orderedList ?? paragraph,
+        unorderedList: unorderedList ?? paragraph,
         nonBreakingSpace,
         softHyphen,
         link: !!link,
     };
+}
+
+/**
+ * Sets the default heading level and, for heading-only blocks, makes the heading the schema's
+ * default block type (the position paragraphs would otherwise take, by priority).
+ */
+function buildHeadingExtension({
+    base,
+    levels,
+    defaultLevel,
+    hasParagraph,
+}: {
+    base: typeof Heading;
+    levels: HeadingLevel[];
+    defaultLevel: HeadingLevel;
+    hasParagraph: boolean;
+}) {
+    return base
+        .extend({
+            ...(hasParagraph ? {} : { priority: paragraphPriority }),
+            addAttributes() {
+                return {
+                    ...this.parent?.(),
+                    // `rendered: false` keeps TipTap from adding a `level` HTML attribute, the level is the tag name.
+                    level: { default: defaultLevel, rendered: false },
+                };
+            },
+        })
+        .configure({ levels });
 }
 
 function buildExtensions({
@@ -271,17 +337,30 @@ function buildExtensions({
             italic: resolvedOptions.italic ? {} : false,
             underline: resolvedOptions.underline ? {} : false,
             strike: resolvedOptions.strike ? {} : false,
-            heading: resolvedOptions.heading && !hasTextBlockStyles ? { levels: resolvedOptions.heading.levels } : false,
-            paragraph: hasTextBlockStyles ? false : undefined,
+            // The heading extension is added separately below to set the default heading level.
+            heading: false,
+            paragraph: resolvedOptions.paragraph && !hasTextBlockStyles ? undefined : false,
             orderedList: resolvedOptions.orderedList ? {} : false,
             bulletList: resolvedOptions.unorderedList ? {} : false,
+            // A list item's content starts with a paragraph, so lists cannot exist without one.
+            listItem: resolvedOptions.paragraph ? undefined : false,
+            listKeymap: resolvedOptions.paragraph ? undefined : false,
             blockquote: false,
             code: false,
             codeBlock: false,
             link: false,
         }),
-        ...(hasTextBlockStyles ? [TextBlockStyleParagraph] : []),
-        ...(hasTextBlockStyles && resolvedOptions.heading ? [TextBlockStyleHeading.configure({ levels: resolvedOptions.heading.levels })] : []),
+        ...(resolvedOptions.paragraph && hasTextBlockStyles ? [TextBlockStyleParagraph] : []),
+        ...(resolvedOptions.heading
+            ? [
+                  buildHeadingExtension({
+                      base: hasTextBlockStyles ? TextBlockStyleHeading : Heading,
+                      levels: resolvedOptions.heading.levels,
+                      defaultLevel: resolvedOptions.heading.defaultLevel,
+                      hasParagraph: resolvedOptions.paragraph,
+                  }),
+              ]
+            : []),
         ...(hasInlineStyles ? [InlineStyleMark] : []),
         ...(resolvedOptions.sup ? [Superscript] : []),
         ...(resolvedOptions.sub ? [Subscript] : []),

--- a/packages/api/cms-api/src/blocks/tipTap/migrations/buildDraftJsToTipTapMigration.test.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/migrations/buildDraftJsToTipTapMigration.test.ts
@@ -283,6 +283,64 @@ describe("createTipTapRichTextBlock with migrateFromDraftJs", () => {
         });
     });
 
+    describe("heading-only target schema", () => {
+        const block = createTipTapRichTextBlock(
+            {
+                paragraph: false,
+                heading: { levels: [2, 3, 4], defaultLevel: 3 },
+                migrateFromDraftJs: true,
+            },
+            "MigratedHeadingOnly",
+        );
+
+        it("migrates a DraftJS block without a heading level into a heading with the default level", () => {
+            const data = block.blockDataFactory({
+                draftContent: {
+                    blocks: [draftBlock({ type: "unstyled", text: "Headline" })],
+                    entityMap: {},
+                },
+            });
+            expect(data.tipTapContent).toEqual({
+                type: "doc",
+                content: [{ type: "heading", attrs: { level: 3 }, content: [{ type: "text", text: "Headline" }] }],
+            });
+        });
+
+        it("keeps a DraftJS heading level that is allowed", () => {
+            const data = block.blockDataFactory({
+                draftContent: {
+                    blocks: [draftBlock({ type: "header-two", text: "Headline" })],
+                    entityMap: {},
+                },
+            });
+            expect(data.tipTapContent).toEqual({
+                type: "doc",
+                content: [{ type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "Headline" }] }],
+            });
+        });
+
+        it("migrates empty DraftJS content into an empty heading with the default level", () => {
+            const data = block.blockDataFactory({
+                draftContent: { blocks: [], entityMap: {} },
+            });
+            expect(data.tipTapContent).toEqual({ type: "doc", content: [{ type: "heading", attrs: { level: 3 } }] });
+        });
+
+        it("falls back to headings with the default level when the conversion is invalid", () => {
+            const data = block.blockDataFactory({
+                draftContent: {
+                    // header-one is not one of the allowed levels, so the converted doc doesn't validate.
+                    blocks: [draftBlock({ type: "header-one", text: "Headline" })],
+                    entityMap: {},
+                },
+            });
+            expect(data.tipTapContent).toEqual({
+                type: "doc",
+                content: [{ type: "heading", attrs: { level: 3 }, content: [{ type: "text", text: "Headline" }] }],
+            });
+        });
+    });
+
     describe("maxTextBlocks fallback", () => {
         const block = createTipTapRichTextBlock({ maxTextBlocks: 2, migrateFromDraftJs: true }, "MigratedRichTextMaxBlocks");
 

--- a/packages/api/cms-api/src/blocks/tipTap/migrations/buildDraftJsToTipTapMigration.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/migrations/buildDraftJsToTipTapMigration.ts
@@ -7,7 +7,13 @@ import type { Block } from "../../block";
 import { BlockMigration } from "../../migrations/BlockMigration";
 import type { BlockMigrationInterface } from "../../migrations/types";
 import { isValidTipTapContentSync } from "../tipTapValidation";
-import { buildStrippedTipTapDoc, convertDraftJsToTipTap, type ConvertOptions, type DraftJsContent } from "./convertDraftJsToTipTap";
+import {
+    buildEmptyTipTapDoc,
+    buildStrippedTipTapDoc,
+    convertDraftJsToTipTap,
+    type ConvertOptions,
+    type DraftJsContent,
+} from "./convertDraftJsToTipTap";
 
 interface From {
     draftContent?: DraftJsContent;
@@ -37,10 +43,9 @@ interface BuildOptions extends ConvertOptions {
     link?: Block;
 }
 
-const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] };
-
 export function buildDraftJsToTipTapMigration(options: BuildOptions): ClassConstructor<BlockMigrationInterface> {
     const { schema, maxTextBlocks, headingLevels, resolvedOptions, link, textBlockStyleMap, inlineStyleMap, listLevelMax } = options;
+    const emptyDoc = buildEmptyTipTapDoc(resolvedOptions);
 
     return class DraftJsToTipTapMigration extends BlockMigration<(from: From) => To> implements BlockMigrationInterface {
         public readonly toVersion = 1;
@@ -51,7 +56,7 @@ export function buildDraftJsToTipTapMigration(options: BuildOptions): ClassConst
                 if (from.tipTapContent !== undefined) {
                     return { tipTapContent: from.tipTapContent };
                 }
-                return { tipTapContent: EMPTY_DOC };
+                return { tipTapContent: emptyDoc };
             }
 
             const converted = convertDraftJsToTipTap(from.draftContent, { resolvedOptions, link, textBlockStyleMap, inlineStyleMap, listLevelMax });
@@ -63,14 +68,14 @@ export function buildDraftJsToTipTapMigration(options: BuildOptions): ClassConst
                 throw new Error(`DraftJS->TipTap migration produced invalid content that doesn't pass validation`);
             }
 
-            const stripped = buildStrippedTipTapDoc(from.draftContent);
+            const stripped = buildStrippedTipTapDoc(from.draftContent, resolvedOptions);
             if (isValidTipTapContentSync(stripped, schema, { maxTextBlocks, headingLevels })) {
                 console.warn("DraftJS->TipTap migration failed, using stripped content");
                 return { tipTapContent: stripped };
             }
 
             console.warn("DraftJS->TipTap migration failed, lost content!");
-            return { tipTapContent: EMPTY_DOC };
+            return { tipTapContent: emptyDoc };
         }
     };
 }

--- a/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.test.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.test.ts
@@ -856,24 +856,27 @@ describe("convertDraftJsToTipTap", () => {
 
 describe("buildStrippedTipTapDoc", () => {
     it("returns minimal doc for empty input", () => {
-        expect(buildStrippedTipTapDoc({ blocks: [], entityMap: {} })).toEqual({
+        expect(buildStrippedTipTapDoc({ blocks: [], entityMap: {} }, allEnabled)).toEqual({
             type: "doc",
             content: [{ type: "paragraph" }],
         });
     });
 
     it("emits one paragraph per block with plain text only", () => {
-        const result = buildStrippedTipTapDoc({
-            blocks: [
-                makeBlock({
-                    type: "header-one",
-                    text: "Hi",
-                    inlineStyleRanges: [{ style: "BOLD", offset: 0, length: 2 }],
-                }),
-                makeBlock({ type: "unordered-list-item", text: "item" }),
-            ],
-            entityMap: {},
-        });
+        const result = buildStrippedTipTapDoc(
+            {
+                blocks: [
+                    makeBlock({
+                        type: "header-one",
+                        text: "Hi",
+                        inlineStyleRanges: [{ style: "BOLD", offset: 0, length: 2 }],
+                    }),
+                    makeBlock({ type: "unordered-list-item", text: "item" }),
+                ],
+                entityMap: {},
+            },
+            allEnabled,
+        );
         expect(result).toEqual({
             type: "doc",
             content: [
@@ -884,10 +887,7 @@ describe("buildStrippedTipTapDoc", () => {
     });
 
     it("emits empty paragraphs for empty text blocks", () => {
-        const result = buildStrippedTipTapDoc({
-            blocks: [makeBlock({ type: "unstyled", text: "" })],
-            entityMap: {},
-        });
+        const result = buildStrippedTipTapDoc({ blocks: [makeBlock({ type: "unstyled", text: "" })], entityMap: {} }, allEnabled);
         expect(result.content).toEqual([{ type: "paragraph" }]);
     });
 });

--- a/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.ts
@@ -111,8 +111,12 @@ const TEXT_BLOCK_TYPE_TO_HEADING_LEVEL: Record<TipTapTextBlockStyleTargetType, n
     "heading-6": 6,
 };
 
-function makeEmptyDoc(): JSONContent {
-    return { type: "doc", content: [{ type: "paragraph" }] };
+/**
+ * Builds a document with a single empty text block, matching the target schema's default text block
+ * type (a paragraph, or a heading for a heading-only schema).
+ */
+export function buildEmptyTipTapDoc(resolvedOptions: TipTapResolvedOptions): JSONContent {
+    return { type: "doc", content: [makeTextBlockNode([], { resolvedOptions })] };
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -264,8 +268,15 @@ function splitAtomChars(text: string, marks: NonNullable<JSONContent["marks"]>, 
 
 function makeTextBlockNode(
     inlineContent: JSONContent[],
-    { headingLevel, textBlockStyle }: { headingLevel?: number; textBlockStyle?: string } = {},
+    {
+        headingLevel: explicitHeadingLevel,
+        textBlockStyle,
+        resolvedOptions,
+    }: { headingLevel?: number; textBlockStyle?: string; resolvedOptions: TipTapResolvedOptions },
 ): JSONContent {
+    // A heading-only schema has no paragraph to fall back to.
+    const headingLevel =
+        explicitHeadingLevel ?? (resolvedOptions.paragraph || resolvedOptions.heading === false ? undefined : resolvedOptions.heading.defaultLevel);
     const node: JSONContent = { type: headingLevel !== undefined ? "heading" : "paragraph" };
 
     const attrs: JSONContent["attrs"] = {};
@@ -285,10 +296,10 @@ function makeTextBlockNode(
     return node;
 }
 
-function makeListItem(inlineContent: JSONContent[]): JSONContent {
+function makeListItem(inlineContent: JSONContent[], resolvedOptions: TipTapResolvedOptions): JSONContent {
     return {
         type: "listItem",
-        content: [makeTextBlockNode(inlineContent)],
+        content: [makeTextBlockNode(inlineContent, { resolvedOptions })],
     };
 }
 
@@ -312,11 +323,12 @@ function normalizeTextBlockStyleMapping(mapping: string | TextBlockStyleMapping 
 }
 
 export function convertDraftJsToTipTap(draftContent: DraftJsContent | undefined | null, options: ConvertOptions): JSONContent {
+    const resolvedOptions = options.resolvedOptions;
+
     if (!draftContent || !Array.isArray(draftContent.blocks) || draftContent.blocks.length === 0) {
-        return makeEmptyDoc();
+        return buildEmptyTipTapDoc(resolvedOptions);
     }
 
-    const resolvedOptions = options.resolvedOptions;
     const hasLink = !!options.link;
     const textBlockStyleMap = options.textBlockStyleMap ?? {};
     const inlineStyleMap = options.inlineStyleMap ?? {};
@@ -370,7 +382,7 @@ export function convertDraftJsToTipTap(draftContent: DraftJsContent | undefined 
             openLists.push({ type: listType, items: [] });
         }
 
-        openLists[openLists.length - 1].items.push(makeListItem(inlineContent));
+        openLists[openLists.length - 1].items.push(makeListItem(inlineContent, resolvedOptions));
     };
 
     for (const block of draftContent.blocks) {
@@ -390,6 +402,7 @@ export function convertDraftJsToTipTap(draftContent: DraftJsContent | undefined 
 
         topLevel.push(
             makeTextBlockNode(inlineContent, {
+                resolvedOptions,
                 headingLevel: headingLevel !== undefined && resolvedOptions.heading !== false ? headingLevel : undefined,
                 textBlockStyle: mapping?.textBlockStyle,
             }),
@@ -399,27 +412,24 @@ export function convertDraftJsToTipTap(draftContent: DraftJsContent | undefined 
     flushLists();
 
     if (topLevel.length === 0) {
-        return makeEmptyDoc();
+        return buildEmptyTipTapDoc(resolvedOptions);
     }
 
     return { type: "doc", content: topLevel };
 }
 
-export function buildStrippedTipTapDoc(draftContent: DraftJsContent | undefined | null): JSONContent {
+export function buildStrippedTipTapDoc(draftContent: DraftJsContent | undefined | null, resolvedOptions: TipTapResolvedOptions): JSONContent {
     if (!draftContent || !Array.isArray(draftContent.blocks) || draftContent.blocks.length === 0) {
-        return makeEmptyDoc();
+        return buildEmptyTipTapDoc(resolvedOptions);
     }
 
     const content: JSONContent[] = draftContent.blocks.map((block) => {
         const text = block.text ?? "";
-        if (text.length === 0) {
-            return { type: "paragraph" };
-        }
-        return { type: "paragraph", content: [{ type: "text", text }] };
+        return makeTextBlockNode(text.length === 0 ? [] : [{ type: "text", text }], { resolvedOptions });
     });
 
     if (content.length === 0) {
-        return makeEmptyDoc();
+        return buildEmptyTipTapDoc(resolvedOptions);
     }
 
     return { type: "doc", content };

--- a/packages/site/site-react/src/blocks/helpers/TipTapRichTextRenderer.tsx
+++ b/packages/site/site-react/src/blocks/helpers/TipTapRichTextRenderer.tsx
@@ -94,9 +94,13 @@ export function renderTipTapRichText({ content, nodeMapping, markMapping }: Rend
     return renderNode(content, undefined);
 }
 
+// An empty text block renders nothing, no matter which type it has. A heading-only block starts
+// out with an empty heading, just like a regular rich text block starts out with an empty paragraph.
+const emptyableTextBlockTypes = ["paragraph", "heading"];
+
 export function hasTipTapRichTextContent(content: TipTapNode | null | undefined): boolean {
     if (!content?.content || !Array.isArray(content.content)) {
         return false;
     }
-    return content.content.some((node) => node.type !== "paragraph" || (Array.isArray(node.content) && node.content.length > 0));
+    return content.content.some((node) => !emptyableTextBlockTypes.includes(node.type) || (Array.isArray(node.content) && node.content.length > 0));
 }

--- a/packages/site/site-react/src/blocks/helpers/TipTapRichTextRenderer.tsx
+++ b/packages/site/site-react/src/blocks/helpers/TipTapRichTextRenderer.tsx
@@ -96,11 +96,11 @@ export function renderTipTapRichText({ content, nodeMapping, markMapping }: Rend
 
 // An empty text block renders nothing, no matter which type it has. A heading-only block starts
 // out with an empty heading, just like a regular rich text block starts out with an empty paragraph.
-const emptyableTextBlockTypes = ["paragraph", "heading"];
+const isEmptyableTextBlock = (node: TipTapNode): boolean => node.type === "paragraph" || node.type === "heading";
 
 export function hasTipTapRichTextContent(content: TipTapNode | null | undefined): boolean {
     if (!content?.content || !Array.isArray(content.content)) {
         return false;
     }
-    return content.content.some((node) => !emptyableTextBlockTypes.includes(node.type) || (Array.isArray(node.content) && node.content.length > 0));
+    return content.content.some((node) => !isEmptyableTextBlock(node) || (Array.isArray(node.content) && node.content.length > 0));
 }


### PR DESCRIPTION
`paragraph` is now a feature of `createTipTapRichTextBlock` like the other text block types, enabled by default. Turning it off results in a heading-only block (e.g. a headline): the text block type select only offers headings, the editor starts with a heading instead of a paragraph, and content containing a paragraph is rejected during validation.

The `heading` options gain a `defaultLevel`, the level a newly created heading gets. It defaults to the lowest allowed level and must be one of them. `migrateFromDraftJs` uses it for Draft.js blocks that don't carry a heading level, so migrated content doesn't fall back to paragraphs the schema doesn't allow.

## Example

A project of ours has a Draft.js rich text block that supports only h2 to h4, defaulting to h3:

```tsx
export const QuoteRichTextBlock = createRichTextBlock({
    link: LinkBlock,
    rte: {
        supports: ["header-two", "header-three", "header-four", "bold", "italic", "sub", "sup", "non-breaking-space", "soft-hyphen"],
        standardBlockType: "header-three",
        blocktypeMap: {
            "header-two": {
                label: <FormattedMessage id="blocks.quoteRichText.heading2" defaultMessage="Heading 2" />,
            },
            "header-three": {
                label: <FormattedMessage id="blocks.quoteRichText.heading3" defaultMessage="Heading 3" />,
            },
            "header-four": {
                label: <FormattedMessage id="blocks.quoteRichText.heading4" defaultMessage="Heading 4" />,
            },
        },
    },
    minHeight: 0,
});
```

This can now be achieved with the TipTap rich text block as well:

```tsx
createTipTapRichTextBlock({
    paragraph: false,
    heading: { levels: [2, 3, 4], defaultLevel: 3 },
    maxTextBlocks: 1,
});
```

## Stories

Headling-only story: https://69df3371c46abe69b5199825-urqgjuvlxu.chromatic.com/?path=/story/blocks-tiptaprichtextblock--heading-only

<img width="349" height="241" alt="image" src="https://github.com/user-attachments/assets/09537a5e-ab61-4efa-81d4-640700ab2d2a" />

## Implementation details

_Note: This section was generated by Claude, but I thought it is worth keeping._

Without a paragraph in the schema, a few things have to follow:

- The heading takes the paragraph's place as ProseMirror's default block type (via the paragraph's extension priority), so new blocks, `clearNodes` and the trailing node produce a heading instead of a horizontal rule.
- The list item node is dropped, because its content expression (`paragraph block*`) references the paragraph. The toolbar no longer asks the editor about `listItem` when lists aren't supported, which would otherwise throw.
- The heading keyboard shortcuts use `setHeading` instead of `toggleHeading`, which toggles back to a paragraph and throws when there is none.
- `migrateFromDraftJs` converts Draft.js blocks without a heading level into a heading with `defaultLevel`, so migrated content doesn't fall back to paragraphs the schema rejects.
- `hasTipTapRichTextContent` treats an empty heading as empty, like an empty paragraph, so a blank headline block still shows the preview skeleton.

https://claude.ai/code/session_01MHUbSx18jymxCo6kJKw8JT