### PR TITLE
site-react: Fix block preview outlines not ending at the block's right edge

### DIFF
--- a/.changeset/fix-block-preview-outline-width.md
+++ b/.changeset/fix-block-preview-outline-width.md
@@ -2,6 +2,8 @@
 "@dextinity/site-react": patch
 ---
 
-Fix block preview outlines ending short of the block's right edge
+Fix block preview outlines not ending at the block's right edge
 
 `IFrameBridgeProvider` clipped every outline to the width of its children wrapper, comparing the block's document-relative left edge against that width. The comparison holds only while the wrapper starts at x = 0, so padding or another offset on an ancestor of the provider cut those pixels off the right edge of every outline of a block that fills the wrapper. The clip now uses the wrapper's right edge in document coordinates.
+
+The wrapper was also measured during render, while the resize and mutation observers recompute the outlines without a render in between. A recompute after a resize therefore clipped to the previous layout, and when its result matched the outlines already on screen, the `isEqual` check blocked the re-render that would have refreshed the measurement, so the outlines kept the wrong width. The wrapper is now measured in the recompute itself.

--- a/.changeset/fix-block-preview-outline-width.md
+++ b/.changeset/fix-block-preview-outline-width.md
@@ -2,8 +2,8 @@
 "@dextinity/site-react": patch
 ---
 
-Fix block preview outlines not ending at the block's right edge
+Fix block preview outlines having the wrong width
 
-`IFrameBridgeProvider` clipped every outline to the width of its children wrapper, comparing the block's document-relative left edge against that width. The comparison holds only while the wrapper starts at x = 0, so padding or another offset on an ancestor of the provider cut those pixels off the right edge of every outline of a block that fills the wrapper. The clip now uses the wrapper's right edge in document coordinates.
+`IFrameBridgeProvider` clipped every outline to the width of its children wrapper, comparing the block's document-relative left edge against that width. The comparison holds only while the wrapper starts at `x = 0`, so padding or another offset on an ancestor of the provider cut those pixels off the right edge of every outline of a block that fills the wrapper. The clip now uses the wrapper's right edge in document coordinates.
 
-The wrapper was also measured during render, while the resize and mutation observers recompute the outlines without a render in between. A recompute after a resize therefore clipped to the previous layout, and when its result matched the outlines already on screen, the `isEqual` check blocked the re-render that would have refreshed the measurement, so the outlines kept the wrong width. The wrapper is now measured in the recompute itself.
+The wrapper was measured during render, while the resize and mutation observers recompute the outlines without a render in between. A recompute after a resize therefore clipped to the previous layout, and when its result matched the outlines already on screen, the `isEqual` check blocked the re-render that would have refreshed the measurement, so the outlines kept the wrong width. The wrapper is now measured in the recompute itself.

--- a/.changeset/fix-block-preview-outline-width.md
+++ b/.changeset/fix-block-preview-outline-width.md
@@ -2,8 +2,4 @@
 "@dextinity/site-react": patch
 ---
 
-Fix block preview outlines having the wrong width
-
-`IFrameBridgeProvider` clipped every outline to the width of its children wrapper, comparing the block's document-relative left edge against that width. The comparison holds only while the wrapper starts at `x = 0`, so padding or another offset on an ancestor of the provider cut those pixels off the right edge of every outline of a block that fills the wrapper. The clip now uses the wrapper's right edge in document coordinates.
-
-The wrapper was measured during render, while the resize and mutation observers recompute the outlines without a render in between. A recompute after a resize therefore clipped to the previous layout, and when its result matched the outlines already on screen, the `isEqual` check blocked the re-render that would have refreshed the measurement, so the outlines kept the wrong width. The wrapper is now measured in the recompute itself.
+Fix block preview outlines being cut off when `IFrameBridgeProvider` does not start at the left edge of the page, for instance because of padding or centering

--- a/.changeset/fix-block-preview-outline-width.md
+++ b/.changeset/fix-block-preview-outline-width.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/site-react": patch
+---
+
+Fix block preview outlines ending short of the block's right edge
+
+`IFrameBridgeProvider` clipped every outline to the width of its children wrapper, comparing the block's document-relative left edge against that width. The comparison holds only while the wrapper starts at x = 0, so padding or another offset on an ancestor of the provider cut those pixels off the right edge of every outline of a block that fills the wrapper. The clip now uses the wrapper's right edge in document coordinates.

