### PR TITLE
RFC: Refactor TipTap `supports` from array to object-based configuration

### DIFF
--- a/.changeset/tiptap-supports-object.md
+++ b/.changeset/tiptap-supports-object.md
@@ -1,0 +1,29 @@
+---
+"@dextinity/cms-admin": minor
+"@dextinity/cms-api": minor
+---
+
+Change the TipTap Rich Text Block's `supports` option from an array to an object of booleans
+
+The values passed are merged into the defaults, so a single feature can be disabled without repeating all others.
+
+**Example**
+
+```ts
+// Before
+createTipTapRichTextBlock({
+    supports: ["history", "bold", "italic", "strike", "sub", "sup", "ordered-list", "unordered-list", "non-breaking-space", "soft-hyphen"],
+});
+
+// After
+createTipTapRichTextBlock({
+    supports: { heading: false },
+});
+```
+
+The features are named `bold`, `italic`, `underline`, `strike`, `sub`, `sup`, `heading`, `orderedList`, `unorderedList`, `nonBreakingSpace`, `softHyphen`, `link` and (Admin only) `history`.
+All of them are enabled by default, except `underline`.
+
+`link` no longer has to be enabled explicitly when a `link` block is passed, but it can now be disabled with `supports: { link: false }`.
+
+`TipTapSupports` is now the type of the whole `supports` object (previously it was the union of the feature names) and is exported from both packages.

--- a/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
+++ b/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
@@ -78,8 +78,8 @@ All of them are enabled by default, except `underline`.
 
 :::warning
 
-`supports` must be configured identically on the API and in the Admin.
-The API builds its validation schema from it, so content using a feature that is only enabled in the Admin is rejected when saving.
+The shared feature flags must be configured identically on the API and in the Admin; only `history` is Admin-only and has no API counterpart.
+The API builds its validation schema from those flags, so content using a feature that is only enabled in the Admin is rejected when saving.
 
 :::
 

--- a/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
+++ b/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
@@ -49,18 +49,39 @@ Most features of the Draft.js `RichTextBlock` have a direct equivalent in the Ti
 | Draft.js `RichTextBlock`                        | TipTap Rich Text Block                                                                               |
 | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `createRichTextBlock`                           | `createTipTapRichTextBlock`                                                                          |
