### PR TITLE
cms-admin: Fix order of link and special character buttons in TipTap toolbar

### DIFF
--- a/.changeset/fix-tiptap-toolbar-link-order.md
+++ b/.changeset/fix-tiptap-toolbar-link-order.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/cms-admin": patch
+---
+
+Fix order of `link` and special character (`nonBreakingSpace`, `softHyphen`) buttons in the TipTap rich text block toolbar
+
+They were swapped; `link` now appears before the special character buttons.

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -561,31 +561,23 @@ export const TipTapToolbar = ({
                     />
                 </ToolbarGroup>
             )}
-            {specialChars && (
+            {hasLink && linkBlock && (
                 <ToolbarGroup>
-                    {supports.includes("non-breaking-space") && (
-                        <ToolbarButton
-                            editor={editor}
-                            icon={RteNonBreakingSpace}
-                            tooltip={
-                                <FormattedMessage
-                                    id="dextinity.blocks.tipTapRichText.nonBreakingSpace.tooltip"
-                                    defaultMessage="Insert a non-breaking space"
-                                />
-                            }
-                            onToggle={() => editor.chain().focus().insertContent({ type: "nonBreakingSpace" }).run()}
-                        />
-                    )}
-                    {supports.includes("soft-hyphen") && (
-                        <ToolbarButton
-                            editor={editor}
-                            icon={RteSoftHyphen}
-                            tooltip={
-                                <FormattedMessage id="dextinity.blocks.tipTapRichText.softHyphen.tooltip" defaultMessage="Insert a soft hyphen" />
-                            }
-                            onToggle={() => editor.chain().focus().insertContent({ type: "softHyphen" }).run()}
-                        />
-                    )}
+                    <ToolbarButton
+                        editor={editor}
+                        icon={RteLink}
+                        tooltip={<FormattedMessage id="dextinity.blocks.tipTapRichText.link.tooltip" defaultMessage="Link" />}
+                        isActive="link"
+                        disabled={editorState.selectionEmpty && !editorState.isLinkActive}
+                        onToggle={() => setLinkDialogOpen(true)}
+                    />
+                    <ToolbarButton
+                        editor={editor}
+                        icon={RteClearLink}
+                        tooltip={<FormattedMessage id="dextinity.blocks.tipTapRichText.removeLink.tooltip" defaultMessage="Remove link" />}
+                        disabled={!editorState.isLinkActive}
+                        onToggle={() => editor.chain().focus().extendMarkRange("link").unsetCmsLink().run()}
+                    />
                 </ToolbarGroup>
             )}
             {hasPlaceholders && (
@@ -625,23 +617,31 @@ export const TipTapToolbar = ({
                     </Menu>
                 </ToolbarGroup>
             )}
-            {hasLink && linkBlock && (
+            {specialChars && (
                 <ToolbarGroup>
-                    <ToolbarButton
-                        editor={editor}
-                        icon={RteLink}
-                        tooltip={<FormattedMessage id="dextinity.blocks.tipTapRichText.link.tooltip" defaultMessage="Link" />}
-                        isActive="link"
-                        disabled={editorState.selectionEmpty && !editorState.isLinkActive}
-                        onToggle={() => setLinkDialogOpen(true)}
-                    />
-                    <ToolbarButton
-                        editor={editor}
-                        icon={RteClearLink}
-                        tooltip={<FormattedMessage id="dextinity.blocks.tipTapRichText.removeLink.tooltip" defaultMessage="Remove link" />}
-                        disabled={!editorState.isLinkActive}
-                        onToggle={() => editor.chain().focus().extendMarkRange("link").unsetCmsLink().run()}
-                    />
+                    {supports.includes("non-breaking-space") && (
+                        <ToolbarButton
+                            editor={editor}
+                            icon={RteNonBreakingSpace}
+                            tooltip={
+                                <FormattedMessage
+                                    id="dextinity.blocks.tipTapRichText.nonBreakingSpace.tooltip"
+                                    defaultMessage="Insert a non-breaking space"
+                                />
+                            }
+                            onToggle={() => editor.chain().focus().insertContent({ type: "nonBreakingSpace" }).run()}
+                        />
+                    )}
+                    {supports.includes("soft-hyphen") && (
+                        <ToolbarButton
+                            editor={editor}
+                            icon={RteSoftHyphen}
+                            tooltip={
+                                <FormattedMessage id="dextinity.blocks.tipTapRichText.softHyphen.tooltip" defaultMessage="Insert a soft hyphen" />
+                            }
+                            onToggle={() => editor.chain().focus().insertContent({ type: "softHyphen" }).run()}
+                        />
+                    )}
                 </ToolbarGroup>
             )}
             {hasChildBlocks && (


### PR DESCRIPTION
The `link` toolbar buttons were rendered after the `non-breaking-space`/`soft-hyphen` buttons in the TipTap rich text block toolbar instead of before them; this swaps them back.

|Before|After|
|------|-----|
|<img width="384" height="238" alt="Bildschirmfoto 2026-08-27 um 11 44 48" src="https://github.com/user-attachments/assets/0a8d2222-f951-4b35-9442-f73c64f45e0a" />|<img width="370" height="404" alt="Bildschirmfoto 2026-08-27 um 11 26 04" src="https://github.com/user-attachments/assets/3c72f32e-e938-48d1-a7eb-267cfadb2c58" />|
