### PR TITLE
mail-react: Stop relying on CSS that Gmail drops

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/1-email-basics.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/1-email-basics.md
@@ -5,7 +5,7 @@ title: Email Basics
 Email clients don't share a rendering engine the way web browsers do. The most constrained major client — Outlook on Windows (2007–2019) — uses Microsoft Word to render HTML, supporting only a fraction of modern CSS. While Outlook's global market share is small, it dominates in enterprise and B2B environments. This shapes every aspect of email development: table-based layouts (handled by MJML), inline styles for the base rendering, and responsive styles layered on top as progressive enhancement.
 
 :::tip
-For researching support across clients, [Can I email](https://www.caniemail.com/scoreboard/) and the [Litmus blog](https://www.litmus.com/blog/) are invaluable resources.
+For researching support across clients, [Can I email](https://www.caniemail.com/scoreboard/), [Google's Gmail CSS support](https://developers.google.com/workspace/gmail/design/css) and the [Litmus blog](https://www.litmus.com/blog/) are invaluable resources.
 :::
 
 ## MJML Fundamentals

--- a/docs/docs/3-features-modules/13-building-html-emails/5-customization.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/5-customization.md
@@ -162,6 +162,32 @@ registerStyles(
 Always use `!important` in media query overrides. Without it, the email client's inlined styles will take precedence and your responsive styles won't apply.
 :::
 
+### Selectors That Reach Every Client
+
+Gmail applies class, element and id selectors, and descendant and child combinators. It drops the whole rule for a pseudo-class or a pseudo-element, and of the attribute selectors it applies only `[class~="value"]`. Its mobile webmail is narrower still: no combinators, no attribute selectors, and no media queries, so no responsive rule reaches it.
+
+`:hover` is the exception, but only in Gmail's desktop webmail and its Android app, and not there on a non-Google account. Its iOS app and mobile webmail drop it, so keep state styles decorative.
+
+Where a rule depends on an item's position, set a modifier class while rendering:
+
+```css
+/* Gmail drops this. */
+.stackedList__item:not(:last-child) {
+    margin-bottom: 24px !important;
+}
+
+/* Gmail applies this. Set `--last` on the final item while rendering. */
+.stackedList__item {
+    margin-bottom: 24px !important;
+}
+
+.stackedList__item--last {
+    margin-bottom: 0 !important;
+}
+```
+
+A flex `gap` does not stand in for this — see [Multi-Column Symmetric Layouts](./6-layout-patterns.md#multi-column-symmetric-layouts).
+
 ### CSS Class Name Conventions
 
 The built-in components apply stable CSS class names that you can target in your own `registerStyles` calls:

--- a/docs/docs/3-features-modules/13-building-html-emails/6-layout-patterns.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/6-layout-patterns.md
@@ -311,13 +311,15 @@ Below the desktop breakpoint, the compensated inline widths no longer make sense
 
 The one design decision is **when to collapse to a stack** — and that's per-component. A dense 3-column row might need to stack at mobile; a 4-column row would be too cramped below the default breakpoint.
 
+The horizontal gap is `column-gap` rather than the `gap` shorthand, and the stacked gap is a margin that `threeColumnsSection__column--last` clears on the final column, because Gmail applies `column-gap` and not `row-gap`. The shorthand would set both, so the stack would space itself in every client except Gmail.
+
 ```ts
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
             .threeColumnsSection > table > tbody > tr > td > div {
                 display: flex !important;
-                gap: 20px !important;
+                column-gap: 20px !important;
             }
             .threeColumnsSection__column {
                 flex: 1 1 0% !important;
@@ -339,6 +341,10 @@ registerStyles(
                 flex: none !important;
                 width: 100% !important;
                 max-width: 100% !important;
+                margin-bottom: 20px !important;
+            }
+            .threeColumnsSection__column--last {
+                margin-bottom: 0 !important;
             }
         }
     `,

--- a/docs/docs/3-features-modules/13-building-html-emails/6-layout-patterns.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/6-layout-patterns.md
@@ -292,7 +292,7 @@ Outer columns get a width accounting for half-gap padding; inner columns are wid
         <MjmlText>Second</MjmlText>
     </MjmlColumn>
     <MjmlColumn
-        className="threeColumnsSection__column"
+        className="threeColumnsSection__column threeColumnsSection__column--last"
         width={outerColumnWidth}
         paddingLeft={halfColumnGap}
     >

--- a/packages/mail-react/README.md
+++ b/packages/mail-react/README.md
@@ -22,7 +22,7 @@ We extend `@faire/mjml-react` rather than fork it. A few rules keep that working
 ### Styling
 
 - **Inline first.** Components must render correctly without any `<style>` block — clients like Outlook ignore them.
-- **Media queries** via `registerStyles` are progressive enhancement for mobile, where modern CSS (flex, grid) is fine. Use `theme.breakpoints.*.belowMediaQuery` (max-width queries) to target viewports below a breakpoint.
+- **Media queries** via `registerStyles` are progressive enhancement for mobile, where modern CSS (flex, grid) is available — support still varies per property. Use `theme.breakpoints.*.belowMediaQuery` (max-width queries) to target viewports below a breakpoint.
 - **BEM, camelCase blocks.** Block `mjmlSection`, element `mjmlSection__item`, modifier `mjmlSection--indented`. Every component applies its block class and merges any consumer-provided `className` with `clsx`: `clsx("mjmlSection", className)`.
 
 ### Theme variants

--- a/packages/mail-react/src/__stories__/layout-patterns/SymmetricFourColumnLayout.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/SymmetricFourColumnLayout.stories.tsx
@@ -31,7 +31,6 @@ registerStyles(
             .symmetricFourColumnsSection > table > tbody > tr > td > div {
                 display: flex !important;
                 flex-direction: column !important;
-                gap: 20px !important;
             }
 
             .symmetricFourColumnsSection__column {
@@ -39,6 +38,11 @@ registerStyles(
                 width: 100% !important;
                 max-width: 100% !important;
                 display: block !important;
+                margin-bottom: 20px !important;
+            }
+
+            .symmetricFourColumnsSection__column--last {
+                margin-bottom: 0 !important;
             }
 
             .symmetricFourColumnsSection__column > table > tbody > tr > td {
@@ -91,7 +95,11 @@ export const Default: StoryObj = {
                         </MjmlText>
                         <MjmlText>Occaecati vel possimus similique reiciendis iure rerum sit architecto.</MjmlText>
                     </MjmlColumn>
-                    <MjmlColumn width={outerColumnWidth} paddingLeft={halfColumnGap} className="symmetricFourColumnsSection__column">
+                    <MjmlColumn
+                        width={outerColumnWidth}
+                        paddingLeft={halfColumnGap}
+                        className="symmetricFourColumnsSection__column symmetricFourColumnsSection__column--last"
+                    >
                         <MjmlText variant="subheading" bottomSpacing>
                             Fourth
                         </MjmlText>

--- a/packages/mail-react/src/__stories__/layout-patterns/SymmetricThreeColumnLayout.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/SymmetricThreeColumnLayout.stories.tsx
@@ -30,7 +30,7 @@ registerStyles(
         ${theme.breakpoints.default.belowMediaQuery} {
             .symmetricThreeColumnsSection > table > tbody > tr > td > div {
                 display: flex !important;
-                gap: 20px !important;
+                column-gap: 20px !important;
             }
 
             .symmetricThreeColumnsSection__column {
@@ -55,6 +55,11 @@ registerStyles(
                 flex: none !important;
                 width: 100% !important;
                 max-width: 100% !important;
+                margin-bottom: 20px !important;
+            }
+
+            .symmetricThreeColumnsSection__column--last {
+                margin-bottom: 0 !important;
             }
         }
     `,
@@ -95,7 +100,11 @@ export const Default: StoryObj = {
                             Numquam aut voluptas numquam aspernatur. Consequatur quidem omnis dolorem natus quis soluta. Est recusandae delectus.
                         </MjmlText>
                     </MjmlColumn>
-                    <MjmlColumn width={outerColumnWidth} paddingLeft={halfColumnGap} className="symmetricThreeColumnsSection__column">
+                    <MjmlColumn
+                        width={outerColumnWidth}
+                        paddingLeft={halfColumnGap}
+                        className="symmetricThreeColumnsSection__column symmetricThreeColumnsSection__column--last"
+                    >
                         <MjmlText variant="subheading" bottomSpacing>
                             Third column
                         </MjmlText>
@@ -142,7 +151,7 @@ registerStyles(
         ${theme.breakpoints.default.belowMediaQuery} {
             .neverStackingThreeColumnsSection > table > tbody > tr > td > div {
                 display: flex !important;
-                gap: 20px !important;
+                column-gap: 20px !important;
             }
 
             .neverStackingThreeColumnsSection__column {

--- a/skills/dextinity-mail-react/SKILL.md
+++ b/skills/dextinity-mail-react/SKILL.md
@@ -19,25 +19,28 @@ Before implementing any visual technique — even things that seem basic like ro
 
 Keep these open during email development:
 
-| Resource                       | What it's for                                                                    | URL                                  |
-| ------------------------------ | -------------------------------------------------------------------------------- | ------------------------------------ |
-| **Can I email**                | Check CSS/HTML feature support across email clients (like caniuse.com for email) | https://www.caniemail.com/           |
-| **MJML Documentation**         | Full reference for all MJML tags and their attributes                            | https://documentation.mjml.io/       |
-| **Litmus Blog & Resources**    | Email development best practices, testing guides, client quirks                  | https://www.litmus.com/blog/         |
-| **Campaign Monitor CSS Guide** | Comprehensive CSS support tables per email client                                | https://www.campaignmonitor.com/css/ |
-| **Bulletproof Backgrounds**    | VML-based background image generator for Outlook                                 | https://www.backgrounds.cm/          |
-| **Bulletproof Buttons**        | VML-based rounded button generator for Outlook                                   | https://www.buttons.cm/              |
+| Resource                       | What it's for                                                                    | URL                                                      |
+| ------------------------------ | -------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **Can I email**                | Check CSS/HTML feature support across email clients (like caniuse.com for email) | https://www.caniemail.com/                               |
+| **Gmail CSS support**          | Google's own list of the CSS properties and selectors Gmail applies              | https://developers.google.com/workspace/gmail/design/css |
+| **MJML Documentation**         | Full reference for all MJML tags and their attributes                            | https://documentation.mjml.io/                           |
+| **Litmus Blog & Resources**    | Email development best practices, testing guides, client quirks                  | https://www.litmus.com/blog/                             |
+| **Campaign Monitor CSS Guide** | Comprehensive CSS support tables per email client                                | https://www.campaignmonitor.com/css/                     |
+| **Bulletproof Backgrounds**    | VML-based background image generator for Outlook                                 | https://www.backgrounds.cm/                              |
+| **Bulletproof Buttons**        | VML-based rounded button generator for Outlook                                   | https://www.buttons.cm/                                  |
 
 ### The Research Habit
 
 When implementing any visual feature:
 
-1. Check [Can I email](https://www.caniemail.com/) for the CSS properties involved
+1. Check [Can I email](https://www.caniemail.com/) for the CSS properties and selectors involved
 2. If the property isn't supported in Outlook, search for VML workarounds or provide a graceful fallback (skipping border-radius is generally acceptable)
 3. Test in Storybook with the MJML Warnings panel open
 4. When uncertain, consult the Litmus blog or Campaign Monitor guide for known patterns
 
 This applies to seemingly simple things: `border-radius`, `background-image`, `flexbox`, `gap`, custom fonts — all have partial or no support in major email clients.
+
+For which selectors reach which clients, see [`styling-and-customization.md`](references/styling-and-customization.md) → Selectors That Reach Every Client.
 
 ### Library Documentation
 

--- a/skills/dextinity-mail-react/references/layout-patterns.md
+++ b/skills/dextinity-mail-react/references/layout-patterns.md
@@ -134,7 +134,7 @@ Three columns shown; for four or more, repeat the middle-column.
     <MjmlColumn className="multiColumnSection__column" width={innerColumnWidth} paddingLeft={halfColumnGap} paddingRight={halfColumnGap}>
         …
     </MjmlColumn>
-    <MjmlColumn className="multiColumnSection__column" width={outerColumnWidth} paddingLeft={halfColumnGap}>
+    <MjmlColumn className="multiColumnSection__column multiColumnSection__column--last" width={outerColumnWidth} paddingLeft={halfColumnGap}>
         …
     </MjmlColumn>
 </MjmlSection>

--- a/skills/dextinity-mail-react/references/layout-patterns.md
+++ b/skills/dextinity-mail-react/references/layout-patterns.md
@@ -95,6 +95,8 @@ registerStyles(
 );
 ```
 
+The margin sits on `.twoColumnsSection__leftColumn`, a class the section writes on every render. `.column:not(.column--last)` says the same thing and reads better, and Gmail drops it, taking the gap with it — see [`styling-and-customization.md`](styling-and-customization.md) → Selectors That Reach Every Client.
+
 For three or more equal-width columns, see [Multi-Column Symmetric Layouts](#multi-column-symmetric-layouts-3-columns).
 
 ---
@@ -156,7 +158,7 @@ All three strategies share the same flex reset on the `MjmlGroup` `<div>` that d
 ${theme.breakpoints.default.belowMediaQuery} {
     .multiColumnSection > table > tbody > tr > td > div {
         display: flex !important;
-        gap: 20px !important;
+        column-gap: 20px !important;
     }
     .multiColumnSection__column {
         flex: 1 1 0% !important;
@@ -178,11 +180,17 @@ ${theme.breakpoints.mobile.belowMediaQuery} {
         flex: none !important;
         width: 100% !important;
         max-width: 100% !important;
+        margin-bottom: 20px !important;
+    }
+    .multiColumnSection__column--last {
+        margin-bottom: 0 !important;
     }
 }
 ```
 
-**Strategy B** — collapse the two blocks: put `flex-direction: column` and `width: 100%` in the `default.belowMediaQuery` block and drop the `mobile.belowMediaQuery` block.
+The horizontal gap is `column-gap` rather than the `gap` shorthand, and the stacked gap is a margin that `multiColumnSection__column--last` clears on the final column, because Gmail applies `column-gap` and not `row-gap`. The shorthand would set both, so the stack would space itself in every client except Gmail.
+
+**Strategy B** — collapse the two blocks: put `flex-direction: column`, `width: 100%` and both margin rules in the `default.belowMediaQuery` block, drop the `mobile.belowMediaQuery` block, and drop `column-gap`, which a stack never uses.
 
 **Strategy C** — keep Strategy A's `default.belowMediaQuery` block and drop the `mobile.belowMediaQuery` block. The columns then hold their flex widths at every viewport.
 

--- a/skills/dextinity-mail-react/references/styling-and-customization.md
+++ b/skills/dextinity-mail-react/references/styling-and-customization.md
@@ -7,18 +7,21 @@ Deep dive into the desktop-first styling model, `registerStyles`, BEM naming, cu
 1. [Desktop-First Styling Model](#desktop-first-styling-model)
 2. [The `css` Helper](#the-css-helper)
 3. [Registering Responsive Styles](#registering-responsive-styles)
-4. [BEM Class Naming Convention](#bem-class-naming-convention)
-5. [Custom Component Pattern](#custom-component-pattern)
-6. [The `belowMediaQuery` Pattern](#the-belowmediaquery-pattern)
-7. [Overriding Built-In Components](#overriding-built-in-components)
-8. [Forwarding Props via `slotProps`](#forwarding-props-via-slotprops)
-9. [MJML Table Structure](#mjml-table-structure)
+4. [Selectors That Reach Every Client](#selectors-that-reach-every-client)
+5. [BEM Class Naming Convention](#bem-class-naming-convention)
+6. [Custom Component Pattern](#custom-component-pattern)
+7. [The `belowMediaQuery` Pattern](#the-belowmediaquery-pattern)
+8. [Overriding Built-In Components](#overriding-built-in-components)
+9. [Forwarding Props via `slotProps`](#forwarding-props-via-slotprops)
+10. [MJML Table Structure](#mjml-table-structure)
 
 ---
 
 ## Desktop-First Styling Model
 
 Email clients that lack CSS support are almost exclusively desktop clients (Outlook 2007–2019, older Lotus Notes). Mobile email clients — Apple Mail, Gmail app, Outlook mobile — all support `<style>` blocks and media queries.
+
+Reading a `<style>` block is not the same as applying everything in it. Gmail reads the block and then drops each rule whose selector it does not take — see [Selectors That Reach Every Client](#selectors-that-reach-every-client).
 
 This means:
 
@@ -103,6 +106,32 @@ registerStyles(css`
 - Duplicate registrations with the same function/string reference overwrite (stored in a `Map`)
 - Theme-aware entries always resolve against the **root theme** from `MjmlMailRoot` — nested `ThemeProvider` scopes do not affect them
 - Optional second argument: partial `MjmlStyle` props (forwarded to the underlying `<mj-style>`)
+
+---
+
+## Selectors That Reach Every Client
+
+Gmail applies class, element and id selectors, and descendant and child combinators. It drops the whole rule for a pseudo-class or a pseudo-element, and of the attribute selectors it applies only `[class~="value"]`. Its mobile webmail is narrower still: no combinators, no attribute selectors, and no media queries, so no responsive rule reaches it.
+
+`:hover` is the exception, but only in Gmail's desktop webmail and its Android app, and not there on a non-Google account. Its iOS app and mobile webmail drop it, so keep state styles decorative.
+
+Where a rule depends on an item's position, set a modifier class while rendering instead of using a positional selector:
+
+```tsx
+<td className={`stackedList__item ${isLastItem ? "stackedList__item--last" : ""}`}>
+```
+
+```css
+.stackedList__item {
+    margin-bottom: 24px !important;
+}
+
+.stackedList__item--last {
+    margin-bottom: 0 !important;
+}
+```
+
+A flex `gap` does not stand in for this — see [`layout-patterns.md`](layout-patterns.md) → Multi-Column Symmetric Layouts.
 
 ---
 


### PR DESCRIPTION
Stacked columns lose their gap in Gmail, while every other client shows it.

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13730