### PR TITLE
eslint-plugin: Enable TypeScript strict mode

### DIFF
--- a/packages/eslint-plugin/src/rules/no-other-module-relative-import.ts
+++ b/packages/eslint-plugin/src/rules/no-other-module-relative-import.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 function parentDirCount(dir: string) {
     const match = dir.match(/^(\.\.\/)*/);
-    return match[0].length / 3;
+    return (match?.[0].length ?? 0) / 3;
 }
 
 export default {
@@ -30,7 +30,11 @@ export default {
             ImportDeclaration: function (node) {
                 const options = context.options[0] ?? { sourceRoot: "./src", sourceRootAlias: "@src" };
 
-                const importParentDirCount = parentDirCount(node.source.value.toString());
+                // An import source is always a string literal
+                if (typeof node.source.value !== "string") return;
+                const importPath = node.source.value;
+
+                const importParentDirCount = parentDirCount(importPath);
                 if (!importParentDirCount) {
                     // import is not relative
                     return;
@@ -57,7 +61,7 @@ export default {
                         node,
                         message: "Avoid relative import from other module",
                         fix: (fixer) => {
-                            const importPathRelativeToSourceDir = path.relative(sourceDir, `${fileDir}/${node.source.value.toString()}`);
+                            const importPathRelativeToSourceDir = path.relative(sourceDir, `${fileDir}/${importPath}`);
                             return fixer.replaceText(node.source, `"${options.sourceRootAlias}/${importPathRelativeToSourceDir}"`);
                         },
                     });

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "outDir": "lib",
-        "rootDir": "src"
+        "rootDir": "src",
+        "strict": true
     },
     "exclude": ["node_modules", "lib"],
     "extends": "../../tsconfig.core.json",


### PR DESCRIPTION
## Status quo

TypeScript's `strict` mode is set for most of the repo, but `eslint-plugin` sets no strict flag at all.

## Change

Switch it on. `no-other-module-relative-import` needed two narrowing guards to compile, neither changes behaviour. The rule's own tests pass unchanged.

No changeset, since nothing about the published package changes. One package per pull request, and the flag moves to `tsconfig.core.json` once they all carry it.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-1079
