### PR TITLE
storybook: Enable TypeScript strict mode

### DIFF
--- a/storybook/src/admin/snackbar/UndoSnackbar.stories.tsx
+++ b/storybook/src/admin/snackbar/UndoSnackbar.stories.tsx
@@ -6,7 +6,6 @@ const UndoSnackbarExample = () => {
     const [chosenOption, setChosenOption] = useState("one");
     const snackbarApi = useSnackbarApi();
 
-    // `UndoSnackbar` passes its optional `payload` on to `onUndoClick`
     const handleUndo = (prevOption?: string) => {
         if (prevOption !== undefined) {
             setChosenOption(prevOption);

--- a/storybook/src/admin/snackbar/UndoSnackbar.stories.tsx
+++ b/storybook/src/admin/snackbar/UndoSnackbar.stories.tsx
@@ -6,8 +6,11 @@ const UndoSnackbarExample = () => {
     const [chosenOption, setChosenOption] = useState("one");
     const snackbarApi = useSnackbarApi();
 
-    const handleUndo = (prevOption: string) => {
-        setChosenOption(prevOption);
+    // `UndoSnackbar` passes its optional `payload` on to `onUndoClick`
+    const handleUndo = (prevOption?: string) => {
+        if (prevOption !== undefined) {
+            setChosenOption(prevOption);
+        }
     };
 
     const handleChange = (event: MouseEvent<HTMLElement>, newOption: string) => {

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -8,12 +8,11 @@
         "lib": ["DOM", "ES2015", "ES2016", "ES2017", "ES2018", "ES2019", "ESNext.AsyncIterable"],
         "module": "preserve",
         "moduleResolution": "bundler",
-        "noImplicitAny": true,
         "outDir": "lib",
         "rootDirs": ["src", ".storybook"],
         "skipLibCheck": true,
         "sourceMap": true,
-        "strictNullChecks": true,
+        "strict": true,
         "target": "es5"
     },
     "include": ["./src", ".storybook/**/*.ts", ".storybook/**/*.tsx"]


### PR DESCRIPTION
## Status quo

Strict mode is not enabled everywhere in this repo. The Storybook has a standalone `tsconfig.json` that sets `noImplicitAny` and `strictNullChecks` individually.

## Change

Enable `strict`, which implies both flags, so they are replaced by the single one.

No changeset: `dextinity-storybook` is private.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-1079


---
_Generated by [Claude Code](https://claude.ai/code/session_01JkyZV6LzEij2nv4VkArNxU)_