### PR TITLE
cms-admin: Expose setPageState in the usePage hook

### DIFF
--- a/.changeset/expose-set-page-state-in-use-page.md
+++ b/.changeset/expose-set-page-state-in-use-page.md
@@ -1,0 +1,33 @@
+---
+"@dextinity/cms-admin": minor
+---
+
+Expose `setPageState` in the `usePage` hook returned by `createUsePage`
+
+Until now, the page state could only be read, so features that modify a page's content had to be built into `createUsePage` itself (like `translateContent`).
+`setPageState` allows applications to change the page's content programmatically, for instance, to apply changes suggested by an assistant.
+The changes are applied locally only, `handleSavePage` persists them.
+
+Additionally, the `PageState` type is exported now.
+
+**Example**
+
+```tsx
+const { pageState, setPageState } = usePage({ pageId: id });
+
+const applySuggestedHtmlTitle = (htmlTitle: string) => {
+    setPageState((pageState) => {
+        if (!pageState?.document) {
+            return pageState;
+        }
+
+        return {
+            ...pageState,
+            document: {
+                ...pageState.document,
+                seo: { ...pageState.document.seo, htmlTitle },
+            },
+        };
+    });
+};
+```

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -196,7 +196,7 @@ export { serializeInitialValues } from "./form/serializeInitialValues";
 export { SyncFields } from "./form/SyncFields";
 export { useFormSaveConflict } from "./form/useFormSaveConflict";
 export { createEditPageNode } from "./pages/createEditPageNode";
-export { createUsePage } from "./pages/createUsePage";
+export { createUsePage, type PageState } from "./pages/createUsePage";
 export { PagesPage } from "./pages/pagesPage/PagesPage";
 export type { AllCategories } from "./pages/pageTree/PageTreeContext";
 export { useCopyPastePages } from "./pages/pageTree/useCopyPastePages";

--- a/packages/admin/cms-admin/src/pages/createUsePage.test.tsx
+++ b/packages/admin/cms-admin/src/pages/createUsePage.test.tsx
@@ -1,0 +1,108 @@
+import { type TypedDocumentNode, useQuery } from "@apollo/client";
+import { MockedProvider } from "@apollo/client/testing";
+import { MuiThemeProvider, SnackbarProvider } from "@dextinity/admin";
+import { createTheme } from "@mui/material";
+import type { PropsWithChildren } from "react";
+import { IntlProvider } from "react-intl";
+import { act, renderHook } from "test-utils";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import type { BlockInterface } from "../blocks/types";
+import { createUsePage } from "./createUsePage";
+
+vi.mock(import("@apollo/client"), async (importOriginal) => {
+    const originalModule = await importOriginal();
+    return {
+        ...originalModule,
+        useQuery: vi.fn(),
+    };
+});
+
+type TextBlockState = { text: string };
+
+const TextBlock = {
+    name: "Text",
+    defaultValues: () => ({ text: "" }),
+    input2State: (input: TextBlockState | null) => ({ text: input?.text ?? "" }),
+    state2Output: (state: TextBlockState) => ({ text: state.text }),
+    isValid: () => true,
+    AdminComponent: () => null,
+} as unknown as BlockInterface;
+
+type EditPageQuery = {
+    page: {
+        id: string;
+        path: string;
+        document: {
+            __typename: "Page";
+            id: string;
+            updatedAt: string;
+            content: TextBlockState;
+        } | null;
+    } | null;
+};
+
+const usePage = createUsePage({ rootBlocks: { content: TextBlock }, pageType: "Page" })<EditPageQuery>({
+    // The queries are never executed because `useQuery` is mocked and the page isn't saved in these tests.
+    getQuery: {} as TypedDocumentNode<EditPageQuery, { id: string }>,
+    updateMutation: {} as TypedDocumentNode<{ id: string } & { content: unknown }, { pageId: string; input: { content: unknown } }>,
+});
+
+function Providers({ children }: PropsWithChildren) {
+    return (
+        <MockedProvider>
+            <IntlProvider locale="en">
+                <MuiThemeProvider theme={createTheme()}>
+                    <SnackbarProvider>{children}</SnackbarProvider>
+                </MuiThemeProvider>
+            </IntlProvider>
+        </MockedProvider>
+    );
+}
+
+describe("createUsePage", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        (useQuery as Mock).mockReturnValue({
+            loading: false,
+            data: {
+                page: {
+                    id: "page-tree-node-id",
+                    path: "/example",
+                    document: {
+                        __typename: "Page",
+                        id: "page-id",
+                        updatedAt: "2026-01-01T00:00:00.000Z",
+                        content: { text: "Content from the api" },
+                    },
+                },
+            } satisfies EditPageQuery,
+            error: undefined,
+            refetch: vi.fn(),
+        });
+    });
+
+    it("initializes the page state with the block states of the loaded document", () => {
+        const { result } = renderHook(() => usePage({ pageId: "page-tree-node-id" }), { wrapper: Providers });
+
+        expect(result.current.pageState?.path).toBe("/example");
+        expect(result.current.pageState?.document?.content).toEqual({ text: "Content from the api" });
+        expect(result.current.hasChanges).toBe(false);
+    });
+
+    it("applies changes made through setPageState", () => {
+        const { result } = renderHook(() => usePage({ pageId: "page-tree-node-id" }), { wrapper: Providers });
+
+        act(() => {
+            result.current.setPageState((pageState) => {
+                if (!pageState?.document) {
+                    return pageState;
+                }
+                return { ...pageState, document: { ...pageState.document, content: { text: "Content set from outside" } } };
+            });
+        });
+
+        expect(result.current.pageState?.document?.content).toEqual({ text: "Content set from outside" });
+        expect(result.current.hasChanges).toBe(true);
+    });
+});

