### PR TITLE
cms-admin: Build the hovered block's route from the sub-route prefix

### DIFF
--- a/.changeset/fix-block-preview-hover-below-subroute.md
+++ b/.changeset/fix-block-preview-hover-below-subroute.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/cms-admin": patch
+---
+
+Fix the block list not marking the block that is hovered in a block preview
+
+`HoverPreviewComponent` built the block's route from `useRouteMatch`, which does not see the path of a `SubRoute`. Below a `SaveBoundary` the route therefore missed that segment and never matched the route the preview reports, so hovering a block in the preview left its list entry unmarked, and hovering a list entry left the block in the preview unmarked. The route is now built from `useSubRoutePrefix`, the prefix the block routes in `BlockPreviewContext` already use.

--- a/packages/admin/cms-admin/src/blocks/iframebridge/HoverPreviewComponent.tsx
+++ b/packages/admin/cms-admin/src/blocks/iframebridge/HoverPreviewComponent.tsx
@@ -1,5 +1,5 @@
+import { useSubRoutePrefix } from "@dextinity/admin";
 import { type PropsWithChildren, useEffect, useRef } from "react";
-import { useRouteMatch } from "react-router";
 import scrollIntoView from "scroll-into-view-if-needed";
 
 import * as sc from "./HoverPreviewComponent.sc";
@@ -10,11 +10,15 @@ interface HoverPreviewComponentProps {
 }
 
 export const HoverPreviewComponent = ({ children, componentSlug }: PropsWithChildren<HoverPreviewComponentProps>) => {
-    const match = useRouteMatch();
+    // The routes of the previewed blocks are built from the same prefix, through
+    // `BlockPreviewContext.parentUrl` and `parentUrlSubRoute`. A `SubRoute` passes its path through
+    // a context instead of a router match, so `useRouteMatch` would miss that segment and a block
+    // list below one, for instance below a `SaveBoundary`, would never be recognized as hovered.
+    const subRoutePrefix = useSubRoutePrefix();
     const iFrameBridge = useIFrameBridge();
     const rootEl = useRef<HTMLDivElement | null>(null);
 
-    const componentRoute = componentSlug.startsWith("#") ? `${match.url}${componentSlug}` : `${match.url}/${componentSlug}`;
+    const componentRoute = componentSlug.startsWith("#") ? `${subRoutePrefix}${componentSlug}` : `${subRoutePrefix}/${componentSlug}`;
 
     const isHovered = iFrameBridge.hoveredSiteRoute?.includes(componentRoute) ?? false;
     useEffect(() => {


### PR DESCRIPTION
## Problem

In a project whose block form sits inside a `SaveBoundary`, hovering a block in the block preview does not mark the block's entry in the block list, and hovering a list entry does not mark the block in the preview. Both directions fail silently.

`HoverPreviewComponent` builds the block's route from `useRouteMatch().url`. The routes of the previewed blocks are built from a different base: `createBlocksBlock`, `createListBlock` and `createColumnsBlock` use `previewCtx.parentUrlSubRoute ?? previewCtx.parentUrl`, and `createCompositeBlock` sets `parentUrlSubRoute` exactly where it renders child blocks inside a `SubRoute`.

A `SubRoute` passes its path through a React context, not a router match, so `useRouteMatch` cannot see it. `SaveBoundary` renders a `RouterPrompt` with `subRoutePath: "./save"` by default, so in any project that passes `parentUrl: useSubRoutePrefix()` the two routes differ by that one segment and `hoveredSiteRoute?.includes(componentRoute)` never matches.

Measured in such a project (article editor, 12 blocks):

Preview -> admin, on hovering a block in the preview:

```json
{ "cometType": "HoverComponent", "data": { "route": ".../edit/save/<blockKey>/blocks" } }
```

Admin -> preview, on hovering a list entry:

```json
{ "cometType": "HoverComponent", "data": { "adminRoute": ".../edit/<blockKey>/blocks" } }
```

Injecting a `HoverComponent` message into the admin by hand confirms it: the route without `save` marks the matching list entry, the route with `save` marks nothing.

Clicking a block is not affected. `SelectPreviewComponent` sends `location.pathname` and `IFrameBridgeProvider` navigates with `history.push(message.data.adminRoute)`, so both use the full route including the sub-route segment.

## Solution

Build the route from `useSubRoutePrefix`, the prefix the block routes in `BlockPreviewContext` already use.

```diff
+import { useSubRoutePrefix } from "@dextinity/admin";
 import { type PropsWithChildren, useEffect, useRef } from "react";
-import { useRouteMatch } from "react-router";

-    const match = useRouteMatch();
+    const subRoutePrefix = useSubRoutePrefix();

-    const componentRoute = componentSlug.startsWith("#") ? `${match.url}${componentSlug}` : `${match.url}/${componentSlug}`;
+    const componentRoute = componentSlug.startsWith("#") ? `${subRoutePrefix}${componentSlug}` : `${subRoutePrefix}/${componentSlug}`;
```

This is safe in the other two cases: `useSubRoutePrefix()` returns `match.url` as soon as that starts with the `SubRoute` path, so nested blocks — where `match.url` is the real URL — keep the route they have today. Without a `SubRoute` it returns `match.url` unchanged, so the demo and the starter behave exactly as before.

## Further information

The bug is only reproducible in a project that combines a `SaveBoundary` with `parentUrl: useSubRoutePrefix()`; neither the demo nor the starter does, which is why it went unnoticed.
