### PR TITLE
Show the mail addon UI in a composed Storybook

### DIFF
--- a/dev-pm.config.ts
+++ b/dev-pm.config.ts
@@ -137,7 +137,7 @@ export default defineConfig({
         {
             name: "mail-react-storybook",
             script: "pnpm --filter @dextinity/mail-react run storybook",
-            group: ["mail-react"],
+            group: ["mail-react", "storybook", "docs"],
         },
 
         //group brevo
@@ -270,7 +270,7 @@ export default defineConfig({
             name: "storybook",
             script: "pnpm --filter dextinity-storybook run storybook",
             group: ["storybook", "docs"],
-            waitOn: ["tcp:26646", "tcp:26647"], // storybook-dextinity-admin, storybook-dextinity-cms-admin
+            waitOn: ["tcp:26646", "tcp:26647", "tcp:6066"], // storybook-dextinity-admin, storybook-dextinity-cms-admin, mail-react-storybook
         },
         {
             name: "docs",

--- a/packages/mail-react/src/storybook/MailRendererDecorator.tsx
+++ b/packages/mail-react/src/storybook/MailRendererDecorator.tsx
@@ -25,9 +25,10 @@ export function MailRendererDecorator(Story: () => React.JSX.Element, context: {
         console.warn("MJML warning:", warning);
     }
 
-    const html = globals.usePublicImageUrls ? replaceImagesWithPublicUrl(rawHtml) : rawHtml;
+    const usePublicImageUrls = Boolean(globals.usePublicImageUrls);
+    const html = usePublicImageUrls ? replaceImagesWithPublicUrl(rawHtml) : rawHtml;
 
-    emit(RENDER_RESULT_EVENT, { html, mjmlWarnings });
+    emit(RENDER_RESULT_EVENT, { html, mjmlWarnings, usePublicImageUrls });
 
     return <div dangerouslySetInnerHTML={{ __html: html }} />;
 }

--- a/packages/mail-react/src/storybook/UsePublicImageUrlsToggle.tsx
+++ b/packages/mail-react/src/storybook/UsePublicImageUrlsToggle.tsx
@@ -1,20 +1,31 @@
 /** @jsxRuntime classic */
 /** @jsx React.createElement */
-import React from "react";
+import React, { useState } from "react";
 import { IconButton, TooltipNote, WithTooltip } from "storybook/internal/components";
-import { useGlobals } from "storybook/manager-api";
+import { UPDATE_GLOBALS } from "storybook/internal/core-events";
+import { useChannel } from "storybook/manager-api";
+
+const RENDER_RESULT_EVENT = "dextinity-mail-render-result";
 
 export function UsePublicImageUrlsToggle() {
-    const [globals, updateGlobals] = useGlobals();
-    const isActive = Boolean(globals.usePublicImageUrls);
+    const [isUsingPublicImageUrls, setIsUsingPublicImageUrls] = useState(false);
+
+    // The manager shares globals only with its own preview, not with a referenced Storybook, so `useGlobals` can neither read nor set this value here.
+    const emit = useChannel({
+        [RENDER_RESULT_EVENT]: ({ usePublicImageUrls }: { usePublicImageUrls: boolean }) => {
+            setIsUsingPublicImageUrls(usePublicImageUrls);
+        },
+    });
+
+    const togglePublicImageUrls = () => emit(UPDATE_GLOBALS, { globals: { usePublicImageUrls: !isUsingPublicImageUrls } });
 
     return (
         <WithTooltip
             tooltip={<TooltipNote note="Helpful to test with real images on external devices that cannot access localhost, e.g. Email on Acid." />}
             trigger="hover"
         >
-            <IconButton size="small" active={isActive} onClick={() => updateGlobals({ usePublicImageUrls: !isActive })}>
-                <input type="checkbox" checked={isActive} readOnly style={{ pointerEvents: "none", marginLeft: 4 }} />
+            <IconButton size="small" active={isUsingPublicImageUrls} onClick={togglePublicImageUrls}>
+                <input type="checkbox" checked={isUsingPublicImageUrls} readOnly style={{ pointerEvents: "none", marginLeft: 4 }} />
                 Use public image URLs
                 <span role="img" aria-label="info">
                     ℹ️

--- a/packages/mail-react/src/storybook/index.ts
+++ b/packages/mail-react/src/storybook/index.ts
@@ -7,6 +7,14 @@ export function managerEntries(existing: string[] = []) {
     return [...existing, resolve(directoryOfThisFile, "manager.js")];
 }
 
-export function previewAnnotations(input: string[] = []) {
-    return [...input, resolve(directoryOfThisFile, "preview.js")];
+type PreviewAnnotationsOptions = {
+    /**
+     * Set this when this Storybook's own stories must not be rendered as emails.
+     * The addon UI stays registered and appears on mail stories from a composed Storybook.
+     */
+    disablePreviewAnnotations?: boolean;
+};
+
+export function previewAnnotations(input: string[] = [], { disablePreviewAnnotations }: PreviewAnnotationsOptions = {}) {
+    return disablePreviewAnnotations ? input : [...input, resolve(directoryOfThisFile, "preview.js")];
 }

--- a/packages/mail-react/src/storybook/manager.tsx
+++ b/packages/mail-react/src/storybook/manager.tsx
@@ -1,30 +1,46 @@
 /** @jsxRuntime classic */
 /** @jsx React.createElement */
-import React from "react";
-import { addons, types } from "storybook/manager-api";
+import React, { type PropsWithChildren, type ReactNode } from "react";
+import { addons, types, useParameter } from "storybook/manager-api";
 
 import { CopyMailHtmlButton } from "./CopyMailHtmlButton.js";
 import { MjmlWarningsPanel, MjmlWarningsPanelTitle } from "./MjmlWarningsPanel.js";
 import { UsePublicImageUrlsToggle } from "./UsePublicImageUrlsToggle.js";
 
 const ADDON_ID = "dextinity-mail-react";
+const ADDON_UI_PARAMETER = "showDextinityMailAddonUi";
+
+function WhenAddonUiEnabled({ children }: PropsWithChildren): ReactNode {
+    const shouldShowAddonUi = useParameter(ADDON_UI_PARAMETER, false);
+
+    return shouldShowAddonUi ? children : null;
+}
 
 addons.register(ADDON_ID, () => {
     addons.add(`${ADDON_ID}/copy-html`, {
         type: types.TOOL,
         title: "Copy Mail HTML",
-        render: () => <CopyMailHtmlButton />,
+        render: () => (
+            <WhenAddonUiEnabled>
+                <CopyMailHtmlButton />
+            </WhenAddonUiEnabled>
+        ),
     });
 
     addons.add(`${ADDON_ID}/public-urls`, {
         type: types.TOOL,
         title: "Use public image URLs",
-        render: () => <UsePublicImageUrlsToggle />,
+        render: () => (
+            <WhenAddonUiEnabled>
+                <UsePublicImageUrlsToggle />
+            </WhenAddonUiEnabled>
+        ),
     });
 
     addons.add(`${ADDON_ID}/mjml-warnings`, {
         type: types.PANEL,
         title: () => <MjmlWarningsPanelTitle />,
+        disabled: (parameters) => !parameters?.[ADDON_UI_PARAMETER],
         render: ({ active }) => <MjmlWarningsPanel active={Boolean(active)} />,
     });
 });

--- a/packages/mail-react/src/storybook/preview.ts
+++ b/packages/mail-react/src/storybook/preview.ts
@@ -7,6 +7,7 @@ export const initialGlobals = {
 };
 
 export const parameters = {
+    showDextinityMailAddonUi: true,
     viewport: {
         options: {
             mobile: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2819,6 +2819,9 @@ importers:
       '@dextinity/eslint-config':
         specifier: workspace:*
         version: link:../packages/eslint-config
+      '@dextinity/mail-react':
+        specifier: workspace:*
+        version: link:../packages/mail-react
       '@faker-js/faker':
         specifier: ^10.4.0
         version: 10.4.0

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -16,6 +16,7 @@ const config: StorybookConfig = {
             },
         },
         "@storybook/addon-vitest",
+        { name: "@dextinity/mail-react/storybook", options: { disablePreviewAnnotations: true } },
     ],
 
     env: (config) => ({

--- a/storybook/eslint.config.mjs
+++ b/storybook/eslint.config.mjs
@@ -16,6 +16,8 @@ export default defineConfig([
             "@dextinity/no-other-module-relative-import": "off",
             "react/react-in-jsx-scope": "off",
             "react/jsx-no-literals": "off",
+            // The dependencies can only list the package `@dextinity/mail-react`, while the rule looks for the addon name with the `/storybook` subpath.
+            "storybook/no-uninstalled-addons": ["error", { ignore: ["@dextinity/mail-react/storybook"] }],
         },
     },
 ]);

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -58,6 +58,7 @@
         "@babel/cli": "^7.29.7",
         "@dextinity/admin-babel-preset": "workspace:*",
         "@dextinity/eslint-config": "workspace:*",
+        "@dextinity/mail-react": "workspace:*",
         "@faker-js/faker": "^10.4.0",
         "@graphql-mocks/network-msw": "^0.4.4",
         "@storybook/addon-docs": "^10.3.5",


### PR DESCRIPTION
The Storybook in `storybook/` composes the mail Storybook.
Composition loads only the preview of a referenced Storybook, not its manager, so the addon's toolbar buttons and the MJML warnings panel were missing from the mail stories shown there.