### PR TITLE
cms-admin: Move icons to the start of the TipTap "More options" menu items

### DIFF
--- a/.changeset/tiptap-more-options-icon-alignment.md
+++ b/.changeset/tiptap-more-options-icon-alignment.md
@@ -2,6 +2,6 @@
 "@dextinity/cms-admin": patch
 ---
 
-Align icons flush right in the TipTap "More options" menu
+Move icons to the start of the TipTap "More options" menu items
 
-Superscript, Subscript, and custom inline-style menu items previously placed their icon directly after the label, so the icon's horizontal position varied with the label's length. The label now grows to fill the available space, so icons line up in a consistent column at the menu's right edge, matching the old Draft.js-based rich text editor.
+Superscript, Subscript, and custom inline-style menu items placed their icon directly after the label using a custom flexbox layout, so the icon's horizontal position varied with the label's length. They now use MUI's `ListItemIcon`/`ListItemText` with the icon leading the label, matching MUI's own menu item convention.

--- a/.changeset/tiptap-more-options-icon-alignment.md
+++ b/.changeset/tiptap-more-options-icon-alignment.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/cms-admin": patch
+---
+
+Align icons flush right in the TipTap "More options" menu
+
+Superscript, Subscript, and custom inline-style menu items previously placed their icon directly after the label, so the icon's horizontal position varied with the label's length. The label now grows to fill the available space, so icons line up in a consistent column at the menu's right edge, matching the old Draft.js-based rich text editor.

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -25,6 +25,7 @@ import {
     FormControl,
     inputBaseClasses,
     ListItemIcon,
+    ListItemText,
     Menu,
     MenuItem,
     Select,
@@ -544,14 +545,12 @@ export const TipTapToolbar = ({
                                                 onMouseDown={() => runMenuItemAction(item.onToggle)}
                                                 onClick={(e) => handleMenuItemKeyboardActivate(e, item.onToggle)}
                                             >
-                                                <Box component="span" sx={{ flexGrow: 1 }}>
-                                                    {item.label}
-                                                </Box>
                                                 {Icon && (
-                                                    <ListItemIcon sx={{ justifyContent: "flex-end" }}>
+                                                    <ListItemIcon>
                                                         <Icon />
                                                     </ListItemIcon>
                                                 )}
+                                                <ListItemText>{item.label}</ListItemText>
                                             </MenuItem>
                                         );
                                     })}

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -544,7 +544,9 @@ export const TipTapToolbar = ({
                                                 onMouseDown={() => runMenuItemAction(item.onToggle)}
                                                 onClick={(e) => handleMenuItemKeyboardActivate(e, item.onToggle)}
                                             >
-                                                {item.label}
+                                                <Box component="span" sx={{ flexGrow: 1 }}>
+                                                    {item.label}
+                                                </Box>
                                                 {Icon && (
                                                     <ListItemIcon sx={{ justifyContent: "flex-end" }}>
                                                         <Icon />


### PR DESCRIPTION
## Summary
- Superscript, Subscript, and custom inline-style menu items in the TipTap toolbar's "More options" menu placed their icon directly after the label using a custom flexbox layout, so the icon's horizontal position varied with the label's length.
- They now use MUI's `ListItemIcon`/`ListItemText` with the icon leading the label, matching MUI's own menu item convention.

Follow-up requested by @nsams on #6246 (comment: https://github.com/vivid-planet/dextinity/pull/6246#issuecomment-5439385562).

Stacked on #6246 — targets that branch instead of `main` so it merges after it.

Before:
<img width="377" height="315" alt="Bildschirmfoto 2026-08-27 um 13 32 12" src="https://github.com/user-attachments/assets/b56447b8-758a-499e-9f52-e9dee85395a6" />

After:
<img width="319" height="212" alt="Bildschirmfoto 2026-09-01 um 10 56 10" src="https://github.com/user-attachments/assets/43e5b690-59bc-4aeb-a8e4-742dba4e73ce" />

Storybook: https://deploy-preview-6281.cms-storybook.dextinity.com/?path=/story/@dextinity/cms-admin_blocks-tiptaprichtextblock--combined-text-block-and-inline-styles