--- a/packages/site/site-react/src/iframebridge/IFrameBridge.tsx
+++ b/packages/site/site-react/src/iframebridge/IFrameBridge.tsx
@@ -106,10 +106,9 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
             return;
         }
 
-        // `getCombinedPositioningOfElements` measures in document coordinates, so the comparisons below need the wrapper's right edge in
-        // those coordinates. Its width is that edge only while the wrapper starts at `x = 0`; an offset from an ancestor, such as padding
-        // or centering, shifts it. Measuring here and not during render keeps the value current: the observers below recompute without a
-        // render in between, so a value read during render would still describe the layout from before the resize.
+        // The comparisons below are in document coordinates, so they need the wrapper's right edge in those coordinates, not its width,
+        // which is that edge only while the wrapper starts at `x = 0`. Measured here and not during render because the observers recompute
+        // without a render in between.
         const childrenWrapperRight = childrenWrapper.getBoundingClientRect().right + window.scrollX;
 
         const newPreviewElementsData = previewElements

--- a/packages/site/site-react/src/iframebridge/IFrameBridge.tsx
+++ b/packages/site/site-react/src/iframebridge/IFrameBridge.tsx
@@ -99,6 +99,12 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
 
     const childrenWrapperRef = useRef<HTMLDivElement>(null);
     const childrenWrapperWidth = childrenWrapperRef.current?.offsetWidth;
+    // `getCombinedPositioningOfElements` measures in document coordinates, so an element's right
+    // edge has to be compared against the wrapper's right edge in those coordinates. The wrapper's
+    // width is that edge only while the wrapper starts at x = 0: with an offset from an ancestor,
+    // such as padding or centering, an element that fills the wrapper loses the offset from its
+    // right edge.
+    const childrenWrapperRight = childrenWrapperRef.current ? childrenWrapperRef.current.getBoundingClientRect().right + window.scrollX : 0;
 
     const recalculatePreviewElementsData = useCallback(() => {
         if (!childrenWrapperWidth) {
@@ -110,7 +116,7 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
                 const childNodes = getRecursiveChildrenOfPreviewElement(previewElement.element);
                 const positioning = getCombinedPositioningOfElements(childNodes);
 
-                const isRenderedOutsideOfViewportWidth = positioning.left > childrenWrapperWidth;
+                const isRenderedOutsideOfViewportWidth = positioning.left > childrenWrapperRight;
 
                 if (isRenderedOutsideOfViewportWidth) {
                     // TODO: Simply return `null` here after updating to typescript 5+
@@ -126,7 +132,7 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
                     };
                 }
 
-                const spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport = positioning.left + positioning.width - childrenWrapperWidth;
+                const spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport = positioning.left + positioning.width - childrenWrapperRight;
                 const tooWideForPreviewViewportByPixels =
                     spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport > 0 ? spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport : 0;
 
@@ -167,7 +173,7 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
 
             return newPreviewElementsData;
         });
