### PR TITLE
mail-react: Keep columns side by side without the `<style>` block

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/1-email-basics.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/1-email-basics.md
@@ -24,6 +24,8 @@ Email styling follows a desktop-first approach where all default styles must be 
 Never rely on `<style>` blocks for your base/desktop layout. Outlook and several other major clients strip or ignore them. Always set default styles inline via MJML component props.
 :::
 
+MJML breaks this rule for column widths: it puts them in a `min-width` media query, so a multi-column section stacks in any client that drops that query — GMX and Web.de, for example. See [Column Widths Must Be Inline](./6-layout-patterns.md#column-widths-must-be-inline).
+
 Media queries, registered via [`registerStyles`](./5-customization.md#registering-responsive-styles), serve as **progressive enhancement** for mobile and responsive behavior. Clients that support media queries also support modern CSS, so properties like `flex` and CSS custom properties are safe to use inside them. Because inline styles take precedence over `<style>` blocks, responsive overrides must use `!important` to take effect. See [Adding Custom Responsive Styles](./5-customization.md#adding-custom-responsive-styles) for details.
 
 ## MJML Components vs HTML Components

--- a/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/2-components-and-theme.md
@@ -229,6 +229,8 @@ By default, columns in a section stack vertically on mobile. To keep them side-b
 
 This wraps the children in an `MjmlGroup`, preventing the columns from stacking.
 
+The group is also what makes MJML write the column widths inline, so every section with more than one column needs this prop, including sections that are meant to stack. See [Column Widths Must Be Inline](./6-layout-patterns.md#column-widths-must-be-inline).
+
 **CSS class names:** `.mjmlSection`, `.mjmlSection--indented` (when `indent` is set).
 
 ## MjmlWrapper

--- a/docs/docs/3-features-modules/13-building-html-emails/6-layout-patterns.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/6-layout-patterns.md
@@ -26,6 +26,21 @@ Properties like `margin-bottom` that apply to the column wrapper itself use the 
 Use `theme.breakpoints.mobile.belowMediaQuery` (or `theme.breakpoints.default.belowMediaQuery`) instead of hardcoded media queries to keep responsive styles in sync with the theme's breakpoint configuration.
 :::
 
+## Column Widths Must Be Inline
+
+MJML puts column widths in a `min-width` media query instead of inline. Clients that drop that query — GMX and Web.de, for example — show the columns stacked.
+
+:::caution
+Set `disableResponsiveBehavior` on every section with more than one column, including sections that are meant to stack. The prop wraps the columns in an `MjmlGroup`, which is what makes MJML write their widths inline.
+:::
+
+Two things follow:
+
+- Write the mobile stacking yourself, in `theme.breakpoints.mobile.belowMediaQuery`. A group never stacks by itself.
+- Target the column container one level deeper. The group adds a `<div>`, so a flex container is `… > td > div`.
+
+Inside a group, a column without a `width` prop gets `parseInt(100 / siblings)%` — `33%` for three columns, not `33.33%`. Set explicit widths when the count does not divide 100 evenly.
+
 ## Symmetric Two-Column Layout
 
 Two equal-width columns with a gap between them, stacking vertically on mobile.
@@ -54,7 +69,7 @@ const TwoColumnsSection = () => {
     const halfGap = columnGap / 2;
 
     return (
-        <MjmlSection indent className="twoColumnsSection">
+        <MjmlSection indent disableResponsiveBehavior className="twoColumnsSection">
             <MjmlColumn className="twoColumnsSection__leftColumn" paddingRight={halfGap}>
                 <MjmlText>Left column content.</MjmlText>
             </MjmlColumn>
@@ -68,12 +83,19 @@ const TwoColumnsSection = () => {
 
 ### Responsive Stacking
 
-On mobile, the columns stack vertically. Reset the gap padding so content stretches full-width, and add a vertical margin to replace the horizontal gap:
+On mobile, the columns stack vertically. The group suppresses MJML's own stacking, so write it yourself. Reset the gap padding so content stretches full-width, and add a vertical margin to replace the horizontal gap:
 
 ```ts
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.mobile.belowMediaQuery} {
+            .twoColumnsSection__leftColumn,
+            .twoColumnsSection__rightColumn {
+                display: block !important;
+                width: 100% !important;
+                max-width: 100% !important;
+            }
+
             .twoColumnsSection__leftColumn > table > tbody > tr > td {
                 padding-right: 0 !important;
             }
@@ -126,7 +148,7 @@ const fluidColumnWidth = sectionInnerWidth - SMALL_COLUMN_WIDTH;
 The gap is created by padding on the fluid column's inner edge — the same principle as the symmetric layout, just applied to one side:
 
 ```tsx
-<MjmlSection indent>
+<MjmlSection indent disableResponsiveBehavior>
     <MjmlColumn
         className="imageTextLayout__smallColumn"
         width={`${SMALL_COLUMN_WIDTH}px`}
@@ -149,12 +171,19 @@ To place the small column on the right instead, swap the column order and move t
 
 ### Two-Breakpoint Responsive Behavior
 
-Fixed-width columns create an overflow problem between the desktop `bodyWidth` and the mobile stacking breakpoint — the total fixed width can exceed the viewport. The solution uses two `belowMediaQuery` breakpoints stacked via CSS cascade order:
+Fixed-width columns create an overflow problem between the desktop `bodyWidth` and the mobile stacking breakpoint — the total fixed width can exceed the viewport. The solution uses two `belowMediaQuery` breakpoints stacked via CSS cascade order.
+
+Inside a group a pixel width is written inline as a percentage of the section, so the fixed column also needs its pixel width back below `bodyWidth`, where the section is narrower:
 
 ```ts
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
+            .imageTextLayout__smallColumn {
+                width: ${SMALL_COLUMN_WIDTH}px !important;
+                max-width: ${SMALL_COLUMN_WIDTH}px !important;
+            }
+
             .imageTextLayout__fluidColumn {
                 width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
                 max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
@@ -162,7 +191,9 @@ registerStyles(
         }
 
         ${theme.breakpoints.mobile.belowMediaQuery} {
+            .imageTextLayout__smallColumn,
             .imageTextLayout__fluidColumn {
+                display: block !important;
                 width: 100% !important;
                 max-width: 100% !important;
             }
@@ -183,11 +214,11 @@ The `default.belowMediaQuery` block makes the fluid column responsive via `calc(
 
 ### Controlling Mobile Stack Order
 
-By default, MJML stacks columns in source order on mobile. If you need a column that appears on the right on desktop to stack on top on mobile (e.g., an image that should appear above the text), use `direction="rtl"` on the section to flip the visual order on desktop while keeping the desired stacking order in the source:
+By default, MJML stacks columns in source order on mobile. If you need a column that appears on the right on desktop to stack on top on mobile (e.g., an image that should appear above the text), use `direction="rtl"` to flip the visual order on desktop while keeping the desired stacking order in the source. The prop goes on the group, not on the section: `MjmlGroup` writes its own `direction` and defaults it to `ltr`, so a value on the section would be cancelled.
 
 ```tsx
 <MjmlWrapper padding={`0 ${sectionIndent}px`} backgroundColor={theme.colors.background.content}>
-    <MjmlSection direction="rtl">
+    <MjmlSection disableResponsiveBehavior slotProps={{ group: { direction: "rtl" } }}>
         <MjmlColumn className="layout__smallColumn" width={`${SMALL_COLUMN_WIDTH}px`}>
             <MjmlImage src="..." alt="..." width={SMALL_COLUMN_WIDTH} />
         </MjmlColumn>
@@ -244,7 +275,7 @@ Outer columns get a width accounting for half-gap padding; inner columns are wid
 ### Pattern — Three Columns
 
 ```tsx
-<MjmlSection indent className="threeColumnsSection">
+<MjmlSection indent disableResponsiveBehavior className="threeColumnsSection">
     <MjmlColumn
         className="threeColumnsSection__column"
         width={outerColumnWidth}
@@ -276,7 +307,7 @@ Same formula; the inner-column is simply repeated. For four columns, the two mid
 
 ### Responsive Stacking
 
-Below the desktop breakpoint, the compensated inline widths no longer make sense: they were calibrated for a specific container width, and inner columns would otherwise render visibly wider than outer ones. A flex reset on the section's inner `<td>` neutralizes those widths so columns size equally.
+Below the desktop breakpoint, the compensated inline widths no longer make sense: they were calibrated for a specific container width, and inner columns would otherwise render visibly wider than outer ones. A flex reset on the `MjmlGroup` `<div>` that holds the columns neutralizes those widths so columns size equally.
 
 The one design decision is **when to collapse to a stack** — and that's per-component. A dense 3-column row might need to stack at mobile; a 4-column row would be too cramped below the default breakpoint.
 
@@ -284,7 +315,7 @@ The one design decision is **when to collapse to a stack** — and that's per-co
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
-            .threeColumnsSection > table > tbody > tr > td {
+            .threeColumnsSection > table > tbody > tr > td > div {
                 display: flex !important;
                 gap: 20px !important;
             }
@@ -301,7 +332,7 @@ registerStyles(
         }
 
         ${theme.breakpoints.mobile.belowMediaQuery} {
-            .threeColumnsSection > table > tbody > tr > td {
+            .threeColumnsSection > table > tbody > tr > td > div {
                 flex-direction: column !important;
             }
             .threeColumnsSection__column {
@@ -321,35 +352,21 @@ registerStyles(
 
 ### Non-Stacking Rows
 
-For short fixed-value rows — numeric data, icon strips — that remain readable even when narrow, keep columns side-by-side at every viewport. Add `disableResponsiveBehavior` on the section to suppress MJML's own mobile auto-stack:
+For short fixed-value rows — numeric data, icon strips — that remain readable even when narrow, keep columns side-by-side at every viewport.
 
-```tsx
-<MjmlSection indent disableResponsiveBehavior className="iconStrip">
-    {/* …columns as in the Three-Column pattern above… */}
-</MjmlSection>
-```
-
-The inline width compensation still needs to be neutralized so columns render at equal widths. Apply the same flex reset as in [Responsive Stacking](#responsive-stacking), with one adjustment: `disableResponsiveBehavior` wraps the columns in an `MjmlGroup` `<div>`, so the container selector goes one level deeper (`… > td > div`). Drop the `mobile.belowMediaQuery` block entirely — columns never stack.
-
-```ts
-.iconStrip > table > tbody > tr > td > div {
-    display: flex !important;
-    gap: 20px !important;
-}
-/* column rules identical to Responsive Stacking */
-```
+Take the [Responsive Stacking](#responsive-stacking) styles and drop the `mobile.belowMediaQuery` block. Nothing else changes: `disableResponsiveBehavior` is already on the section, and it also suppresses MJML's own mobile auto-stack, which is the wanted result here.
 
 ## Breakpoint Content Switch
 
 Sometimes you cannot make both views from the same HTML, because the mobile view needs a different structure than the desktop view. Then put both layouts in the email and hide one of them.
 
 :::tip
-First try to make one layout that works at each width. Two layouts make twice as much markup, and columns already stack below `theme.breakpoints.mobile`.
+First try to make one layout that works at each width. Two layouts make twice as much markup, and the column patterns above already stack below `theme.breakpoints.mobile`.
 :::
 
 The switch has two parts:
 
-- The **default layout** is not hidden. It shows if the email client removes the `<style>` block, so make it the complete layout.
+- The **default layout** is not hidden. It shows if the email client removes the `<style>` block, so make it the complete layout. If it has columns, its section needs `disableResponsiveBehavior`, or the columns stack in exactly the clients this layout exists for.
 - The **mobile layout** is hidden with inline styles. A media query then hides the default layout and shows the mobile layout.
 
 ### The Pattern
@@ -423,7 +440,7 @@ registerStyles(
 The media query must cancel each hiding style. `display: block` with `max-height: 0` still shows nothing. `overflow: visible` is also necessary, because Yahoo Mail adds `overflow-x` and `overflow-y` if it finds `max-height`.
 :::
 
-Do not put the switch breakpoint below `theme.breakpoints.mobile`. The default layout then stacks its columns before the media query hides it. If you must, add `disableResponsiveBehavior` to its section. For `belowMediaQuery`, see [The `belowMediaQuery` Pattern](./5-customization.md#the-belowmediaquery-pattern).
+Do not put the switch breakpoint below `theme.breakpoints.mobile`. The default layout then stacks its columns before the media query hides it. For `belowMediaQuery`, see [The `belowMediaQuery` Pattern](./5-customization.md#the-belowmediaquery-pattern).
 
 ## Grouping Sections with a Shared Background
 

--- a/packages/mail-react/src/__stories__/layout-patterns/AsymmetricTwoColumnLayout.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/AsymmetricTwoColumnLayout.stories.tsx
@@ -35,6 +35,11 @@ const fluidColumnWidth = sectionInnerWidth - SMALL_COLUMN_WIDTH;
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
+            .asymmetricLayoutLeft__smallColumn {
+                width: ${SMALL_COLUMN_WIDTH}px !important;
+                max-width: ${SMALL_COLUMN_WIDTH}px !important;
+            }
+
             .asymmetricLayoutLeft__fluidColumn {
                 width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
                 max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
@@ -42,7 +47,9 @@ registerStyles(
         }
 
         ${theme.breakpoints.mobile.belowMediaQuery} {
+            .asymmetricLayoutLeft__smallColumn,
             .asymmetricLayoutLeft__fluidColumn {
+                display: block !important;
                 width: 100% !important;
                 max-width: 100% !important;
             }
@@ -76,7 +83,7 @@ export const SmallColumnLeft: StoryObj = {
                 </MjmlColumn>
             </MjmlSection>
 
-            <MjmlSection indent>
+            <MjmlSection indent disableResponsiveBehavior>
                 <MjmlColumn className="asymmetricLayoutLeft__smallColumn" width={`${SMALL_COLUMN_WIDTH}px`} verticalAlign="middle">
                     <MjmlImage
                         src={`https://picsum.photos/seed/1/${SMALL_COLUMN_WIDTH}/150`}
@@ -113,6 +120,11 @@ export const SmallColumnLeft: StoryObj = {
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
+            .asymmetricLayoutRight__smallColumn {
+                width: ${SMALL_COLUMN_WIDTH}px !important;
+                max-width: ${SMALL_COLUMN_WIDTH}px !important;
+            }
+
             .asymmetricLayoutRight__fluidColumn {
                 width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
                 max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
@@ -120,7 +132,9 @@ registerStyles(
         }
 
         ${theme.breakpoints.mobile.belowMediaQuery} {
+            .asymmetricLayoutRight__smallColumn,
             .asymmetricLayoutRight__fluidColumn {
+                display: block !important;
                 width: 100% !important;
                 max-width: 100% !important;
             }
@@ -154,7 +168,7 @@ export const SmallColumnRight: StoryObj = {
                 </MjmlColumn>
             </MjmlSection>
 
-            <MjmlSection indent>
+            <MjmlSection indent disableResponsiveBehavior>
                 <MjmlColumn
                     className="asymmetricLayoutRight__fluidColumn"
                     width={`${fluidColumnWidth}px`}
@@ -191,6 +205,11 @@ export const SmallColumnRight: StoryObj = {
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
+            .asymmetricLayoutRtl__smallColumn {
+                width: ${SMALL_COLUMN_WIDTH}px !important;
+                max-width: ${SMALL_COLUMN_WIDTH}px !important;
+            }
+
             .asymmetricLayoutRtl__fluidColumn {
                 width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
                 max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
@@ -198,7 +217,9 @@ registerStyles(
         }
 
         ${theme.breakpoints.mobile.belowMediaQuery} {
+            .asymmetricLayoutRtl__smallColumn,
             .asymmetricLayoutRtl__fluidColumn {
+                display: block !important;
                 width: 100% !important;
                 max-width: 100% !important;
             }
@@ -225,16 +246,17 @@ export const ReversedMobileStackOrder: StoryObj = {
                         Small column on the right, stacks on top on mobile
                     </MjmlText>
                     <MjmlText>
-                        Uses <code>direction=&quot;rtl&quot;</code> on the section to visually place the small column on the right on desktop, while
-                        keeping it first in source order so it stacks on top on mobile. A wrapper handles the indentation separately to avoid a 1px
-                        line artifact in Outlook.
+                        Uses <code>direction=&quot;rtl&quot;</code> to visually place the small column on the right on desktop, while keeping it first
+                        in source order so it stacks on top on mobile. The prop goes on the group that
+                        <code>disableResponsiveBehavior</code> adds, because that group writes its own <code>direction</code> and would otherwise
+                        cancel the value of the section. A wrapper handles the indentation separately to avoid a 1px line artifact in Outlook.
                     </MjmlText>
                     <MjmlSpacer height={30} />
                 </MjmlColumn>
             </MjmlSection>
 
             <MjmlWrapper padding={`0 ${sectionIndent}px`} backgroundColor={theme.colors.background.content}>
-                <MjmlSection direction="rtl">
+                <MjmlSection disableResponsiveBehavior slotProps={{ group: { direction: "rtl" } }}>
                     <MjmlColumn className="asymmetricLayoutRtl__smallColumn" width={`${SMALL_COLUMN_WIDTH}px`} verticalAlign="middle">
                         <MjmlImage
                             src={`https://picsum.photos/seed/3/${SMALL_COLUMN_WIDTH}/150`}

--- a/packages/mail-react/src/__stories__/layout-patterns/BreakpointContentSwitch.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/BreakpointContentSwitch.stories.tsx
@@ -89,7 +89,7 @@ registerStyles(
 
 function MailHeaderDefaultLayout({ className }: { className?: string }): ReactNode {
     return (
-        <MjmlSection indent className={className}>
+        <MjmlSection indent disableResponsiveBehavior className={className}>
             <MjmlColumn width="120px" verticalAlign="middle">
                 <MjmlImage src="https://picsum.photos/seed/4/240/80" alt="Logo" align="left" width={120} />
             </MjmlColumn>

--- a/packages/mail-react/src/__stories__/layout-patterns/SymmetricFourColumnLayout.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/SymmetricFourColumnLayout.stories.tsx
@@ -28,7 +28,7 @@ const theme = createTheme({
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
-            .symmetricFourColumnsSection > table > tbody > tr > td {
+            .symmetricFourColumnsSection > table > tbody > tr > td > div {
                 display: flex !important;
                 flex-direction: column !important;
                 gap: 20px !important;
@@ -62,7 +62,7 @@ export const Default: StoryObj = {
             const innerColumnWidth = `${((contentWidthPerColumn + columnGap) / availableContentWidth) * 100}%`;
 
             return (
-                <MjmlSection indent className="symmetricFourColumnsSection">
+                <MjmlSection indent disableResponsiveBehavior className="symmetricFourColumnsSection">
                     <MjmlColumn width={outerColumnWidth} paddingRight={halfColumnGap} className="symmetricFourColumnsSection__column">
                         <MjmlText variant="subheading" bottomSpacing>
                             First

--- a/packages/mail-react/src/__stories__/layout-patterns/SymmetricThreeColumnLayout.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/SymmetricThreeColumnLayout.stories.tsx
@@ -28,7 +28,7 @@ const theme = createTheme({
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
-            .symmetricThreeColumnsSection > table > tbody > tr > td {
+            .symmetricThreeColumnsSection > table > tbody > tr > td > div {
                 display: flex !important;
                 gap: 20px !important;
             }
@@ -47,7 +47,7 @@ registerStyles(
         }
 
         ${theme.breakpoints.mobile.belowMediaQuery} {
-            .symmetricThreeColumnsSection > table > tbody > tr > td {
+            .symmetricThreeColumnsSection > table > tbody > tr > td > div {
                 flex-direction: column !important;
             }
 
@@ -73,7 +73,7 @@ export const Default: StoryObj = {
             const innerColumnWidth = `${((contentWidthPerColumn + columnGap) / availableContentWidth) * 100}%`;
 
             return (
-                <MjmlSection indent className="symmetricThreeColumnsSection">
+                <MjmlSection indent disableResponsiveBehavior className="symmetricThreeColumnsSection">
                     <MjmlColumn width={outerColumnWidth} paddingRight={halfColumnGap} className="symmetricThreeColumnsSection__column">
                         <MjmlText variant="subheading" bottomSpacing>
                             First column
@@ -214,9 +214,8 @@ export const NeverStacks: StoryObj = {
                             so columns stay side-by-side at every viewport.
                         </MjmlText>
                         <MjmlText bottomSpacing>
-                            <code>disableResponsiveBehavior</code> wraps the columns in an <code>MjmlGroup</code> internally so MJML&apos;s own mobile
-                            auto-stack is suppressed even in clients that ignore the flex CSS. Because of that wrapper, the flex reset targets one
-                            level deeper (<code>… &gt; td &gt; div</code>) than in the default layout.
+                            Both layouts set <code>disableResponsiveBehavior</code> to get the inline widths. It also suppresses MJML&apos;s own
+                            mobile auto-stack, which is the wanted result here, so no <code>mobile</code> block replaces it.
                         </MjmlText>
                         <MjmlText>
                             Suitable for short, fixed-value rows — metrics, numeric summaries, icon strips — that remain readable even when narrow.

--- a/packages/mail-react/src/__stories__/layout-patterns/SymmetricTwoColumnLayout.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/SymmetricTwoColumnLayout.stories.tsx
@@ -27,6 +27,13 @@ const theme = createTheme({
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.mobile.belowMediaQuery} {
+            .twoColumnsSection__leftColumn,
+            .twoColumnsSection__rightColumn {
+                display: block !important;
+                width: 100% !important;
+                max-width: 100% !important;
+            }
+
             .twoColumnsSection__leftColumn > table > tbody > tr > td {
                 padding-right: 0 !important;
             }
@@ -50,7 +57,7 @@ export const Default: StoryObj = {
             const halfGap = columnGap / 2;
 
             return (
-                <MjmlSection indent className="twoColumnsSection">
+                <MjmlSection indent disableResponsiveBehavior className="twoColumnsSection">
                     <MjmlColumn className="twoColumnsSection__leftColumn" paddingRight={halfGap}>
                         <MjmlText variant="subheading" bottomSpacing>
                             Left column

--- a/skills/dextinity-mail-react/SKILL.md
+++ b/skills/dextinity-mail-react/SKILL.md
@@ -91,7 +91,9 @@ const halfGap = columnGap / 2;
 
 On mobile, reset the gap padding so content stretches full-width, and add a vertical margin between the stacked columns. Column padding compiles to an inner `<td>`, so target it via `.className > table > tbody > tr > td`.
 
-→ For complete two-column patterns (equal-width and fixed+fluid) with responsive styles, CSS targeting rules, and the `direction="rtl"` technique for controlling mobile stack order, read [`references/layout-patterns.md`](references/layout-patterns.md).
+Set `disableResponsiveBehavior` on **every** section with more than one column. It wraps the columns in an `MjmlGroup`, which is what makes MJML write their widths inline; without it the widths exist only in a `min-width` media query, and clients that drop that query — GMX and Web.de, for example — show the columns stacked. The group never stacks by itself, so write the mobile stacking into `registerStyles`, and target the column container one level deeper (`… > td > div`).
+
+→ For complete patterns — two columns, three or more, fixed+fluid — with responsive styles, CSS targeting rules, the stacking strategies, and the `direction="rtl"` technique for controlling mobile stack order, read [`references/layout-patterns.md`](references/layout-patterns.md).
 
 ### Ending Tags
 
@@ -115,6 +117,8 @@ Email styling follows a **desktop-first** approach:
 
 Never rely on `<style>` blocks for base/desktop layout. Set all default styles inline via MJML component props.
 
+MJML breaks this rule for column widths: it puts them in a `min-width` media query, so a multi-column section stacks in any client that drops that query — GMX and Web.de, for example. See [Multi-Column Layouts](#multi-column-layouts).
+
 ### Prefer Theme Breakpoints
 
 Always use `theme.breakpoints.*.belowMediaQuery` inside `registerStyles` instead of hardcoding media query values. This keeps responsive styles in sync with the theme configuration. If a breakpoint value is needed repeatedly but doesn't exist in the theme, add it via `createBreakpoint` and module augmentation rather than duplicating raw media queries. Reserve hardcoded media queries for genuinely one-off values.
@@ -125,7 +129,9 @@ Always use `theme.breakpoints.*.belowMediaQuery` inside `registerStyles` instead
 
 Sometimes you cannot make both views from the same HTML, because the mobile view needs a different structure than the desktop view. Then put both layouts in the email and hide one of them: inline styles hide the mobile layout, and a media query in `registerStyles` switches the two.
 
-Two layouts make twice as much markup, so first try to make one layout that works at each width. Columns already stack on mobile.
+Two layouts make twice as much markup, so first try to make one layout that works at each width. The column patterns already stack on mobile.
+
+The default layout is the one that shows when the `<style>` block is gone, so if it has columns its section needs `disableResponsiveBehavior` as well.
 
 → For the hiding styles, the extra step classic Outlook needs, and what to avoid, read [`references/layout-patterns.md`](references/layout-patterns.md) → Breakpoint Content Switch.
 

--- a/skills/dextinity-mail-react/references/components-and-theme.md
+++ b/skills/dextinity-mail-react/references/components-and-theme.md
@@ -242,6 +242,8 @@ Full-width horizontal row with theme integration.
 </MjmlSection>
 ```
 
+`disableResponsiveBehavior` wraps the columns in an `MjmlGroup`. Every multi-column section needs it, because the group is what makes MJML write the column widths inline — see [`layout-patterns.md`](layout-patterns.md) → Column Widths Must Be Inline.
+
 Indentation values come from `theme.sizes.contentIndentation`, which supports responsive values.
 
 **Inside `MjmlWrapper`:** the theme-default `backgroundColor` is suppressed so the wrapper's background shows through. An explicit `backgroundColor` prop still wins.

--- a/skills/dextinity-mail-react/references/layout-patterns.md
+++ b/skills/dextinity-mail-react/references/layout-patterns.md
@@ -25,6 +25,19 @@ Follow the BEM convention with camelCase blocks. Adapt the block name to the com
 
 ---
 
+## Column Widths Must Be Inline
+
+Set `disableResponsiveBehavior` on **every** section with more than one column, including sections that are meant to stack. The prop wraps the columns in an `MjmlGroup`, which is what makes MJML write their widths inline. Without it the widths exist only in a `min-width` media query, and clients that drop that query — GMX and Web.de, for example — show the columns stacked.
+
+Two things follow:
+
+- Write the mobile stacking yourself, in `theme.breakpoints.mobile.belowMediaQuery`. A group never stacks by itself.
+- Target the column container one level deeper. The group adds a `<div>`, so a flex container is `… > td > div`.
+
+Inside a group, a column without a `width` prop gets `parseInt(100 / siblings)%` — `33%` for three columns, not `33.33%`. Set explicit widths when the count does not divide 100 evenly.
+
+---
+
 ## Symmetric Two-Column Layout (Equal Width)
 
 Two equal-width columns with a gap between them, stacking vertically on mobile.
@@ -39,7 +52,7 @@ const TwoColumnsSection = () => {
     const halfGap = columnGap / 2;
 
     return (
-        <MjmlSection indent className="twoColumnsSection">
+        <MjmlSection indent disableResponsiveBehavior className="twoColumnsSection">
             <MjmlColumn className="twoColumnsSection__leftColumn" paddingRight={halfGap}>
                 <MjmlText>Left column content.</MjmlText>
             </MjmlColumn>
@@ -53,12 +66,19 @@ const TwoColumnsSection = () => {
 
 ### Responsive Stacking
 
-On mobile, columns stack vertically. Reset the gap padding so content stretches full-width, and add a vertical margin between the stacked columns:
+The group suppresses MJML's own stacking, so write it yourself. Reset the gap padding so content stretches full-width, and add a vertical margin between the stacked columns:
 
 ```ts
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.mobile.belowMediaQuery} {
+            .twoColumnsSection__leftColumn,
+            .twoColumnsSection__rightColumn {
+                display: block !important;
+                width: 100% !important;
+                max-width: 100% !important;
+            }
+
             .twoColumnsSection__leftColumn > table > tbody > tr > td {
                 padding-right: 0 !important;
             }
@@ -105,7 +125,7 @@ Scales to any N; 3 and 4 differ only in how many middle columns you repeat. Perc
 Three columns shown; for four or more, repeat the middle-column.
 
 ```tsx
-<MjmlSection indent className="multiColumnSection">
+<MjmlSection indent disableResponsiveBehavior className="multiColumnSection">
     <MjmlColumn className="multiColumnSection__column" width={outerColumnWidth} paddingRight={halfColumnGap}>
         …
     </MjmlColumn>
@@ -122,55 +142,15 @@ Three columns shown; for four or more, repeat the middle-column.
 
 Stacking is a **design decision per component**, not a function of column count. Do not assume the user wants the storybook default — these are starting points, not rules. If it is unclear which strategy fits, infer from the content (dense text vs. short labels vs. fixed-width icons/numbers) or ask.
 
-| Strategy            | When to pick it                                                                         | How it's implemented                                                               |
-| ------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| A. Stack at mobile  | Columns stay readable while narrowing below `bodyWidth` (e.g., 3-col storybook default) | Flex reset at `default` + stack at `mobile`                                        |
-| B. Stack at default | Columns would get too cramped below `bodyWidth` (e.g., 4-col storybook default)         | Flex reset that stacks at `default`                                                |
-| C. Never stack      | Short fixed content that must remain horizontal (numeric rows, icon strips)             | `disableResponsiveBehavior` + flex reset one level deeper (targets `… > td > div`) |
+| Strategy            | When to pick it                                                                         | How it's implemented                        |
+| ------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------- |
+| A. Stack at mobile  | Columns stay readable while narrowing below `bodyWidth` (e.g., 3-col storybook default) | Flex reset at `default` + stack at `mobile` |
+| B. Stack at default | Columns would get too cramped below `bodyWidth` (e.g., 4-col storybook default)         | Flex reset that stacks at `default`         |
+| C. Never stack      | Short fixed content that must remain horizontal (numeric rows, icon strips)             | Flex reset at `default`, no `mobile` block  |
 
-All three strategies share the same flex reset on the element that directly contains the columns — it neutralises the compensated inline widths so content areas stay equal at every viewport (without it, percentage widths and pixel paddings drift apart below `bodyWidth`, making columns unequal by a few pixels). For A and B the container is the section's inner `<td>`; for C it is the `MjmlGroup` wrapper `<div>` that `disableResponsiveBehavior` inserts between the `<td>` and the columns, so the selector goes one level deeper (`… > td > div`). They also differ at `mobile.belowMediaQuery`: A adds a stack override, B collapses into the `default` block and stacks immediately, C adds nothing. Strategy C additionally needs `disableResponsiveBehavior` on the section — MJML auto-stacks below its own mobile breakpoint by default, and this prop wraps the columns in an `MjmlGroup` internally so the auto-stack is suppressed even in clients that ignore the flex CSS.
+All three strategies share the same flex reset on the `MjmlGroup` `<div>` that directly contains the columns — it neutralises the compensated inline widths so content areas stay equal at every viewport (without it, percentage widths and pixel paddings drift apart below `bodyWidth`, making columns unequal by a few pixels). They differ only at `mobile.belowMediaQuery`: A adds a stack override, B collapses into the `default` block and stacks immediately, C adds nothing. The section carries `disableResponsiveBehavior` in every case, because the columns need their inline widths — see [Column Widths Must Be Inline](#column-widths-must-be-inline).
 
 **Strategy A** — keep the horizontal intermediate state, stack at mobile:
-
-```ts
-${theme.breakpoints.default.belowMediaQuery} {
-    .multiColumnSection > table > tbody > tr > td {
-        display: flex !important;
-        gap: 20px !important;
-    }
-    .multiColumnSection__column {
-        flex: 1 1 0% !important;
-        width: auto !important;
-        max-width: none !important;
-        display: block !important;
-    }
-    .multiColumnSection__column > table > tbody > tr > td {
-        padding-left: 0 !important;
-        padding-right: 0 !important;
-    }
-}
-
-${theme.breakpoints.mobile.belowMediaQuery} {
-    .multiColumnSection > table > tbody > tr > td {
-        flex-direction: column !important;
-    }
-    .multiColumnSection__column {
-        flex: none !important;
-        width: 100% !important;
-        max-width: 100% !important;
-    }
-}
-```
-
-**Strategy B** — collapse the two blocks: put `flex-direction: column` and `width: 100%` in the `default.belowMediaQuery` block and drop the `mobile.belowMediaQuery` block.
-
-**Strategy C** — set `disableResponsiveBehavior` on the section and apply Strategy A's flex reset one level deeper (the group wrapper), dropping the `mobile.belowMediaQuery` block:
-
-```tsx
-<MjmlSection indent disableResponsiveBehavior className="multiColumnSection">
-    {/* …columns as in the pattern above… */}
-</MjmlSection>
-```
 
 ```ts
 ${theme.breakpoints.default.belowMediaQuery} {
@@ -189,9 +169,22 @@ ${theme.breakpoints.default.belowMediaQuery} {
         padding-right: 0 !important;
     }
 }
+
+${theme.breakpoints.mobile.belowMediaQuery} {
+    .multiColumnSection > table > tbody > tr > td > div {
+        flex-direction: column !important;
+    }
+    .multiColumnSection__column {
+        flex: none !important;
+        width: 100% !important;
+        max-width: 100% !important;
+    }
+}
 ```
 
-The only difference from Strategy A's `default.belowMediaQuery` block is the `> div` in the first selector — `disableResponsiveBehavior` wraps the columns in an `MjmlGroup` `<div>` inside the `<td>`, so the flex container has to target that wrapper instead of the `<td>` to make the columns its direct flex children. Applying flex to the `<td>` instead would give it a single flex item (the wrapper), and the block-display rule on the columns below would make them stack vertically inside that wrapper.
+**Strategy B** — collapse the two blocks: put `flex-direction: column` and `width: 100%` in the `default.belowMediaQuery` block and drop the `mobile.belowMediaQuery` block.
+
+**Strategy C** — keep Strategy A's `default.belowMediaQuery` block and drop the `mobile.belowMediaQuery` block. The columns then hold their flex widths at every viewport.
 
 ---
 
@@ -219,7 +212,7 @@ const fluidColumnWidth = sectionInnerWidth - SMALL_COLUMN_WIDTH;
 Gap is created by padding on the fluid column's inner edge:
 
 ```tsx
-<MjmlSection indent>
+<MjmlSection indent disableResponsiveBehavior>
     <MjmlColumn className="imageTextLayout__smallColumn" width={`${SMALL_COLUMN_WIDTH}px`} verticalAlign="middle">
         <MjmlImage src="..." alt="..." width={SMALL_COLUMN_WIDTH} />
     </MjmlColumn>
@@ -233,12 +226,19 @@ To place the small column on the right, swap column order and move padding to `p
 
 ### Two-Breakpoint Responsive Behavior
 
-Fixed-width columns overflow between `bodyWidth` and the mobile stacking breakpoint. Use two stacked `belowMediaQuery` blocks — the later one overrides the earlier via cascade order:
+Fixed-width columns overflow between `bodyWidth` and the mobile stacking breakpoint. Use two stacked `belowMediaQuery` blocks — the later one overrides the earlier via cascade order.
+
+Inside a group a pixel width is written inline as a percentage of the section, so the fixed column also needs its pixel width back below `bodyWidth`, where the section is narrower:
 
 ```ts
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
+            .imageTextLayout__smallColumn {
+                width: ${SMALL_COLUMN_WIDTH}px !important;
+                max-width: ${SMALL_COLUMN_WIDTH}px !important;
+            }
+
             .imageTextLayout__fluidColumn {
                 width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
                 max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
@@ -246,7 +246,9 @@ registerStyles(
         }
 
         ${theme.breakpoints.mobile.belowMediaQuery} {
+            .imageTextLayout__smallColumn,
             .imageTextLayout__fluidColumn {
+                display: block !important;
                 width: 100% !important;
                 max-width: 100% !important;
             }
@@ -267,11 +269,11 @@ This cascade-based approach is the idiomatic pattern. Never use hardcoded `@medi
 
 ### Controlling Mobile Stack Order with `direction="rtl"`
 
-MJML stacks columns in source order on mobile. To make a right-side column stack on top, use `direction="rtl"` on the section to flip the desktop visual order while keeping the source (and mobile stacking) order:
+MJML stacks columns in source order on mobile. To make a right-side column stack on top, use `direction="rtl"` to flip the desktop visual order while keeping the source (and mobile stacking) order. The prop goes on the group, not on the section: `MjmlGroup` writes its own `direction` and defaults it to `ltr`, so a value on the section would be cancelled.
 
 ```tsx
 <MjmlWrapper padding={`0 ${sectionIndent}px`} backgroundColor={theme.colors.background.content}>
-    <MjmlSection direction="rtl">
+    <MjmlSection disableResponsiveBehavior slotProps={{ group: { direction: "rtl" } }}>
         <MjmlColumn className="layout__smallColumn" width={`${SMALL_COLUMN_WIDTH}px`}>
             <MjmlImage src="..." alt="..." width={SMALL_COLUMN_WIDTH} />
         </MjmlColumn>
@@ -293,9 +295,9 @@ When using `direction="rtl"`:
 
 Sometimes you cannot make both views from the same HTML, because the mobile view needs a different structure than the desktop view. Then put both layouts in the email and hide one of them.
 
-Two layouts make twice as much markup, so first try to make one layout that works at each width. Columns already stack below `theme.breakpoints.mobile`.
+Two layouts make twice as much markup, so first try to make one layout that works at each width. The column patterns above already stack below `theme.breakpoints.mobile`.
 
-- The **default layout** is not hidden. It shows if the email client removes the `<style>` block, so make it the complete layout.
+- The **default layout** is not hidden. It shows if the email client removes the `<style>` block, so make it the complete layout. If it has columns, its section needs `disableResponsiveBehavior`, or the columns stack in exactly the clients this layout exists for.
 - The **mobile layout** is hidden with inline styles. A media query then hides the default layout and shows the mobile layout.
 
 Make a component for each layout, and start it at its `MjmlSection`. Then the call site shows only the switch. Put the hiding styles on a `<div>` around the section: a section becomes a table, and `max-height` does not work on a table.
@@ -353,7 +355,7 @@ Write only `mso-hide: all` on those elements. `display: none` there breaks the t
 
 The media query must cancel each hiding style. `display: block` with `max-height: 0` still shows nothing. `overflow: visible` is also necessary, because Yahoo Mail adds `overflow-x` and `overflow-y` if it finds `max-height`.
 
-Do not put the switch breakpoint below `theme.breakpoints.mobile`. The default layout then stacks its columns before the media query hides it. If you must, add `disableResponsiveBehavior` to its section.
+Do not put the switch breakpoint below `theme.breakpoints.mobile`. The default layout then stacks its columns before the media query hides it.
 
 Do not use a conditional comment (`<!--[if !mso]>`) to hide a layout. MJML puts its own `[if mso]` comments around each section, and their `<![endif]-->` closes your comment too early. `MjmlConditionalComment` selects an email client, not a screen width.
 

--- a/skills/dextinity-mail-react/references/styling-and-customization.md
+++ b/skills/dextinity-mail-react/references/styling-and-customization.md
@@ -27,6 +27,8 @@ This means:
 
 The base email must look correct with zero CSS from `<style>` blocks. Media queries are layered on top as progressive enhancement for mobile viewports.
 
+MJML's column widths are the exception: they live in a `min-width` media query, not inline. A section with more than one column needs `disableResponsiveBehavior` — see [`layout-patterns.md`](layout-patterns.md) → Column Widths Must Be Inline.
+
 ### Why `!important`?
 
 Email clients inline all styles during processing. Since inline styles have higher CSS specificity than `<style>` block rules, responsive overrides must use `!important` to win. Every property inside a media query override should have `!important`.


### PR DESCRIPTION
Some mail clients, such as GMX and Web.de, do not apply the `<style>` block in the head.

MJML keeps the real column widths only there, in a `min-width` media query, and writes `width: 100%` inline instead.
Every multi-column example therefore rendered as a stack in those clients, with the inner-edge gap padding left behind as an indent on the second column.

The examples with that `<style>` block removed:

| Before | After |
| --- | --- |
| <img width="380" alt="before-two-column" src="https://github.com/user-attachments/assets/22afc9cf-f2e0-4f3a-bd40-75ed9e35b0e8" /> | <img width="380" alt="after-two-column" src="https://github.com/user-attachments/assets/9d51434e-7fee-4ef8-a5a7-cb83d1303a71" /> |
| <img width="380" alt="before-three-column" src="https://github.com/user-attachments/assets/b54b345e-404f-4a3f-b198-5ab8d185e3c7" /> | <img width="380" alt="after-three-column" src="https://github.com/user-attachments/assets/62a41187-db8f-4037-96d9-a1496f8ac87f" /> |
| <img width="380" alt="before-asymmetric" src="https://github.com/user-attachments/assets/db58e185-5063-4a60-842b-29455f9084c8" /> | <img width="380" alt="after-asymmetric" src="https://github.com/user-attachments/assets/56f9e5b4-7e53-45d3-a5f6-5be40b3a7bdd" /> |

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13730