### PR TITLE
admin-rte: Enable TypeScript strict mode

### DIFF
--- a/.changeset/admin-rte-strict-mode.md
+++ b/.changeset/admin-rte-strict-mode.md
@@ -4,6 +4,6 @@
 
 Type `requiredValidator` and `ControlButton`'s `onButtonClick` more precisely
 
-`requiredValidator` is no longer declared as a `FieldValidator`. Its optional `meta` parameter made the type invariant in the field value, which kept the validator from being used for a `string`-valued field.
+`requiredValidator` is now generic over the field value. `FieldValidator` is invariant in it, so the previous single instantiation could not be passed to a `string`-valued `Field`.
 
 `ControlButton` receives its `onButtonClick` handler with a `MouseEvent<HTMLButtonElement>`, matching the `button` element the handler is attached to.

--- a/.changeset/admin-rte-strict-mode.md
+++ b/.changeset/admin-rte-strict-mode.md
@@ -1,0 +1,9 @@
+---
+"@dextinity/admin-rte": patch
+---
+
+Type `requiredValidator` and `ControlButton`'s `onButtonClick` more precisely
+
+`requiredValidator` is no longer declared as a `FieldValidator`. Its optional `meta` parameter made the type invariant in the field value, which kept the validator from being used for a `string`-valued field.
+
+`ControlButton` receives its `onButtonClick` handler with a `MouseEvent<HTMLButtonElement>`, matching the `button` element the handler is attached to.

--- a/packages/admin/admin-rte/src/core/Controls/ControlButton.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/ControlButton.tsx
@@ -72,7 +72,7 @@ export interface IProps
     }> {
     disabled?: boolean;
     selected?: boolean;
-    onButtonClick?: (e: MouseEvent) => void;
+    onButtonClick?: (e: MouseEvent<HTMLButtonElement>) => void;
     icon?: ForwardRefExoticComponent<Omit<SvgIconProps, "ref"> & RefAttributes<SVGSVGElement>>;
 
     /** @deprecated use icon instead */

--- a/packages/admin/admin-rte/src/core/Controls/useBlockTypes.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/useBlockTypes.tsx
@@ -44,9 +44,6 @@ const createFeaturesFromBlocktypeMap =
             })),
     ];
 