-    }, [previewElements, childrenWrapperWidth]);
+    }, [previewElements, childrenWrapperWidth, childrenWrapperRight]);
 
     useEffect(() => {
         if (childrenWrapperRef.current) {

--- a/packages/site/site-react/src/iframebridge/IFrameBridge.tsx
+++ b/packages/site/site-react/src/iframebridge/IFrameBridge.tsx
@@ -98,18 +98,20 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
     const [previewElementsData, setPreviewElementsData] = useState<OverlayElementData[]>([]);
 
     const childrenWrapperRef = useRef<HTMLDivElement>(null);
-    const childrenWrapperWidth = childrenWrapperRef.current?.offsetWidth;
-    // `getCombinedPositioningOfElements` measures in document coordinates, so an element's right
-    // edge has to be compared against the wrapper's right edge in those coordinates. The wrapper's
-    // width is that edge only while the wrapper starts at x = 0: with an offset from an ancestor,
-    // such as padding or centering, an element that fills the wrapper loses the offset from its
-    // right edge.
-    const childrenWrapperRight = childrenWrapperRef.current ? childrenWrapperRef.current.getBoundingClientRect().right + window.scrollX : 0;
 
     const recalculatePreviewElementsData = useCallback(() => {
-        if (!childrenWrapperWidth) {
+        const childrenWrapper = childrenWrapperRef.current;
+
+        if (!childrenWrapper?.offsetWidth) {
             return;
         }
+
+        // `getCombinedPositioningOfElements` measures in document coordinates, so an element's right edge has to be compared against the
+        // wrapper's right edge in those coordinates. The wrapper's width is that edge only while the wrapper starts at x = 0: with an offset
+        // from an ancestor, such as padding or centering, an element that fills the wrapper loses the offset from its right edge.
+        // The wrapper is measured here and not during render because the observers below call this without a render in between, so a value
+        // from the render would describe the layout from before the resize, and `isEqual` would block the re-render that refreshes it.
+        const childrenWrapperRight = childrenWrapper.getBoundingClientRect().right + window.scrollX;
 
         const newPreviewElementsData = previewElements
             .map((previewElement) => {
@@ -173,7 +175,7 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
 
             return newPreviewElementsData;
         });
-    }, [previewElements, childrenWrapperWidth, childrenWrapperRight]);
+    }, [previewElements]);
 
     useEffect(() => {
         if (childrenWrapperRef.current) {

--- a/packages/site/site-react/src/iframebridge/IFrameBridge.tsx
+++ b/packages/site/site-react/src/iframebridge/IFrameBridge.tsx
@@ -106,11 +106,10 @@ export const IFrameBridgeProvider = ({ children }: PropsWithChildren) => {
             return;
         }
 
-        // `getCombinedPositioningOfElements` measures in document coordinates, so an element's right edge has to be compared against the
-        // wrapper's right edge in those coordinates. The wrapper's width is that edge only while the wrapper starts at x = 0: with an offset
-        // from an ancestor, such as padding or centering, an element that fills the wrapper loses the offset from its right edge.
-        // The wrapper is measured here and not during render because the observers below call this without a render in between, so a value
-        // from the render would describe the layout from before the resize, and `isEqual` would block the re-render that refreshes it.
+        // `getCombinedPositioningOfElements` measures in document coordinates, so the comparisons below need the wrapper's right edge in
+        // those coordinates. Its width is that edge only while the wrapper starts at `x = 0`; an offset from an ancestor, such as padding
+        // or centering, shifts it. Measuring here and not during render keeps the value current: the observers below recompute without a
+        // render in between, so a value read during render would still describe the layout from before the resize.
         const childrenWrapperRight = childrenWrapper.getBoundingClientRect().right + window.scrollX;
 
         const newPreviewElementsData = previewElements


### PR DESCRIPTION
## Problem

Two defects in `IFrameBridgeProvider` make the block preview outlines end somewhere other than the block's right edge.

**The clip uses the wrapper's width, not its right edge.** Every outline is clipped to the width of the children wrapper, comparing the block's document-relative left edge against that width:

```ts
const childrenWrapperWidth = childrenWrapperRef.current?.offsetWidth;
const isRenderedOutsideOfViewportWidth = positioning.left > childrenWrapperWidth;
const spaceBetweenRightEdgeOfElementAndRightEdgeOfViewport = positioning.left + positioning.width - childrenWrapperWidth;
```

`getCombinedPositioningOfElements` measures in document coordinates, so an element's right edge has to be compared against the wrapper's right edge in those coordinates. The width is that edge only while the wrapper starts at x = 0. When an ancestor of the provider offsets its children — through padding, a margin or centering — that offset is subtracted from the right edge of every outline of a block that fills the wrapper, and a block that starts beyond the wrapper's width is wrongly reported as rendered outside the viewport width.

**The wrapper is measured during render.** The resize and mutation observers call `recalculatePreviewElementsData` without a render in between, so the value read during render describes the layout from before the resize. The recompute clips to the previous layout, and when its result matches the outlines already on screen, the `isEqual` check returns the previous reference to prevent a re-render — which is also the only thing that would refresh the measurement. The outlines then keep the wrong width until an unrelated render happens.

## Solution

Measure the wrapper's right edge in document coordinates, inside the recompute.

Without an offset the right edge equals the width, so nothing changes for a wrapper that starts at x = 0. The guard keeps its previous condition, so the recompute still bails out while the wrapper has no width.

Dropping the measurement from the dependencies keeps `recalculatePreviewElementsData` stable across resizes. The observer effect no longer disconnects and reconnects both observers on every width change, and the `ResizeObserver` already covers the case that the reconnect was firing the recompute for.
