### PR TITLE
Fix `FormMutation` throwing when rendered

### DIFF
--- a/.changeset/fix-form-mutation-this-props.md
+++ b/.changeset/fix-form-mutation-this-props.md
@@ -4,4 +4,4 @@
 
 Fix `FormMutation` throwing when rendered
 
-`FormMutation` read its children from `this.props` although it is a function component, so `this` was `undefined` and rendering it failed with `TypeError: Cannot read properties of undefined (reading 'props')`.
+`FormMutation` accessed its children through `this.props` although it is a function component. Modules are always in strict mode, so `this` was `undefined` and rendering the component failed with `TypeError: Cannot read properties of undefined (reading 'props')`.

--- a/.changeset/fix-form-mutation-this-props.md
+++ b/.changeset/fix-form-mutation-this-props.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/admin": patch
+---
+
+Fix `FormMutation` throwing when rendered
+
+`FormMutation` read its children from `this.props` although it is a function component, so `this` was `undefined` and rendering it failed with `TypeError: Cannot read properties of undefined (reading 'props')`.

--- a/packages/admin/admin/src/FormMutation.tsx
+++ b/packages/admin/admin/src/FormMutation.tsx
@@ -11,7 +11,7 @@ interface IProps {
 export function FormMutation(props: IProps) {
     const [update, { loading: updateLoading, error: updateError }] = useMutation(props.updateMutation);
     const [create, { loading: createLoading, error: createError }] = useMutation(props.createMutation);
-    return this.props.children(
+    return props.children(
         { update, create },
         {
             loading: updateLoading || createLoading,

--- a/packages/admin/admin/src/__tests__/FormMutation.test.tsx
+++ b/packages/admin/admin/src/__tests__/FormMutation.test.tsx
@@ -1,0 +1,42 @@
+import { gql } from "@apollo/client";
+import { MockedProvider } from "@apollo/client/testing";
+import { render, screen } from "test-utils";
+import { describe, expect, it } from "vitest";
+
+import { FormMutation } from "../FormMutation";
+
+const updateMutation = gql`
+    mutation Update($id: ID!) {
+        update(id: $id) {
+            id
+        }
+    }
+`;
+
+const createMutation = gql`
+    mutation Create {
+        create {
+            id
+        }
+    }
+`;
+
+describe("FormMutation", () => {
+    it("should pass the mutation actions and state to its children", () => {
+        render(
+            <MockedProvider mocks={[]}>
+                <FormMutation updateMutation={updateMutation} createMutation={createMutation}>
+                    {({ update, create }, { loading, error }) => (
+                        <div>
+                            <span data-testid="types">{`${typeof update} ${typeof create}`}</span>
+                            <span data-testid="state">{`${loading} ${error === undefined}`}</span>
+                        </div>
+                    )}
+                </FormMutation>
+            </MockedProvider>,
+        );
+
+        expect(screen.getByTestId("types").textContent).toBe("function function");
+        expect(screen.getByTestId("state").textContent).toBe("false true");
+    });
+});


### PR DESCRIPTION
## Problem

`FormMutation` is exported from `@dextinity/admin`, but rendering it always fails:

> TypeError: Cannot read properties of undefined (reading 'props')

Nothing uses it. Not in this repository and not in any of our client projects, where a search turns up only unrelated GraphQL operation constants whose names happen to end in `FormMutation`.

## Cause

It reads its children from `this.props` although it is a function component. Modules are always in strict mode, so `this` is `undefined` when React calls the component.

## Fix

Read from `props` instead.

## Decisions

- **Fixed rather than removed, even though nothing uses it.** Deleting it is the obvious alternative, but removing a published export is a breaking change and would have to target `next`.

## Verification

Added `FormMutation.test.tsx`, which renders the component and asserts that its children receive the mutation actions and the combined loading and error state. Putting `this.` back in front of `props.children` makes it fail.

Comparing all 343 emitted `.d.ts` files against `main` shows one further change: `FormMutation`'s inferred return type goes from `any` to `ReactNode`. On `main`, `noImplicitThis` is off, so `this` was implicitly `any` and made `this.props.children(...)` — and with it the component — `any`. Reading from `props` yields the `ReactNode` that `IProps.children` declares. Narrowing away an `any` can break a call site in principle, but the component throws unconditionally today, so there is no working call site to break.

## Further information

- Found while enabling TypeScript's `strict` mode, where `noImplicitThis` flagged it: [COM-1079](https://vivid-planet.atlassian.net/browse/COM-1079). It stands on its own as a bugfix, and is a prerequisite for the `admin` step of that chain.


[COM-1079]: ``https://vivid-planet.atlassian.net/browse/COM-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ``