### PR TITLE
Use earliest next run across all allowed builder cron jobs for autoBuildStatus

### DIFF
--- a/.changeset/fix-auto-build-status-next-check.md
+++ b/.changeset/fix-auto-build-status-next-check.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/cms-api": patch
+---
+
+Fix `autoBuildStatus` reporting the wrong `nextCheck`/`lastCheck` when multiple builder cron jobs are allowed for a user
+
+`getAutoBuildStatus` only looked at the first allowed builder cron job, so editors with access to several scopes could see a `nextCheck` time that had nothing to do with the cron job that would actually run next. It now takes the earliest `nextCheck` and the most recent `lastCheck` across all allowed cron jobs.

--- a/packages/api/cms-api/src/builds/builds.service.spec.ts
+++ b/packages/api/cms-api/src/builds/builds.service.spec.ts
@@ -1,14 +1,18 @@
 import { getRepositoryToken } from "@mikro-orm/nestjs";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Test, type TestingModule } from "@nestjs/testing";
+import parser from "cron-parser";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { KubernetesModule } from "../kubernetes/kubernetes.module";
+import type { CurrentUser } from "../user-permissions/dto/current-user";
 import { ACCESS_CONTROL_SERVICE } from "../user-permissions/user-permissions.constants";
 import { BuildTemplatesService } from "./build-templates.service";
 import { CONTENT_SCOPE_ANNOTATION } from "./builds.constants";
 import { BuildsService } from "./builds.service";
 import { ChangesSinceLastBuild } from "./entities/changes-since-last-build.entity";