--- a/packages/admin/cms-admin/src/pages/createUsePage.tsx
+++ b/packages/admin/cms-admin/src/pages/createUsePage.tsx
@@ -84,7 +84,7 @@ type ReplaceBlockInputDataWithBlockState<Doc extends Record<string, unknown> | n
           [K in keyof Doc]: K extends "id" ? string : K extends keyof RootBlocks ? BlockState<RootBlocks[K]> : Doc[K]; // key id is always a string and never a block
       };
 
-type PageState<
+export type PageState<
     GQLEditPageQuery extends GQLEditPageQueryInterface<PageType> | null,
     RootBlocks extends RootBlocksInterface,
     PageType extends string,
@@ -110,6 +110,12 @@ interface UsePageProps {
 }
 interface UsePageApi<PageState, RootBlocks extends RootBlocksInterface> {
     pageState?: PageState;
+    /**
+     * Updates the page state, for instance, to programmatically change the content of a root block.
+     *
+     * The changes are only applied locally, call `handleSavePage` to persist them.
+     */
+    setPageState: Dispatch<SetStateAction<PageState | undefined>>;
     rootBlocksApi: BlockNodeApi<RootBlocks>;
     handleSavePage: () => Promise<void>;
     hasChanges?: boolean;
@@ -483,6 +489,7 @@ export const createUsePage: CreateUsePage =
                 hasChanges,
                 handleSavePage,
                 pageState,
+                setPageState,
                 rootBlocksApi,
                 loading,
                 error,


### PR DESCRIPTION
This is needed for the upcoming Admin AI Mode: agents repeatedly added workarounds like the following to allow updating the state:

```tsx
/** Wraps the page content block so that its Admin component publishes its updater to the surrounding bridge provider. */
export function withPageContentBlockStateBridge(block: typeof PageContentBlock): typeof PageContentBlock {
    const AdminComponent = ({ state, updateState }: { state: PageContentBlockState; updateState: UpdatePageContentBlockState }) => {
        const publishUpdateState = useContext(PublishUpdateStateContext);

        useEffect(() => {
            publishUpdateState?.(updateState);
        }, [publishUpdateState, updateState]);

        return <block.AdminComponent state={state} updateState={updateState} />;
    };

    return { ...block, AdminComponent };
}
```

This shouldn't be necessary if `setPageState` is exposed by the `usePage` hook.

https://claude.ai/code/session_01DokjgYKRsuurNZhg8fdLAk