-| `rte.supports` (`SupportedThings[]`)            | `supports` (`TipTapSupports[]`)                                                                      |
+| `rte.supports` (`SupportedThings[]`)            | `supports` (`TipTapSupports`)                                                                        |
 | `bold`, `italic`, `strikethrough`, `sub`, `sup` | `bold`, `italic`, `strike`, `sub`, `sup`                                                             |
 | `header-one` … `header-six`                     | `heading` support + the [text-block-type select](#text-block-type-and-styling-selects) (Heading 1–6) |
-| `ordered-list`, `unordered-list`                | `ordered-list`, `unordered-list`                                                                     |
+| `ordered-list`, `unordered-list`                | `orderedList`, `unorderedList`                                                                       |
 | `history`                                       | `history` (Admin only)                                                                               |
-| `link`, `links-remove`                          | pass a `link` block (automatically enables `link` support)                                           |
-| `non-breaking-space`, `soft-hyphen`             | `non-breaking-space`, `soft-hyphen`                                                                  |
+| `link`, `links-remove`                          | pass a `link` block (`link` support is enabled by default)                                           |
+| `non-breaking-space`, `soft-hyphen`             | `nonBreakingSpace`, `softHyphen`                                                                     |
 | `rte.blocktypeMap` (custom block types)         | [`textBlockStyles`](#text-block-type-and-styling-selects) + the styling select                       |
 | `rte.customInlineStyles`                        | [`inlineStyles`](#text-block-type-and-styling-selects) + the inline style select                     |
 | `rte.listLevelMax`                              | `listLevelMax`                                                                                       |
 | `rte.maxBlocks`                                 | `maxTextBlocks`                                                                                      |
 | Site rendering with `redraft` + `Renderers`     | Site rendering with `renderTipTapRichText` + `nodeMapping`/`markMapping`                             |
+
+### Enabling and disabling features
+
+Unlike `rte.supports`, which is an array listing everything that is allowed, `supports` is an object of booleans that is merged into the defaults.
+To remove a single feature, disable just that one — all other features keep their default:
+
+```ts title="tip-tap-rich-text.block.ts"
+export const TipTapRichTextBlock = createTipTapRichTextBlock({
+    supports: { heading: false },
+});
+```
+
+The available features are `bold`, `italic`, `underline`, `strike`, `sub`, `sup`, `heading`, `orderedList`, `unorderedList`, `nonBreakingSpace`, `softHyphen`, `link` and (Admin only) `history`.
+All of them are enabled by default, except `underline`.
+
+:::warning
+
+`supports` must be configured identically on the API and in the Admin.
+The API builds its validation schema from it, so content using a feature that is only enabled in the Admin is rejected when saving.
+
+:::
 
 ### Setup
 
@@ -247,7 +268,7 @@ Beyond replacing the old block, the TipTap Rich Text Block adds capabilities the
 
 The editor toolbar offers two dropdowns to structure and style text blocks:
 
-1. **Text block type** — the semantic type of the current block: _Default_ (paragraph) or _Heading 1_ … _Heading 6_. Shown when `heading` is in `supports`.
+1. **Text block type** — the semantic type of the current block: _Default_ (paragraph) or _Heading 1_ … _Heading 6_. Shown when `heading` is enabled in `supports`.
 2. **Styling** — a named style applied to the current text block (`textBlockStyles`). This decouples semantics ("this is a paragraph") from appearance ("small paragraph"), so editors pick a type _and_ a style independently.
 
 There is a matching **inline style** dropdown for `inlineStyles`, which applies named styles to a text selection.

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -247,8 +247,10 @@ export const TipTapToolbar = ({
                 activeTipTapTextBlockType,
                 activeTextBlockStyle: (attrs.textBlockStyle as string) ?? "",
                 activeInlineStyle,
-                canUndo: e.can().undo(),
-                canRedo: e.can().redo(),
+                // The undo/redo commands only exist while the UndoRedo extension is registered,
+                // which follows `supports.history`.
+                canUndo: supports.history ? e.can().undo() : false,
+                canRedo: supports.history ? e.can().redo() : false,
                 canIndent,
                 canDedent: e.can().liftListItem("listItem"),
                 isBoldActive: e.isActive("bold"),

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -39,10 +39,10 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import type { BlockInterface, BlockState, LinkBlockInterface } from "../types";
 import type {
+    ResolvedTipTapSupports,
     TipTapChildBlock,
     TipTapInlineStyle,
     TipTapPlaceholder,
-    TipTapSupports,
     TipTapTextBlockStyle,
     TipTapTextBlockType,
 } from "./createTipTapRichTextBlock";
@@ -168,7 +168,7 @@ export const TipTapToolbar = ({
     headingLevels = [1, 2, 3, 4, 5, 6],
 }: {
     editor: Editor;
-    supports: TipTapSupports[];
+    supports: ResolvedTipTapSupports;
     textBlockStyles: TipTapTextBlockStyle[];
     inlineStyles: TipTapInlineStyle[];
     placeholders: TipTapPlaceholder[];
@@ -183,11 +183,11 @@ export const TipTapToolbar = ({
     const [childBlockAnchorEl, setChildBlockAnchorEl] = useState<null | HTMLElement>(null);
     const [insertChildBlock, setInsertChildBlock] = useState<({ key: string } & TipTapChildBlock) | null>(null);
     const [linkDialogOpen, setLinkDialogOpen] = useState(false);
-    const hasInlineFormatButtons = (["bold", "italic", "underline", "strike"] as const).some((s) => supports.includes(s));
-    const moreOptions = (["sub", "sup"] as const).some((s) => supports.includes(s));
-    const lists = (["ordered-list", "unordered-list"] as const).some((s) => supports.includes(s));
-    const specialChars = (["non-breaking-space", "soft-hyphen"] as const).some((s) => supports.includes(s));
-    const hasLink = supports.includes("link") && !!linkBlock;
+    const hasInlineFormatButtons = supports.bold || supports.italic || supports.underline || supports.strike;
+    const moreOptions = supports.sub || supports.sup;
+    const lists = supports.orderedList || supports.unorderedList;
+    const specialChars = supports.nonBreakingSpace || supports.softHyphen;
+    const hasLink = supports.link && !!linkBlock;
     const hasPlaceholders = placeholders.length > 0;
     const hasInlineStyles = inlineStyles.length > 0;
     const hasChildBlocks = Object.keys(childBlocks).length > 0;
@@ -342,7 +342,7 @@ export const TipTapToolbar = ({
                 px: "6px",
             }}
         >
-            {supports.includes("history") && (
+            {supports.history && (
                 <ToolbarGroup>
                     <ToolbarButton
                         editor={editor}
@@ -360,7 +360,7 @@ export const TipTapToolbar = ({
                     />
                 </ToolbarGroup>
             )}
-            {supports.includes("heading") && (
+            {supports.heading && (
                 <ToolbarGroup>
                     <FormControl sx={selectFormControlSx}>
                         <Select
@@ -436,7 +436,7 @@ export const TipTapToolbar = ({
             )}
             {(hasInlineFormatButtons || moreOptions) && (
                 <ToolbarGroup>
-                    {supports.includes("bold") && (
+                    {supports.bold && (
                         <ToolbarButton
                             editor={editor}
                             icon={RteBold}
@@ -445,7 +445,7 @@ export const TipTapToolbar = ({
                             onToggle={() => editor.chain().focus().toggleBold().run()}
                         />
                     )}
-                    {supports.includes("italic") && (
+                    {supports.italic && (
                         <ToolbarButton
                             editor={editor}
                             icon={RteItalic}
@@ -454,7 +454,7 @@ export const TipTapToolbar = ({
                             onToggle={() => editor.chain().focus().toggleItalic().run()}
                         />
                     )}
-                    {supports.includes("underline") && (
+                    {supports.underline && (
                         <ToolbarButton
                             editor={editor}
                             icon={RteUnderlined}
@@ -463,7 +463,7 @@ export const TipTapToolbar = ({
                             onToggle={() => editor.chain().focus().toggleUnderline().run()}
                         />
                     )}
-                    {supports.includes("strike") && (
+                    {supports.strike && (
                         <ToolbarButton
                             editor={editor}
                             icon={RteStrikethrough}
@@ -490,7 +490,7 @@ export const TipTapToolbar = ({
                                 </Box>
                             </Tooltip>
                             <Menu open={Boolean(moreAnchorEl)} anchorEl={moreAnchorEl} onClose={handleMoreClose}>
-                                {supports.includes("sup") && (
+                                {supports.sup && (
                                     <MenuItem
                                         selected={editor.isActive("superscript")}
                                         onMouseDown={(e) => {
@@ -505,7 +505,7 @@ export const TipTapToolbar = ({
                                         </ListItemIcon>
                                     </MenuItem>
                                 )}
-                                {supports.includes("sub") && (
+                                {supports.sub && (
                                     <MenuItem
                                         selected={editor.isActive("subscript")}
                                         onMouseDown={(e) => {
@@ -527,7 +527,7 @@ export const TipTapToolbar = ({
             )}
             {lists && (
                 <ToolbarGroup>
-                    {supports.includes("ordered-list") && (
+                    {supports.orderedList && (
                         <ToolbarButton
                             editor={editor}
                             icon={RteOl}
@@ -536,7 +536,7 @@ export const TipTapToolbar = ({
                             onToggle={() => editor.chain().focus().toggleOrderedList().run()}
                         />
                     )}
-                    {supports.includes("unordered-list") && (
+                    {supports.unorderedList && (
                         <ToolbarButton
                             editor={editor}
                             icon={RteUl}
@@ -619,7 +619,7 @@ export const TipTapToolbar = ({
             )}
             {specialChars && (
                 <ToolbarGroup>
-                    {supports.includes("non-breaking-space") && (
+                    {supports.nonBreakingSpace && (
                         <ToolbarButton
                             editor={editor}
                             icon={RteNonBreakingSpace}
@@ -632,7 +632,7 @@ export const TipTapToolbar = ({
                             onToggle={() => editor.chain().focus().insertContent({ type: "nonBreakingSpace" }).run()}
                         />
                     )}
-                    {supports.includes("soft-hyphen") && (
+                    {supports.softHyphen && (
                         <ToolbarButton
                             editor={editor}
                             icon={RteSoftHyphen}

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -150,7 +150,20 @@ export const ReadOnly: Story = {
     },
 };
 
-const BoldOnlyBlock = createTipTapRichTextBlock({ supports: ["bold"] });
+const BoldOnlyBlock = createTipTapRichTextBlock({
+    supports: {
+        history: false,
+        italic: false,
+        strike: false,
+        sub: false,
+        sup: false,
+        heading: false,
+        orderedList: false,
+        unorderedList: false,
+        nonBreakingSpace: false,
+        softHyphen: false,
+    },
+});
 
 function BoldOnlyStory() {
     const [state, setState] = useState<TipTapRichTextBlockState>(BoldOnlyBlock.defaultValues());
@@ -344,7 +357,17 @@ export const Placeholders: StoryObj<typeof PlaceholdersStory> = {
 };
 
 const PlaceholdersWithContentBlock = createTipTapRichTextBlock({
-    supports: ["bold", "italic"],
+    supports: {
+        history: false,
+        strike: false,
+        sub: false,
+        sup: false,
+        heading: false,
+        orderedList: false,
+        unorderedList: false,
+        nonBreakingSpace: false,
+        softHyphen: false,
+    },
     placeholders: [
         { name: "firstName", label: "First Name" },
         { name: "lastName", label: "Last Name" },
@@ -567,7 +590,15 @@ export const TextBlockStyleInteractions: StoryObj<typeof TextBlockStyleInteracti
 };
 
 const ListTextBlockStylesBlock = createTipTapRichTextBlock({
-    supports: ["bold", "ordered-list", "unordered-list", "heading"],
+    supports: {
+        history: false,
+        italic: false,
+        strike: false,
+        sub: false,
+        sup: false,
+        nonBreakingSpace: false,
+        softHyphen: false,
+    },
     textBlockStyles: [
         {
             name: "intro",

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -387,6 +387,7 @@ const TipTapEditor = ({
     const editor = useEditor({
         extensions: [
             StarterKit.configure({
+                undoRedo: supports.history ? {} : false,
                 bold: supports.bold ? {} : false,
                 italic: supports.italic ? {} : false,
                 underline: supports.underline ? {} : false,

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -26,34 +26,43 @@ import { createListLevelMaxExtension, getListNestingDepthFromJson, trimListNesti
 import { TextBlockStyleContext } from "./TextBlockStyleContext";
 import { TipTapToolbar } from "./TipTapToolbar";
 
-export type TipTapSupports =
-    | "history"
-    | "bold"
-    | "italic"
-    | "underline"
-    | "strike"
-    | "sub"
-    | "sup"
-    | "heading"
-    | "ordered-list"
-    | "unordered-list"
-    | "non-breaking-space"
-    | "soft-hyphen"
-    | "link";
+export interface TipTapSupports {
+    history?: boolean;
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+    strike?: boolean;
+    sub?: boolean;
+    sup?: boolean;
+    heading?: boolean;
+    orderedList?: boolean;
+    unorderedList?: boolean;
+    nonBreakingSpace?: boolean;
+    softHyphen?: boolean;
+    link?: boolean;
+}
 
-const defaultSupports: TipTapSupports[] = [
-    "history",
-    "heading",
-    "bold",
-    "italic",
-    "strike",
-    "sub",
-    "sup",
-    "ordered-list",
-    "unordered-list",
-    "non-breaking-space",
-    "soft-hyphen",
-];
+export type ResolvedTipTapSupports = Required<TipTapSupports>;
+
+const defaultSupports: ResolvedTipTapSupports = {
+    history: true,
+    bold: true,
+    italic: true,
+    underline: false,
+    strike: true,
+    sub: true,
+    sup: true,
+    heading: true,
+    orderedList: true,
+    unorderedList: true,
+    nonBreakingSpace: true,
+    softHyphen: true,
+    link: true,
+};
+
+function resolveSupports(supports: TipTapSupports = {}): ResolvedTipTapSupports {
+    return { ...defaultSupports, ...supports };
+}
 
 export type { JSONContent as TipTapRichTextBlockContent } from "@tiptap/core";
 
@@ -117,7 +126,11 @@ export interface TipTapChildBlock {
 }
 
 interface TipTapRichTextBlockFactoryOptions {
-    supports?: TipTapSupports[];
+    /**
+     * Enables/disables individual editor features. The passed values are merged into the defaults,
+     * so a single feature can be turned off without repeating all others, e.g. `{ heading: false }`.
+     */
+    supports?: TipTapSupports;
     textBlockStyles?: TipTapTextBlockStyle[];
     inlineStyles?: TipTapInlineStyle[];
     placeholders?: TipTapPlaceholder[];
@@ -351,7 +364,7 @@ const TipTapEditor = ({
 }: {
     state: TipTapRichTextBlockState;
     updateState: React.Dispatch<React.SetStateAction<TipTapRichTextBlockState>>;
-    supports: TipTapSupports[];
+    supports: ResolvedTipTapSupports;
     textBlockStyles: TipTapTextBlockStyle[];
     inlineStyles: TipTapInlineStyle[];
     placeholders: TipTapPlaceholder[];
@@ -364,7 +377,7 @@ const TipTapEditor = ({
 }) => {
     const hasTextBlockStyles = textBlockStyles.length > 0;
     const hasInlineStyles = inlineStyles.length > 0;
-    const hasLink = supports.includes("link") && !!linkBlock;
+    const hasLink = supports.link && !!linkBlock;
     const hasPlaceholders = placeholders.length > 0;
     const childBlockEntries = Object.values(childBlocks);
     const hasBlockChildBlocks = childBlockEntries.some((childBlock) => childBlock.display === "block");
@@ -374,34 +387,28 @@ const TipTapEditor = ({
     const editor = useEditor({
         extensions: [
             StarterKit.configure({
-                bold: supports.includes("bold") ? {} : false,
-                italic: supports.includes("italic") ? {} : false,
-                underline: supports.includes("underline") ? {} : false,
-                strike: supports.includes("strike") ? {} : false,
-                heading: supports.includes("heading")
-                    ? hasTextBlockStyles
-                        ? false
-                        : headingLevels
-                          ? { levels: headingLevels as HeadingLevel[] }
-                          : {}
-                    : false,
+                bold: supports.bold ? {} : false,
+                italic: supports.italic ? {} : false,
+                underline: supports.underline ? {} : false,
+                strike: supports.strike ? {} : false,
+                heading: supports.heading ? (hasTextBlockStyles ? false : headingLevels ? { levels: headingLevels as HeadingLevel[] } : {}) : false,
                 paragraph: hasTextBlockStyles ? false : undefined,
-                orderedList: supports.includes("ordered-list") ? {} : false,
-                bulletList: supports.includes("unordered-list") ? {} : false,
+                orderedList: supports.orderedList ? {} : false,
+                bulletList: supports.unorderedList ? {} : false,
                 blockquote: false,
                 code: false,
                 codeBlock: false,
                 link: false,
             }),
             ...(hasTextBlockStyles ? [TextBlockStyleParagraph] : []),
-            ...(hasTextBlockStyles && supports.includes("heading")
+            ...(hasTextBlockStyles && supports.heading
                 ? [TextBlockStyleHeading.configure(headingLevels ? { levels: headingLevels as HeadingLevel[] } : {})]
                 : []),
             ...(hasInlineStyles ? [InlineStyleMark] : []),
-            ...(supports.includes("sup") ? [Superscript] : []),
-            ...(supports.includes("sub") ? [Subscript] : []),
-            ...(supports.includes("non-breaking-space") ? [NonBreakingSpace] : []),
-            ...(supports.includes("soft-hyphen") ? [SoftHyphen] : []),
+            ...(supports.sup ? [Superscript] : []),
+            ...(supports.sub ? [Subscript] : []),
+            ...(supports.nonBreakingSpace ? [NonBreakingSpace] : []),
+            ...(supports.softHyphen ? [SoftHyphen] : []),
             ...(hasPlaceholders ? [Placeholder] : []),
             ...(hasLink ? [CmsLink] : []),
             ...(hasBlockChildBlocks ? [CmsBlock] : []),
@@ -493,7 +500,7 @@ type TipTapRichTextBlockInterface = BlockInterface<TipTapRichTextBlockData, TipT
  * @experimental
  */
 export const createTipTapRichTextBlock = (options?: TipTapRichTextBlockFactoryOptions): TipTapRichTextBlockInterface => {
-    let supports = options?.supports ?? defaultSupports;
+    const supports = resolveSupports(options?.supports);
     const textBlockStyles = options?.textBlockStyles ?? [];
     const inlineStyles = options?.inlineStyles ?? [];
     const placeholders = options?.placeholders ?? [];
@@ -512,11 +519,6 @@ export const createTipTapRichTextBlock = (options?: TipTapRichTextBlockFactoryOp
             headingLevels.some((level) => !Number.isInteger(level) || level < 1 || level > 6))
     ) {
         throw new Error("headingLevels must be a non-empty array of unique integers between 1 and 6");
-    }
-
-    // Auto-enable link support when a link block is provided
-    if (linkBlock && !supports.includes("link")) {
-        supports = [...supports, "link"];
     }
 
     const sharedEditorProps = {

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -85,6 +85,7 @@ export type {
     TipTapInlineStyle,
     TipTapPlaceholder,
     TipTapRichTextBlockContent,
+    TipTapSupports,
     TipTapTextBlockStyle,
     TipTapTextBlockType,
 } from "./blocks/tipTap/createTipTapRichTextBlock";

--- a/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.test.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.test.ts
@@ -5,10 +5,32 @@ import { ExternalLinkBlock } from "../externalLink/external-link.block";
 import { createLinkBlock } from "../factories/createLinkBlock";
 import {
     createTipTapRichTextBlock,
+    type ResolvedTipTapSupports,
     type TipTapRichTextBlockContent,
     type TipTapRichTextBlockDataInterface,
     type TipTapRichTextBlockInputInterface,
+    type TipTapSupports,
 } from "./createTipTapRichTextBlock";
+
+const noSupports: ResolvedTipTapSupports = {
+    bold: false,
+    italic: false,
+    underline: false,
+    strike: false,
+    sub: false,
+    sup: false,
+    heading: false,
+    orderedList: false,
+    unorderedList: false,
+    nonBreakingSpace: false,
+    softHyphen: false,
+    link: false,
+};
+
+// Enables only the listed features, everything else is turned off.
+function onlySupports(...features: (keyof TipTapSupports)[]): ResolvedTipTapSupports {
+    return features.reduce<ResolvedTipTapSupports>((supports, feature) => ({ ...supports, [feature]: true }), { ...noSupports });
+}
 
 describe("createTipTapRichTextBlock validation", () => {
     describe("default schema (default supports)", () => {
@@ -232,7 +254,7 @@ describe("createTipTapRichTextBlock validation", () => {
     });
 
     describe("bold-only schema", () => {
-        const block = createTipTapRichTextBlock({ supports: ["bold"] }, "TestBoldOnly");
+        const block = createTipTapRichTextBlock({ supports: onlySupports("bold") }, "TestBoldOnly");
 
         it("should accept bold text", async () => {
             const input = block.blockInputFactory({
@@ -322,7 +344,7 @@ describe("createTipTapRichTextBlock validation", () => {
     });
 
     describe("schema with underline support", () => {
-        const block = createTipTapRichTextBlock({ supports: ["underline"] }, "TestUnderline");
+        const block = createTipTapRichTextBlock({ supports: onlySupports("underline") }, "TestUnderline");
 
         it("should accept underline marks", async () => {
             const input = block.blockInputFactory({
@@ -344,7 +366,7 @@ describe("createTipTapRichTextBlock validation", () => {
     describe("schema with text block styles", () => {
         const block = createTipTapRichTextBlock(
             {
-                supports: ["bold", "heading"],
+                supports: onlySupports("bold", "heading"),
                 textBlockStyles: [{ name: "intro", appliesTo: ["paragraph"] }, { name: "highlight" }],
             },
             "TestBlockStyles",
@@ -405,7 +427,7 @@ describe("createTipTapRichTextBlock validation", () => {
     describe("schema with text block styles and lists", () => {
         const block = createTipTapRichTextBlock(
             {
-                supports: ["bold", "heading", "ordered-list", "unordered-list"],
+                supports: onlySupports("bold", "heading", "orderedList", "unorderedList"),
                 textBlockStyles: [
                     { name: "intro", appliesTo: ["paragraph"] },
                     { name: "listStyle", appliesTo: ["ordered-list", "unordered-list"] },
@@ -500,7 +522,7 @@ describe("createTipTapRichTextBlock validation", () => {
     describe("inlineStyles", () => {
         const block = createTipTapRichTextBlock(
             {
-                supports: ["bold"],
+                supports: onlySupports("bold"),
                 inlineStyles: [{ name: "highlight" }, { name: "tag" }],
             },
             "TestInlineStyles",
@@ -551,7 +573,7 @@ describe("createTipTapRichTextBlock validation", () => {
     });
 
     describe("inlineStyles rejected when not configured", () => {
-        const block = createTipTapRichTextBlock({ supports: ["bold"] }, "TestNoInlineStyles");
+        const block = createTipTapRichTextBlock({ supports: onlySupports("bold") }, "TestNoInlineStyles");
 
         it("should reject inlineStyle mark when inlineStyles not configured", async () => {
             const input = block.blockInputFactory({
@@ -573,7 +595,7 @@ describe("createTipTapRichTextBlock validation", () => {
     describe("inlineStyles with appliesTo", () => {
         const block = createTipTapRichTextBlock(
             {
-                supports: ["bold", "heading"],
+                supports: onlySupports("bold", "heading"),
                 inlineStyles: [
                     { name: "highlight" },
                     { name: "tag", appliesTo: ["paragraph"] },
@@ -689,7 +711,7 @@ describe("createTipTapRichTextBlock validation", () => {
     });
 
     describe("minimal schema (no supports)", () => {
-        const block = createTipTapRichTextBlock({ supports: [] }, "TestMinimal");
+        const block = createTipTapRichTextBlock({ supports: noSupports }, "TestMinimal");
 
         it("should accept a plain paragraph", async () => {
             const input = block.blockInputFactory({
@@ -963,7 +985,7 @@ describe("createTipTapRichTextBlock validation", () => {
     describe("schema with placeholders", () => {
         const block = createTipTapRichTextBlock(
             {
-                supports: ["bold"],
+                supports: onlySupports("bold"),
                 placeholders: [{ name: "firstName" }, { name: "lastName" }],
             },
             "TestPlaceholders",
@@ -1007,7 +1029,7 @@ describe("createTipTapRichTextBlock validation", () => {
     });
 
     describe("schema without placeholders", () => {
-        const block = createTipTapRichTextBlock({ supports: ["bold"] }, "TestNoPlaceholders");
+        const block = createTipTapRichTextBlock({ supports: onlySupports("bold") }, "TestNoPlaceholders");
 
         it("should reject a placeholder node when no placeholders are configured", async () => {
             const input = block.blockInputFactory({
@@ -1289,7 +1311,7 @@ describe("createTipTapRichTextBlock validation", () => {
 
     describe("childBlocks option", () => {
         const block = createTipTapRichTextBlock(
-            { supports: ["bold"], childBlocks: { externalLink: { block: ExternalLinkBlock, display: "block" } } },
+            { supports: onlySupports("bold"), childBlocks: { externalLink: { block: ExternalLinkBlock, display: "block" } } },
             "TestChildBlocks",
         );
 
@@ -1327,7 +1349,7 @@ describe("createTipTapRichTextBlock validation", () => {
         });
 
         it("should reject a child block node when no childBlocks are configured", async () => {
-            const blockWithoutChildBlocks = createTipTapRichTextBlock({ supports: ["bold"] }, "TestNoChildBlocks");
+            const blockWithoutChildBlocks = createTipTapRichTextBlock({ supports: onlySupports("bold") }, "TestNoChildBlocks");
             const input = blockWithoutChildBlocks.blockInputFactory({
                 tipTapContent: cmsBlockNode("externalLink", { targetUrl: "https://example.com", openInNewWindow: false, noFollow: false }),
             });
@@ -1350,7 +1372,7 @@ describe("createTipTapRichTextBlock validation", () => {
 
     describe("inline childBlocks option", () => {
         const block = createTipTapRichTextBlock(
-            { supports: ["bold"], childBlocks: { externalLink: { block: ExternalLinkBlock, display: "inline" } } },
+            { supports: onlySupports("bold"), childBlocks: { externalLink: { block: ExternalLinkBlock, display: "inline" } } },
             "TestInlineChildBlocks",
         );
 
@@ -1408,7 +1430,7 @@ describe("createTipTapRichTextBlock validation", () => {
 });
 
 describe("createTipTapRichTextBlock block typing", () => {
-    const block = createTipTapRichTextBlock({ supports: ["bold"] }, "TestTyping");
+    const block = createTipTapRichTextBlock({ supports: onlySupports("bold") }, "TestTyping");
 
     // The typed return value is what makes the block usable in fixtures: `blockInputFactory`
     // validates the `tipTapContent` shape at the call site (no type annotation needed) and the

--- a/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/createTipTapRichTextBlock.ts
@@ -36,19 +36,22 @@ import { buildDraftJsToTipTapMigration } from "./migrations/buildDraftJsToTipTap
 import type { TextBlockStyleMapping } from "./migrations/convertDraftJsToTipTap";
 import { containsInvalidHeadingLevel, getListNestingDepth } from "./tipTapValidation";
 
-export type TipTapSupports =
-    | "bold"
-    | "italic"
-    | "underline"
-    | "strike"
-    | "sub"
-    | "sup"
-    | "heading"
-    | "ordered-list"
-    | "unordered-list"
-    | "non-breaking-space"
-    | "soft-hyphen"
-    | "link";
+export interface TipTapSupports {
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+    strike?: boolean;
+    sub?: boolean;
+    sup?: boolean;
+    heading?: boolean;
+    orderedList?: boolean;
+    unorderedList?: boolean;
+    nonBreakingSpace?: boolean;
+    softHyphen?: boolean;
+    link?: boolean;
+}
+
+export type ResolvedTipTapSupports = Required<TipTapSupports>;
 
 export type { JSONContent as TipTapRichTextBlockContent } from "@tiptap/core";
 
@@ -99,25 +102,35 @@ function isValidHeadingLevels(headingLevels: number[]): headingLevels is Heading
     );
 }
 
-const defaultSupports: TipTapSupports[] = [
-    "bold",
-    "italic",
-    "strike",
-    "sub",
-    "sup",
-    "heading",
-    "ordered-list",
-    "unordered-list",
-    "non-breaking-space",
-    "soft-hyphen",
-];
+const defaultSupports: ResolvedTipTapSupports = {
+    bold: true,
+    italic: true,
+    underline: false,
+    strike: true,
+    sub: true,
+    sup: true,
+    heading: true,
+    orderedList: true,
+    unorderedList: true,
+    nonBreakingSpace: true,
+    softHyphen: true,
+    link: true,
+};
+
+function resolveSupports(supports: TipTapSupports = {}): ResolvedTipTapSupports {
+    return { ...defaultSupports, ...supports };
+}
 
 interface TipTapPlaceholder {
     name: string;
 }
 
 export interface CreateTipTapRichTextBlockOptions {
-    supports?: TipTapSupports[];
+    /**
+     * Enables/disables individual editor features. The passed values are merged into the defaults,
+     * so a single feature can be turned off without repeating all others, e.g. `{ heading: false }`.
+     */
+    supports?: TipTapSupports;
     textBlockStyles?: TipTapTextBlockStyle[];
     inlineStyles?: TipTapInlineStyle[];
     placeholders?: TipTapPlaceholder[];
@@ -171,7 +184,7 @@ export interface CreateTipTapRichTextBlockOptions {
 }
 
 function buildExtensions(
-    supports: TipTapSupports[],
+    supports: ResolvedTipTapSupports,
     textBlockStyles: TipTapTextBlockStyle[],
     inlineStyles: TipTapInlineStyle[],
     placeholders: TipTapPlaceholder[],
@@ -185,26 +198,26 @@ function buildExtensions(
     const hasPlaceholders = placeholders.length > 0;
     return [
         StarterKit.configure({
-            bold: supports.includes("bold") ? {} : false,
-            italic: supports.includes("italic") ? {} : false,
-            underline: supports.includes("underline") ? {} : false,
-            strike: supports.includes("strike") ? {} : false,
-            heading: supports.includes("heading") ? (hasTextBlockStyles ? false : { levels: headingLevels }) : false,
+            bold: supports.bold ? {} : false,
+            italic: supports.italic ? {} : false,
+            underline: supports.underline ? {} : false,
+            strike: supports.strike ? {} : false,
+            heading: supports.heading ? (hasTextBlockStyles ? false : { levels: headingLevels }) : false,
             paragraph: hasTextBlockStyles ? false : undefined,
-            orderedList: supports.includes("ordered-list") ? {} : false,
-            bulletList: supports.includes("unordered-list") ? {} : false,
+            orderedList: supports.orderedList ? {} : false,
+            bulletList: supports.unorderedList ? {} : false,
             blockquote: false,
             code: false,
             codeBlock: false,
             link: false,
         }),
         ...(hasTextBlockStyles ? [TextBlockStyleParagraph] : []),
-        ...(hasTextBlockStyles && supports.includes("heading") ? [TextBlockStyleHeading.configure({ levels: headingLevels })] : []),
+        ...(hasTextBlockStyles && supports.heading ? [TextBlockStyleHeading.configure({ levels: headingLevels })] : []),
         ...(hasInlineStyles ? [InlineStyleMark] : []),
-        ...(supports.includes("sup") ? [Superscript] : []),
-        ...(supports.includes("sub") ? [Subscript] : []),
-        ...(supports.includes("non-breaking-space") ? [NonBreakingSpace] : []),
-        ...(supports.includes("soft-hyphen") ? [SoftHyphen] : []),
+        ...(supports.sup ? [Superscript] : []),
+        ...(supports.sub ? [Subscript] : []),
+        ...(supports.nonBreakingSpace ? [NonBreakingSpace] : []),
+        ...(supports.softHyphen ? [SoftHyphen] : []),
         ...(hasPlaceholders ? [Placeholder] : []),
         ...(hasLink ? [CmsLink] : []),
         ...(hasBlockChildBlocks ? [CmsBlock] : []),
@@ -531,7 +544,7 @@ function extractTextEntries(node: JSONContent, headingLevel?: number): TextEntry
  */
 export function createTipTapRichTextBlock(
     {
-        supports = defaultSupports,
+        supports: supportsOption,
         textBlockStyles = [],
         inlineStyles = [],
         placeholders = [],
@@ -552,7 +565,8 @@ export function createTipTapRichTextBlock(
         throw new Error("headingLevels must be a non-empty array of unique integers between 1 and 6");
     }
 
-    const hasLink = !!LinkBlock;
+    const supports = resolveSupports(supportsOption);
+    const hasLink = supports.link && !!LinkBlock;
     const childBlocks: Record<string, Block> = Object.fromEntries(Object.entries(childBlocksConfig).map(([key, { block }]) => [key, block]));
     const childBlockConfigs = Object.values(childBlocksConfig);
     const hasChildBlocks = childBlockConfigs.length > 0;
@@ -591,7 +605,7 @@ export function createTipTapRichTextBlock(
                   buildDraftJsToTipTapMigration({
                       schema,
                       supports,
-                      link: LinkBlock,
+                      link: hasLink ? LinkBlock : undefined,
                       maxTextBlocks,
                       listLevelMax,
                       headingLevels,

--- a/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.test.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.test.ts
@@ -1,21 +1,43 @@
 import { describe, expect, it } from "vitest";
 
 import type { Block } from "../../block";
+import type { ResolvedTipTapSupports } from "../createTipTapRichTextBlock";
 import { buildStrippedTipTapDoc, convertDraftJsToTipTap, type DraftJsContent } from "./convertDraftJsToTipTap";
 
-const defaultSupports = [
-    "bold",
-    "italic",
-    "underline",
-    "strike",
-    "sub",
-    "sup",
-    "heading",
-    "ordered-list",
-    "unordered-list",
-    "non-breaking-space",
-    "soft-hyphen",
-] as const;
+const noSupports: ResolvedTipTapSupports = {
+    bold: false,
+    italic: false,
+    underline: false,
+    strike: false,
+    sub: false,
+    sup: false,
+    heading: false,
+    orderedList: false,
+    unorderedList: false,
+    nonBreakingSpace: false,
+    softHyphen: false,
+    link: false,
+};
+
+const allSupports: ResolvedTipTapSupports = {
+    bold: true,
+    italic: true,
+    underline: true,
+    strike: true,
+    sub: true,
+    sup: true,
+    heading: true,
+    orderedList: true,
+    unorderedList: true,
+    nonBreakingSpace: true,
+    softHyphen: true,
+    link: true,
+};
+
+// Enables only the listed features, everything else is turned off.
+function onlySupports(...features: (keyof ResolvedTipTapSupports)[]): ResolvedTipTapSupports {
+    return features.reduce<ResolvedTipTapSupports>((supports, feature) => ({ ...supports, [feature]: true }), { ...noSupports });
+}
 
 // Minimal Block stub used only for truthiness checks inside the converter
 const dummyLinkBlock = { name: "Link" } as unknown as Block;
@@ -52,7 +74,7 @@ describe("convertDraftJsToTipTap", () => {
         it("maps unstyled to paragraph", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "unstyled", text: "Hello" })], entityMap: {} },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result).toEqual({
                 type: "doc",
@@ -68,46 +90,40 @@ describe("convertDraftJsToTipTap", () => {
             ["header-five", 5],
             ["header-six", 6],
         ])("maps %s to heading level %d", (type, level) => {
-            const result = convertDraftJsToTipTap(
-                { blocks: [makeBlock({ type, text: "Title" })], entityMap: {} },
-                { supports: [...defaultSupports] },
-            );
+            const result = convertDraftJsToTipTap({ blocks: [makeBlock({ type, text: "Title" })], entityMap: {} }, { supports: allSupports });
             expect(result.content).toEqual([{ type: "heading", attrs: { level }, content: [{ type: "text", text: "Title" }] }]);
         });
 
         it("falls back to paragraph when heading not supported", () => {
-            const result = convertDraftJsToTipTap({ blocks: [makeBlock({ type: "header-one", text: "Title" })], entityMap: {} }, { supports: [] });
+            const result = convertDraftJsToTipTap(
+                { blocks: [makeBlock({ type: "header-one", text: "Title" })], entityMap: {} },
+                { supports: noSupports },
+            );
             expect(result.content).toEqual([{ type: "paragraph", content: [{ type: "text", text: "Title" }] }]);
         });
 
         it("maps blockquote to paragraph", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "blockquote", text: "Quote" })], entityMap: {} },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content).toEqual([{ type: "paragraph", content: [{ type: "text", text: "Quote" }] }]);
         });
 
         it("maps unknown block type to paragraph", () => {
-            const result = convertDraftJsToTipTap(
-                { blocks: [makeBlock({ type: "atomic", text: "x" })], entityMap: {} },
-                { supports: [...defaultSupports] },
-            );
+            const result = convertDraftJsToTipTap({ blocks: [makeBlock({ type: "atomic", text: "x" })], entityMap: {} }, { supports: allSupports });
             expect(result.content).toEqual([{ type: "paragraph", content: [{ type: "text", text: "x" }] }]);
         });
 
         it("emits empty paragraph for empty text", () => {
-            const result = convertDraftJsToTipTap(
-                { blocks: [makeBlock({ type: "unstyled", text: "" })], entityMap: {} },
-                { supports: [...defaultSupports] },
-            );
+            const result = convertDraftJsToTipTap({ blocks: [makeBlock({ type: "unstyled", text: "" })], entityMap: {} }, { supports: allSupports });
             expect(result.content).toEqual([{ type: "paragraph" }]);
         });
 
         it("maps a block type from textBlockStyleMap to a paragraph with textBlockStyle attr", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "paragraph-small", text: "tiny" })], entityMap: {} },
-                { supports: [...defaultSupports], textBlockStyleMap: { "paragraph-small": "small" } },
+                { supports: allSupports, textBlockStyleMap: { "paragraph-small": "small" } },
             );
             expect(result.content).toEqual([{ type: "paragraph", attrs: { textBlockStyle: "small" }, content: [{ type: "text", text: "tiny" }] }]);
         });
@@ -115,7 +131,7 @@ describe("convertDraftJsToTipTap", () => {
         it("keeps the heading level when a header type is mapped to a textBlockStyle", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "header-two", text: "Title" })], entityMap: {} },
-                { supports: [...defaultSupports], textBlockStyleMap: { "header-two": "headline450" } },
+                { supports: allSupports, textBlockStyleMap: { "header-two": "headline450" } },
             );
             expect(result.content).toEqual([
                 { type: "heading", attrs: { level: 2, textBlockStyle: "headline450" }, content: [{ type: "text", text: "Title" }] },
@@ -125,7 +141,7 @@ describe("convertDraftJsToTipTap", () => {
         it("falls back to a paragraph for a mapped header type when heading is not supported", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "header-two", text: "Title" })], entityMap: {} },
-                { supports: [], textBlockStyleMap: { "header-two": "headline450" } },
+                { supports: noSupports, textBlockStyleMap: { "header-two": "headline450" } },
             );
             expect(result.content).toEqual([
                 { type: "paragraph", attrs: { textBlockStyle: "headline450" }, content: [{ type: "text", text: "Title" }] },
@@ -136,7 +152,7 @@ describe("convertDraftJsToTipTap", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "headline450", text: "Title" })], entityMap: {} },
                 {
-                    supports: [...defaultSupports],
+                    supports: allSupports,
                     textBlockStyleMap: { headline450: { textBlockType: "heading-2", textBlockStyle: "headline450" } },
                 },
             );
@@ -148,7 +164,7 @@ describe("convertDraftJsToTipTap", () => {
         it("maps a custom block type to a heading without textBlockStyle", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "headline450", text: "Title" })], entityMap: {} },
-                { supports: [...defaultSupports], textBlockStyleMap: { headline450: { textBlockType: "heading-2" } } },
+                { supports: allSupports, textBlockStyleMap: { headline450: { textBlockType: "heading-2" } } },
             );
             expect(result.content).toEqual([{ type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "Title" }] }]);
         });
@@ -156,7 +172,7 @@ describe("convertDraftJsToTipTap", () => {
         it("textBlockType overrides the heading level derived from the DraftJS header type", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "header-one", text: "Title" })], entityMap: {} },
-                { supports: [...defaultSupports], textBlockStyleMap: { "header-one": { textBlockType: "heading-2" } } },
+                { supports: allSupports, textBlockStyleMap: { "header-one": { textBlockType: "heading-2" } } },
             );
             expect(result.content).toEqual([{ type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "Title" }] }]);
         });
@@ -164,7 +180,7 @@ describe("convertDraftJsToTipTap", () => {
         it("converts a header type to a paragraph when mapped to textBlockType paragraph", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "header-one", text: "Title" })], entityMap: {} },
-                { supports: [...defaultSupports], textBlockStyleMap: { "header-one": { textBlockType: "paragraph", textBlockStyle: "huge" } } },
+                { supports: allSupports, textBlockStyleMap: { "header-one": { textBlockType: "paragraph", textBlockStyle: "huge" } } },
             );
             expect(result.content).toEqual([{ type: "paragraph", attrs: { textBlockStyle: "huge" }, content: [{ type: "text", text: "Title" }] }]);
         });
@@ -173,7 +189,7 @@ describe("convertDraftJsToTipTap", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "headline450", text: "" })], entityMap: {} },
                 {
-                    supports: [...defaultSupports],
+                    supports: allSupports,
                     textBlockStyleMap: { headline450: { textBlockType: "heading-2", textBlockStyle: "headline450" } },
                 },
             );
@@ -188,7 +204,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unordered-list-item", text: "a" }), makeBlock({ type: "unordered-list-item", text: "b" })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content).toEqual([
                 {
@@ -207,7 +223,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "ordered-list-item", text: "1" }), makeBlock({ type: "ordered-list-item", text: "2" })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].type).toBe("orderedList");
             expect(result.content?.[0].content).toHaveLength(2);
@@ -219,7 +235,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "ordered-list-item", text: "1" }), makeBlock({ type: "unordered-list-item", text: "a" })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content).toHaveLength(2);
             expect(result.content?.[0].type).toBe("orderedList");
@@ -232,7 +248,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unordered-list-item", text: "a" }), makeBlock({ type: "unstyled", text: "after" })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content).toHaveLength(2);
             expect(result.content?.[0].type).toBe("bulletList");
@@ -242,7 +258,7 @@ describe("convertDraftJsToTipTap", () => {
         it("falls back to paragraph when list type not supported", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "unordered-list-item", text: "a" })], entityMap: {} },
-                { supports: [] },
+                { supports: noSupports },
             );
             expect(result.content).toEqual([{ type: "paragraph", content: [{ type: "text", text: "a" }] }]);
         });
@@ -256,7 +272,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             const list = result.content?.[0];
             expect(list?.content).toHaveLength(2);
@@ -275,7 +291,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content).toEqual([
                 {
@@ -307,7 +323,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             const subList = result.content?.[0].content?.[0].content?.[1];
             expect(subList?.type).toBe("bulletList");
@@ -324,7 +340,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             const level1 = result.content?.[0].content?.[0].content?.[1];
             const level2 = level1?.content?.[0].content?.[1];
@@ -343,7 +359,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             const list = result.content?.[0];
             expect(list?.content).toHaveLength(2);
@@ -359,7 +375,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             const subList = result.content?.[0].content?.[0].content?.[1];
             expect(subList?.type).toBe("bulletList");
@@ -369,7 +385,7 @@ describe("convertDraftJsToTipTap", () => {
         it("places a leading indented item on the top level", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "unordered-list-item", text: "a", depth: 2 })], entityMap: {} },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content).toEqual([
                 {
@@ -389,7 +405,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             const parentItem = result.content?.[0].content?.[0];
             expect(parentItem?.content?.map((node) => node.type)).toEqual(["paragraph", "bulletList", "orderedList"]);
@@ -404,7 +420,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].type).toBe("bulletList");
             expect(result.content?.[0].content?.[0].content?.[1].type).toBe("orderedList");
@@ -420,7 +436,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content).toHaveLength(2);
             expect(result.content?.[0].type).toBe("bulletList");
@@ -437,7 +453,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports], listLevelMax: 2 },
+                { supports: allSupports, listLevelMax: 2 },
             );
             const subList = result.content?.[0].content?.[0].content?.[1];
             expect(subList?.content).toHaveLength(2);
@@ -453,7 +469,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports], listLevelMax: 1 },
+                { supports: allSupports, listLevelMax: 1 },
             );
             expect(result.content?.[0].content).toHaveLength(2);
             expect(result.content?.[0].content?.[1].content).toEqual([{ type: "paragraph", content: [{ type: "text", text: "a.1" }] }]);
@@ -467,7 +483,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unstyled", text: "bold", inlineStyleRanges: [{ style: "BOLD", offset: 0, length: 4 }] })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "bold", marks: [{ type: "bold" }] }]);
         });
@@ -478,7 +494,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unstyled", text: "abcdef", inlineStyleRanges: [{ style: "BOLD", offset: 2, length: 2 }] })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].content).toEqual([
                 { type: "text", text: "ab" },
@@ -502,7 +518,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             const segments = result.content?.[0].content;
             expect(segments).toEqual([
@@ -519,7 +535,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unstyled", text: "x", inlineStyleRanges: [{ style: "STRIKETHROUGH", offset: 0, length: 1 }] })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].content?.[0].marks).toEqual([{ type: "strike" }]);
         });
@@ -539,7 +555,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             const segments = result.content?.[0].content;
             expect(segments?.[0].marks).toEqual([{ type: "superscript" }]);
@@ -552,7 +568,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unstyled", text: "x", inlineStyleRanges: [{ style: "UNDERLINE", offset: 0, length: 1 }] })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].content?.[0].marks).toEqual([{ type: "underline" }]);
         });
@@ -563,7 +579,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unstyled", text: "x", inlineStyleRanges: [{ style: "UNDERLINE", offset: 0, length: 1 }] })],
                     entityMap: {},
                 },
-                { supports: ["bold"] },
+                { supports: onlySupports("bold") },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "x" }]);
         });
@@ -574,7 +590,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unstyled", text: "x", inlineStyleRanges: [{ style: "WAT", offset: 0, length: 1 }] })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "x" }]);
         });
@@ -585,7 +601,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unstyled", text: "x", inlineStyleRanges: [{ style: "BOLD", offset: 0, length: 1 }] })],
                     entityMap: {},
                 },
-                { supports: ["italic"] },
+                { supports: onlySupports("italic") },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "x" }]);
         });
@@ -603,7 +619,7 @@ describe("convertDraftJsToTipTap", () => {
                         ],
                         entityMap: {},
                     },
-                    { supports: [...defaultSupports] },
+                    { supports: allSupports },
                 ),
             ).not.toThrow();
         });
@@ -614,7 +630,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unstyled", text: "hi", inlineStyleRanges: [{ style: "highlight", offset: 0, length: 2 }] })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports], inlineStyleMap: { highlight: "highlight" } },
+                { supports: allSupports, inlineStyleMap: { highlight: "highlight" } },
             );
             expect(result.content?.[0].content).toEqual([
                 { type: "text", text: "hi", marks: [{ type: "inlineStyle", attrs: { type: "highlight" } }] },
@@ -627,7 +643,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unstyled", text: "x", inlineStyleRanges: [{ style: "HIGHLIGHT", offset: 0, length: 1 }] })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports], inlineStyleMap: { HIGHLIGHT: "highlight" } },
+                { supports: allSupports, inlineStyleMap: { HIGHLIGHT: "highlight" } },
             );
             expect(result.content?.[0].content).toEqual([
                 { type: "text", text: "x", marks: [{ type: "inlineStyle", attrs: { type: "highlight" } }] },
@@ -640,7 +656,7 @@ describe("convertDraftJsToTipTap", () => {
                     blocks: [makeBlock({ type: "unstyled", text: "x", inlineStyleRanges: [{ style: "unknown-style", offset: 0, length: 1 }] })],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports], inlineStyleMap: { highlight: "highlight" } },
+                { supports: allSupports, inlineStyleMap: { highlight: "highlight" } },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "x" }]);
         });
@@ -660,7 +676,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports], inlineStyleMap: { highlight: "highlight" } },
+                { supports: allSupports, inlineStyleMap: { highlight: "highlight" } },
             );
             expect(result.content?.[0].content).toEqual([
                 { type: "text", text: "x", marks: [{ type: "bold" }, { type: "inlineStyle", attrs: { type: "highlight" } }] },
@@ -672,7 +688,7 @@ describe("convertDraftJsToTipTap", () => {
         it("splits a U+00A0 character into a nonBreakingSpace atom node", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "unstyled", text: "a b" })], entityMap: {} },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "a" }, { type: "nonBreakingSpace" }, { type: "text", text: "b" }]);
         });
@@ -680,7 +696,7 @@ describe("convertDraftJsToTipTap", () => {
         it("splits a U+00AD character into a softHyphen atom node", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "unstyled", text: "long­word" })], entityMap: {} },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "long" }, { type: "softHyphen" }, { type: "text", text: "word" }]);
         });
@@ -697,7 +713,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].content).toEqual([
                 { type: "text", text: "a", marks: [{ type: "bold" }] },
@@ -709,7 +725,7 @@ describe("convertDraftJsToTipTap", () => {
         it("handles consecutive and mixed atom characters", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "unstyled", text: "a ­b" })], entityMap: {} },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].content).toEqual([
                 { type: "text", text: "a" },
@@ -722,7 +738,7 @@ describe("convertDraftJsToTipTap", () => {
         it("keeps atom characters as plain text when feature is not in supports", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "unstyled", text: "a b­c" })], entityMap: {} },
-                { supports: ["bold"] },
+                { supports: onlySupports("bold") },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "a b­c" }]);
         });
@@ -730,7 +746,7 @@ describe("convertDraftJsToTipTap", () => {
         it("splits only the supported atom character when one of the two is disabled", () => {
             const result = convertDraftJsToTipTap(
                 { blocks: [makeBlock({ type: "unstyled", text: "a b­c" })], entityMap: {} },
-                { supports: ["non-breaking-space"] },
+                { supports: onlySupports("nonBreakingSpace") },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "a" }, { type: "nonBreakingSpace" }, { type: "text", text: "b­c" }]);
         });
@@ -749,7 +765,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: { "0": { type: "LINK", mutability: "MUTABLE", data: { href: "https://example.com" } } },
                 },
-                { supports: [...defaultSupports], link: dummyLinkBlock },
+                { supports: allSupports, link: dummyLinkBlock },
             );
             expect(result.content?.[0].content).toEqual([
                 { type: "text", text: "click", marks: [{ type: "link", attrs: { data: { href: "https://example.com" } } }] },
@@ -768,7 +784,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: { "0": { type: "LINK", mutability: "MUTABLE", data: { href: "https://example.com" } } },
                 },
-                { supports: [...defaultSupports] },
+                { supports: allSupports },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "click" }]);
         });
@@ -791,7 +807,7 @@ describe("convertDraftJsToTipTap", () => {
                         "1": { type: "LINK", mutability: "MUTABLE", data: { href: "https://c.com" } },
                     },
                 },
-                { supports: [...defaultSupports], link: dummyLinkBlock },
+                { supports: allSupports, link: dummyLinkBlock },
             );
             const segments = result.content?.[0].content;
             expect(segments?.[0].marks).toEqual([{ type: "link", attrs: { data: { href: "https://a.com" } } }]);
@@ -811,7 +827,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: { "0": { type: "LINK", mutability: "MUTABLE", data: { href: "https://x.com" } } },
                 },
-                { supports: [...defaultSupports], link: dummyLinkBlock },
+                { supports: allSupports, link: dummyLinkBlock },
             );
             const marks = result.content?.[0].content?.[0].marks;
             expect(marks).toEqual([{ type: "bold" }, { type: "link", attrs: { data: { href: "https://x.com" } } }]);
@@ -829,7 +845,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: { "0": { type: "IMAGE", mutability: "IMMUTABLE", data: {} } },
                 },
-                { supports: [...defaultSupports], link: dummyLinkBlock },
+                { supports: allSupports, link: dummyLinkBlock },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "x" }]);
         });
@@ -846,7 +862,7 @@ describe("convertDraftJsToTipTap", () => {
                     ],
                     entityMap: {},
                 },
-                { supports: [...defaultSupports], link: dummyLinkBlock },
+                { supports: allSupports, link: dummyLinkBlock },
             );
             expect(result.content?.[0].content).toEqual([{ type: "text", text: "x" }]);
         });

--- a/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.ts
+++ b/packages/api/cms-api/src/blocks/tipTap/migrations/convertDraftJsToTipTap.ts
@@ -1,7 +1,7 @@
 import type { JSONContent } from "@tiptap/core";
 
 import type { Block } from "../../block";
-import type { TipTapSupports } from "../createTipTapRichTextBlock";
+import type { ResolvedTipTapSupports } from "../createTipTapRichTextBlock";
 
 interface DraftJsInlineStyleRange {
     style: string;
@@ -57,7 +57,7 @@ interface TextBlockStyleMapping {
 }
 
 interface ConvertOptions {
-    supports?: TipTapSupports[];
+    supports?: ResolvedTipTapSupports;
     link?: Block;
     /**
      * Maps DraftJS block types (e.g. custom `paragraph-small`) to a TipTap `textBlockStyle`
@@ -81,7 +81,7 @@ interface ConvertOptions {
     listLevelMax?: number;
 }
 
-const INLINE_STYLE_TO_MARK: Record<string, { mark: string; supports: TipTapSupports }> = {
+const INLINE_STYLE_TO_MARK: Record<string, { mark: string; supports: keyof ResolvedTipTapSupports }> = {
     BOLD: { mark: "bold", supports: "bold" },
     ITALIC: { mark: "italic", supports: "italic" },
     UNDERLINE: { mark: "underline", supports: "underline" },
@@ -109,6 +109,21 @@ const TEXT_BLOCK_TYPE_TO_HEADING_LEVEL: Record<TipTapTextBlockStyleTargetType, n
     "heading-6": 6,
 };
 
+const noSupports: ResolvedTipTapSupports = {
+    bold: false,
+    italic: false,
+    underline: false,
+    strike: false,
+    sub: false,
+    sup: false,
+    heading: false,
+    orderedList: false,
+    unorderedList: false,
+    nonBreakingSpace: false,
+    softHyphen: false,
+    link: false,
+};
+
 function makeEmptyDoc(): JSONContent {
     return { type: "doc", content: [{ type: "paragraph" }] };
 }
@@ -125,7 +140,7 @@ interface InlineSegment {
 function buildInlineContent(
     block: DraftJsBlock,
     entityMap: Record<string, DraftJsEntity>,
-    supports: Set<TipTapSupports>,
+    supports: ResolvedTipTapSupports,
     hasLink: boolean,
     inlineStyleMap: Record<string, string>,
 ): JSONContent[] {
@@ -176,7 +191,7 @@ function buildInlineContent(
         for (const range of styleRanges) {
             if (range.start <= start && range.end >= end) {
                 const mapping = INLINE_STYLE_TO_MARK[range.style];
-                if (mapping && supports.has(mapping.supports)) {
+                if (mapping && supports[mapping.supports]) {
                     if (!marks.some((mark) => mark.type === mapping.mark)) {
                         marks.push({ type: mapping.mark });
                     }
@@ -223,9 +238,9 @@ function makeTextNode(text: string, marks: NonNullable<JSONContent["marks"]>): J
 // RTE persists non-breaking-spaces and soft-hyphens) becomes a dedicated TipTap atom node
 // when the corresponding feature is supported. Otherwise the characters are preserved as-is
 // inside the surrounding text node.
-function splitAtomChars(text: string, marks: NonNullable<JSONContent["marks"]>, supports: Set<TipTapSupports>): JSONContent[] {
-    const supportsNbsp = supports.has("non-breaking-space");
-    const supportsShy = supports.has("soft-hyphen");
+function splitAtomChars(text: string, marks: NonNullable<JSONContent["marks"]>, supports: ResolvedTipTapSupports): JSONContent[] {
+    const supportsNbsp = supports.nonBreakingSpace;
+    const supportsShy = supports.softHyphen;
 
     if ((!supportsNbsp && !supportsShy) || (!text.includes(NBSP_CHAR) && !text.includes(SOFT_HYPHEN_CHAR))) {
         return text.length === 0 ? [] : [makeTextNode(text, marks)];
@@ -287,9 +302,9 @@ function makeListItem(inlineContent: JSONContent[]): JSONContent {
 
 type ListType = "orderedList" | "bulletList";
 
-const LIST_BLOCK_TYPE_TO_LIST: Record<string, { listType: ListType; supports: TipTapSupports }> = {
-    "unordered-list-item": { listType: "bulletList", supports: "unordered-list" },
-    "ordered-list-item": { listType: "orderedList", supports: "ordered-list" },
+const LIST_BLOCK_TYPE_TO_LIST: Record<string, { listType: ListType; supports: keyof ResolvedTipTapSupports }> = {
+    "unordered-list-item": { listType: "bulletList", supports: "unorderedList" },
+    "ordered-list-item": { listType: "orderedList", supports: "orderedList" },
 };
 
 interface OpenList {
@@ -309,7 +324,7 @@ export function convertDraftJsToTipTap(draftContent: DraftJsContent | undefined 
         return makeEmptyDoc();
     }
 
-    const supports = new Set<TipTapSupports>(options.supports ?? []);
+    const supports = options.supports ?? noSupports;
     const hasLink = !!options.link;
     const textBlockStyleMap = options.textBlockStyleMap ?? {};
     const inlineStyleMap = options.inlineStyleMap ?? {};
@@ -370,7 +385,7 @@ export function convertDraftJsToTipTap(draftContent: DraftJsContent | undefined 
         const inlineContent = buildInlineContent(block, entityMap, supports, hasLink, inlineStyleMap);
 
         const listMapping = LIST_BLOCK_TYPE_TO_LIST[block.type];
-        if (listMapping && supports.has(listMapping.supports)) {
+        if (listMapping && supports[listMapping.supports]) {
             addListItem(listMapping.listType, block.depth ?? 0, inlineContent);
             continue;
         }
@@ -383,7 +398,7 @@ export function convertDraftJsToTipTap(draftContent: DraftJsContent | undefined 
 
         topLevel.push(
             makeTextBlockNode(inlineContent, {
-                headingLevel: headingLevel !== undefined && supports.has("heading") ? headingLevel : undefined,
+                headingLevel: headingLevel !== undefined && supports.heading ? headingLevel : undefined,
                 textBlockStyle: mapping?.textBlockStyle,
             }),
         );

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -107,6 +107,7 @@ export {
     createTipTapRichTextBlock,
     type CreateTipTapRichTextBlockOptions,
     type TipTapRichTextBlockContent,
+    type TipTapSupports,
 } from "./blocks/tipTap/createTipTapRichTextBlock";
 export { transformToBlockSaveIndex } from "./blocks/transformToBlockSaveIndex/transformToBlockSaveIndex";
 export { IsLinkTarget } from "./blocks/validator/is-link-target.validator";


### PR DESCRIPTION
Changed the TipTap Rich Text Block's `supports` option from an array of feature names to an object of boolean flags. This allows users to selectively enable/disable features by merging with sensible defaults, rather than having to specify all supported features explicitly.

https://claude.ai/code/session_01YCfxggcpqQyb9tbnKpUD4i