+
+const currentUser = {} as CurrentUser;
 
 const jobMain = {
     metadata: {
@@ -48,6 +52,11 @@ const jobMainGerman = {
 
 const mockedBuildTemplatesService = {
     getAllBuilderCronJobs: vi.fn().mockResolvedValue([jobMainEnglish, jobMainGerman]),
+    getAllowedBuilderCronJobs: vi.fn(),
+};
+
+const mockedChangesRepository = {
+    count: vi.fn().mockResolvedValue(0),
 };
 
 vi.mock("@kubernetes/client-node", () => ({}));
@@ -60,7 +69,7 @@ describe("BuildsService", () => {
             imports: [KubernetesModule.register({ helmRelease: "test" })],
             providers: [
                 BuildsService,
-                { provide: getRepositoryToken(ChangesSinceLastBuild), useValue: {} },
+                { provide: getRepositoryToken(ChangesSinceLastBuild), useValue: mockedChangesRepository },
                 { provide: BuildTemplatesService, useValue: mockedBuildTemplatesService },
                 { provide: ACCESS_CONTROL_SERVICE, useValue: {} },
                 { provide: EntityManager, useValue: {} },
@@ -106,6 +115,45 @@ describe("BuildsService", () => {
             await expect(service.getBuilderCronJobsToStart([{ domain: "tertiary" }])).rejects.toThrow(
                 'Found changes in scope {"domain":"tertiary"} but no matching builder cron job!',
             );
+        });
+    });
+
+    describe("getAutoBuildStatus", () => {
+        it("should use the earliest next scheduled run across all allowed cron jobs", async () => {
+            const hourlyCronJob = { spec: { schedule: "0 * * * *" }, status: {} };
+            const everyFiveMinutesCronJob = { spec: { schedule: "*/5 * * * *" }, status: {} };
+            mockedBuildTemplatesService.getAllowedBuilderCronJobs.mockResolvedValueOnce([hourlyCronJob, everyFiveMinutesCronJob]);
+
+            const expectedNextCheck = parser.parseExpression(everyFiveMinutesCronJob.spec.schedule).next().toDate();
+
+            const autoBuildStatus = await service.getAutoBuildStatus(currentUser);
+
+            expect(autoBuildStatus.nextCheck).toEqual(expectedNextCheck);
+        });
+
+        it("should use the most recent lastScheduleTime across all allowed cron jobs", async () => {
+            const olderCronJob = { spec: { schedule: "0 * * * *" }, status: { lastScheduleTime: new Date("2024-01-01T00:00:00Z") } };
+            const newerCronJob = { spec: { schedule: "0 * * * *" }, status: { lastScheduleTime: new Date("2024-01-02T00:00:00Z") } };
+            mockedBuildTemplatesService.getAllowedBuilderCronJobs.mockResolvedValueOnce([olderCronJob, newerCronJob]);
+
+            const autoBuildStatus = await service.getAutoBuildStatus(currentUser);
+
+            expect(autoBuildStatus.lastCheck).toEqual(newerCronJob.status.lastScheduleTime);
+        });
+
+        it("should leave lastCheck undefined if no cron job has been scheduled yet", async () => {
+            const cronJob = { spec: { schedule: "0 * * * *" }, status: {} };
+            mockedBuildTemplatesService.getAllowedBuilderCronJobs.mockResolvedValueOnce([cronJob]);
+
+            const autoBuildStatus = await service.getAutoBuildStatus(currentUser);
+
+            expect(autoBuildStatus.lastCheck).toBeUndefined();
+        });
+
+        it("should throw an error if no allowed cron job is found", async () => {
+            mockedBuildTemplatesService.getAllowedBuilderCronJobs.mockResolvedValueOnce([]);
+
+            await expect(service.getAutoBuildStatus(currentUser)).rejects.toThrow("BuildChecker CronJob not found.");
         });
     });
 });

--- a/packages/api/cms-api/src/builds/builds.service.ts
+++ b/packages/api/cms-api/src/builds/builds.service.ts
@@ -115,14 +115,21 @@ export class BuildsService {
         autoBuildStatus.hasChangesSinceLastBuild = await this.hasChangesSinceLastBuild();
 
         const cronJobs = await this.buildTemplatesService.getAllowedBuilderCronJobs(user);
-        const cronJob = cronJobs?.[0];
-        if (!cronJob) {
+        if (cronJobs.length === 0) {
             throw new Error("BuildChecker CronJob not found.");
         }
-        autoBuildStatus.lastCheck = cronJob.status?.lastScheduleTime;
 
-        const interval = parser.parseExpression(cronJob.spec?.schedule as string);
-        autoBuildStatus.nextCheck = interval.next().toDate();
+        const lastScheduleTimes = cronJobs.map((cronJob) => cronJob.status?.lastScheduleTime).filter((lastScheduleTime) => lastScheduleTime != null);
+        autoBuildStatus.lastCheck =
+            lastScheduleTimes.length > 0 ? new Date(Math.max(...lastScheduleTimes.map((lastScheduleTime) => lastScheduleTime.getTime()))) : undefined;
+
+        const nextCheckTimes = cronJobs.map((cronJob) =>
+            parser
+                .parseExpression(cronJob.spec?.schedule as string)
+                .next()
+                .toDate(),
+        );
+        autoBuildStatus.nextCheck = new Date(Math.min(...nextCheckTimes.map((nextCheckTime) => nextCheckTime.getTime())));
 
         return autoBuildStatus;
     }


### PR DESCRIPTION
## Motivation

`autoBuildStatus.nextCheck` is shown to editors as "Next publication is planned for: …" whenever there are unbuilt content changes. `BuildsService.getAutoBuildStatus` derived it from `cronJobs?.[0]` — only the first builder cron job the user is allowed to see. A user with access to several builder cron jobs (e.g. different domains/languages, each with its own schedule) could therefore be shown a time that has nothing to do with the cron job that will actually build their changes next.

## Solution

Compute `nextCheck` as the earliest next scheduled run across *all* allowed builder cron jobs, and `lastCheck` as the most recent `lastScheduleTime` across all of them (instead of only the first job's). Throw only when there are no allowed cron jobs at all.

## Example usage

Covered by new unit tests in `builds.service.spec.ts`:
- picks the earliest `nextCheck` when cron jobs have different schedules
- picks the most recent `lastCheck` across jobs
- leaves `lastCheck` undefined when no job has run yet
- still throws when no allowed cron job exists

## Changeset

- [x] I have verified if my change requires a changeset

## Open TODOs/questions

None.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-1020
