### PR TITLE
Mark v10 and later as supported in the security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ The versions of the project that are currently supported with security updates.
 |   < 8.x | :x:                                   |
 
 > [!NOTE]
-> Version 9.x is not supported. Use 10.x instead, which is largely compatible with 9.x as it only contains the COMET -> Dextinity rename. See the [migration guide from v9 to v10](https://cms-docs.dextinity.com/docs/migration-guide/migration-from-v9-to-v10).
+> Version 9.x is not supported. Use 10.x instead, which is largely compatible with 9.x: every breaking change in 10.x is part of the COMET -> Dextinity rename. See the [migration guide from v9 to v10](https://cms-docs.dextinity.com/docs/migration-guide/migration-from-v9-to-v10).
 
 ## Reporting a vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ The versions of the project that are currently supported with security updates.
 |   < 8.x | :x:                                   |
 
 > [!NOTE]
-> Version 9.x is not supported. Use 10.x instead, which is largely compatible with 9.x as it only contains the COMET -> Dextinity rename.
+> Version 9.x is not supported. Use 10.x instead, which is largely compatible with 9.x as it only contains the COMET -> Dextinity rename. See the [migration guide from v9 to v10](https://cms-docs.dextinity.com/docs/migration-guide/migration-from-v9-to-v10).
 
 ## Reporting a vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,10 +5,14 @@
 The versions of the project that are currently supported with security updates.
 
 | Version | Supported                             |
-|--------:|:--------------------------------------|
-|     9.x | :white_check_mark:                    |
+| ------: | :------------------------------------ |
+|  ≥ 10.x | :white_check_mark:                    |
+|     9.x | :x: (use 10.x instead, see note)      |
 |     8.x | :white_check_mark: (until 2027-07-07) |
 |   < 8.x | :x:                                   |
+
+> [!NOTE]
+> Version 9.x is not supported. Use 10.x instead, which is largely compatible with 9.x as it only contains the COMET -> Dextinity rename.
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
## Status quo

The supported versions table in `SECURITY.md` still lists `9.x` as supported and does not mention `10.x` at all, so it tells users to stay on a version that no longer receives security updates and gives no guidance for the current major.

## Change

- `10.x` and later are marked as supported.
- `9.x` is marked as unsupported, with a note that `10.x` is a largely compatible replacement because every breaking change in it is part of the COMET -> Dextinity rename. The note links the [migration guide from v9 to v10](https://cms-docs.dextinity.com/docs/migration-guide/migration-from-v9-to-v10).
- Support for `8.x` stays unchanged (until 2027-07-07).

No changeset, as this is a documentation-only change and does not warrant a package release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwicBS8jUVYsZqGmrFhxyB)_
