### PR TITLE
Enable TypeScript strict mode in the packages that need no fixes

### DIFF
--- a/packages/admin/admin-color-picker/tsconfig.json
+++ b/packages/admin/admin-color-picker/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "outDir": "lib",
-        "rootDir": "src"
+        "rootDir": "src",
+        "strict": true
     },
     "extends": "../tsconfig.base.json",
     "include": ["./src"]

--- a/packages/admin/admin-date-time/tsconfig.json
+++ b/packages/admin/admin-date-time/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "outDir": "lib",
-        "rootDir": "src"
+        "rootDir": "src",
+        "strict": true
     },
     "extends": "../tsconfig.base.json",
     "include": ["./src"]

--- a/packages/admin/admin-icons/tsconfig.json
+++ b/packages/admin/admin-icons/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "noEmitOnError": true,
         "outDir": "lib/",
-        "rootDir": "src"
+        "rootDir": "src",
+        "strict": true
     },
     "extends": "../tsconfig.base.json",
     "include": ["./src"]

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "outDir": "lib",
-        "rootDir": "src"
+        "rootDir": "src",
+        "strict": true
     },
     "exclude": ["node_modules", "lib"],
     "extends": "../../tsconfig.core.json",


### PR DESCRIPTION
## Status quo

TypeScript's `strict` mode is set for the api and site packages, `cms-admin`, `brevo-admin`, `admin-generator`, `demo/api` and `demo/site`, but not for the rest — so type checking differs from package to package.

## Change

`cli`, `admin-icons`, `admin-color-picker` and `admin-date-time` already compile under `strict` mode with zero errors, so they only need the flag. No code changes, no behaviour change, no changeset.

First step of enabling it package by package; the rest follow one per pull request, and the flag moves to `tsconfig.core.json` once they all carry it.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-1079