-// Not `SelectChangeEvent<DraftBlockType>`: the `Select` slot is built with `createComponentSlot`, which does not
-// forward MUI's generic, so its `onChange` is typed with an `unknown` value. Under `strictFunctionTypes` a handler
-// declaring a narrower value is not assignable to it, so the event has to be typed as the slot passes it.
 type BlockChangeEvent = SelectChangeEvent<unknown>;
 
 export interface BlockTypesApi {
@@ -90,9 +87,6 @@ export default function useBlockTypes({
         (e: BlockChangeEvent) => {
             e.preventDefault();
 
-            // `DraftBlockType` is a string, so the `unknown` value has to be narrowed before it can be used as one.
-            // Every block type `MenuItem` is keyed by its block type, so anything else cannot occur and is treated
-            // like the empty selection below.
             const blockType = typeof e.target.value === "string" ? e.target.value : undefined;
 
             if (!blockType) {

--- a/packages/admin/admin-rte/src/core/Controls/useBlockTypes.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/useBlockTypes.tsx
@@ -44,6 +44,9 @@ const createFeaturesFromBlocktypeMap =
             })),
     ];
 
+// Not `SelectChangeEvent<DraftBlockType>`: the `Select` slot is built with `createComponentSlot`, which does not
+// forward MUI's generic, so its `onChange` is typed with an `unknown` value. Under `strictFunctionTypes` a handler
+// declaring a narrower value is not assignable to it, so the event has to be typed as the slot passes it.
 type BlockChangeEvent = SelectChangeEvent<unknown>;
 
 export interface BlockTypesApi {
@@ -87,6 +90,9 @@ export default function useBlockTypes({
         (e: BlockChangeEvent) => {
             e.preventDefault();
 
+            // `DraftBlockType` is a string, so the `unknown` value has to be narrowed before it can be used as one.
+            // Every block type `MenuItem` is keyed by its block type, so anything else cannot occur and is treated
+            // like the empty selection below.
             const blockType = typeof e.target.value === "string" ? e.target.value : undefined;
 
             if (!blockType) {

--- a/packages/admin/admin-rte/src/core/Controls/useBlockTypes.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/useBlockTypes.tsx
@@ -44,7 +44,7 @@ const createFeaturesFromBlocktypeMap =
             })),
     ];
 
-type BlockChangeEvent = SelectChangeEvent<DraftBlockType>;
+type BlockChangeEvent = SelectChangeEvent<unknown>;
 
 export interface BlockTypesApi {
     dropdownFeatures: IFeatureConfig[];
@@ -87,13 +87,15 @@ export default function useBlockTypes({
         (e: BlockChangeEvent) => {
             e.preventDefault();
 
-            if (!e.target.value) {
+            const blockType = typeof e.target.value === "string" ? e.target.value : undefined;
+
+            if (!blockType) {
                 const currentBlock = getCurrentBlock(editorState);
                 if (currentBlock) {
                     setEditorState(RichUtils.toggleBlockType(editorState, currentBlock.getType()));
                 }
             } else {
-                setEditorState(RichUtils.toggleBlockType(editorState, e.target.value));
+                setEditorState(RichUtils.toggleBlockType(editorState, blockType));
             }
             // keeps editor focused
             setTimeout(() => {

--- a/packages/admin/admin-rte/src/core/Controls/useInlineStyleType.tsx
+++ b/packages/admin/admin-rte/src/core/Controls/useInlineStyleType.tsx
@@ -1,7 +1,7 @@
 import { RteBold, RteItalic, RteStrikethrough, RteSub, RteSup, RteUnderlined } from "@dextinity/admin-icons";
 import * as detectBrowser from "detect-browser";
 import { type Editor, type EditorState, RichUtils } from "draft-js";
-import { type RefObject, useCallback, useMemo } from "react";
+import { type MouseEvent, type RefObject, useCallback, useMemo } from "react";
 import { FormattedMessage } from "react-intl";
 
 import type { SupportedThings } from "../Rte";

--- a/packages/admin/admin-rte/src/utils/requiredValidator.tsx
+++ b/packages/admin/admin-rte/src/utils/requiredValidator.tsx
@@ -1,10 +1,16 @@
 import { convertFromRaw, type RawDraftContentState } from "draft-js";
+import type { FieldValidator } from "final-form";
 import type { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
 const requiredMessage = <FormattedMessage id="dextinity.form.required" defaultMessage="Required" />;
 
-export const requiredValidator = (value: string | RawDraftContentState | undefined): ReactNode => {
+/**
+ * Generic over the field value because `FieldValidator` is invariant in it: `FieldState` both accepts and returns the
+ * value, so a single `FieldValidator<string | RawDraftContentState | undefined>` cannot be passed to a `string`-valued
+ * `Field`. As a generic it stays a `FieldValidator` for either field value.
+ */
+export const requiredValidator = <T extends string | RawDraftContentState | undefined>(...[value]: Parameters<FieldValidator<T>>): ReactNode => {
     if (value === undefined) {
         return requiredMessage;
     }

--- a/packages/admin/admin-rte/src/utils/requiredValidator.tsx
+++ b/packages/admin/admin-rte/src/utils/requiredValidator.tsx
@@ -1,10 +1,10 @@
 import { convertFromRaw, type RawDraftContentState } from "draft-js";
-import type { FieldValidator } from "final-form";
+import type { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
 const requiredMessage = <FormattedMessage id="dextinity.form.required" defaultMessage="Required" />;
 
-export const requiredValidator: FieldValidator<string | RawDraftContentState | undefined> = (value) => {
+export const requiredValidator = (value: string | RawDraftContentState | undefined): ReactNode => {
     if (value === undefined) {
         return requiredMessage;
     }

--- a/packages/admin/admin-rte/src/utils/requiredValidator.tsx
+++ b/packages/admin/admin-rte/src/utils/requiredValidator.tsx
@@ -5,11 +5,6 @@ import { FormattedMessage } from "react-intl";
 
 const requiredMessage = <FormattedMessage id="dextinity.form.required" defaultMessage="Required" />;
 
-/**
- * Generic over the field value because `FieldValidator` is invariant in it: `FieldState` both accepts and returns the
- * value, so a single `FieldValidator<string | RawDraftContentState | undefined>` cannot be passed to a `string`-valued
- * `Field`. As a generic it stays a `FieldValidator` for either field value.
- */
 export const requiredValidator = <T extends string | RawDraftContentState | undefined>(...[value]: Parameters<FieldValidator<T>>): ReactNode => {
     if (value === undefined) {
         return requiredMessage;

--- a/packages/admin/admin-rte/tsconfig.json
+++ b/packages/admin/admin-rte/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "outDir": "lib",
-        "rootDir": "src"
+        "rootDir": "src",
+        "strict": true
     },
     "extends": "../tsconfig.base.json",
     "include": ["./src"]


### PR DESCRIPTION
## Status quo

Strict mode is not enabled everywhere in this repo. `packages/admin/tsconfig.base.json` stops at `noImplicitAny` and `strictNullChecks`, so `@dextinity/admin-rte` runs without the remaining strict checks.

## Change

Enable `strict` for the package. All four resulting errors come from `strictFunctionTypes`, which compares callback parameters contravariantly:

- `ControlButton` attaches `onButtonClick` to a `button` element, so the prop is typed with React's `MouseEvent` for `HTMLButtonElement` instead of the wider one for `Element`.
- `useInlineStyleType` annotated its click handler with the DOM's global `MouseEvent` instead of React's, so it did not match `IFeatureConfig`.
- `createComponentSlot` drops the generic of MUI's `Select`, which types the slot's `onChange` with an `unknown` value. `useBlockTypes` follows and narrows the block type where it is read.
- `requiredValidator` is no longer declared as a `FieldValidator`: its optional `meta` parameter makes the type invariant in the field value, so it could not be passed to a `string`-valued `Field`.

## Verification

Compared the emitted `.d.ts` files against `main`. Three types change, none of them breaking: the two in the changeset sit in a contravariant position, so handlers and validators that type-checked before still do, and `BlockChangeEvent` is not reachable through anything exported.

`@dextinity/admin`, `@dextinity/cms-admin`, the demo admin and Storybook typecheck against the rebuilt package.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-1079
