### PR TITLE
cms-admin: Share the page state of usePage via context

### DIFF
--- a/.changeset/add-page-state-provider.md
+++ b/.changeset/add-page-state-provider.md
@@ -1,0 +1,46 @@
+---
+"@dextinity/cms-admin": minor
+---
+
+Add `PageStateProvider` and `usePageState`
+
+Components that want to read or modify the content of the page that is currently being edited had to receive the page state as a prop from the edit page.
+`PageStateProvider` shares the page state of `createUsePage`'s `usePage` hook with all nested components, so features that are rendered somewhere else in the Admin (like the AI mode) can access it via `usePageState`.
+
+**Example**
+
+Wrap the content of the edit page with the provider:
+
+```tsx
+const { pageState, setPageState /* ... */ } = usePage({ pageId: id });
+
+return (
+    <PageStateProvider pageState={pageState} setPageState={setPageState}>
+        {/* Toolbar, blocks, ... */}
+    </PageStateProvider>
+);
+```
+
+Nested components can then read and modify the page's content:
+
+```tsx
+const pageStateApi = usePageState<PageState>();
+
+const applySuggestedHtmlTitle = (htmlTitle: string) => {
+    pageStateApi?.setPageState((pageState) => {
+        if (!pageState?.document) {
+            return pageState;
+        }
+
+        return {
+            ...pageState,
+            document: {
+                ...pageState.document,
+                seo: { ...pageState.document.seo, htmlTitle },
+            },
+        };
+    });
+};
+```
+
+`usePageState` returns `undefined` when used outside of an edit page, for instance, when the AI mode is opened on a page that doesn't provide a page state.

--- a/demo/admin/src/documents/pages/EditPage.tsx
+++ b/demo/admin/src/documents/pages/EditPage.tsx
@@ -22,6 +22,7 @@ import {
     DependentsList,
     openSitePreviewWindow,
     PageName,
+    PageStateProvider,
     TranslateContentMenuItem,
     useBlockContext,
     useBlockPreview,
@@ -138,7 +139,7 @@ const usePage = createUsePage({
 
 export const EditPage = ({ id }: Props) => {
     const intl = useIntl();
-    const { pageState, rootBlocksApi, hasChanges, loading, dialogs, pageSaveButton, handleSavePage, translateContent } = usePage({
+    const { pageState, setPageState, rootBlocksApi, hasChanges, loading, dialogs, pageSaveButton, handleSavePage, translateContent } = usePage({
         pageId: id,
     });
 
@@ -180,143 +181,145 @@ export const EditPage = ({ id }: Props) => {
     }
 
     return (
-        <ContentGenerationConfigProvider
-            seo={{
-                getRelevantContent: () => {
-                    if (!pageState || !pageState.document) {
-                        return [];
-                    }
-
-                    return PageContentBlock.extractTextContents?.(pageState.document.content, { includeInvisibleContent: false }) ?? [];
-                },
-            }}
-        >
-            {hasChanges && (
-                <RouterPrompt
-                    message={(location) => {
-                        if (location.pathname.startsWith(match.url)) {
-                            return true;
-                        } //we navigated within our self
-                        return intl.formatMessage({
-                            id: "editPage.discardChanges",
-                            defaultMessage: "Discard unsaved changes?",
-                        });
-                    }}
-                    saveAction={async () => {
-                        try {
-                            await handleSavePage();
-                            return true;
-                        } catch {
-                            return false;
+        <PageStateProvider pageState={pageState} setPageState={setPageState}>
+            <ContentGenerationConfigProvider
+                seo={{
+                    getRelevantContent: () => {
+                        if (!pageState || !pageState.document) {
+                            return [];
                         }
-                    }}
-                />
-            )}
-            <Toolbar scopeIndicator={<ContentScopeIndicator />}>
-                <ToolbarItem>
-                    <IconButton onClick={stackApi?.goBack} size="large">
-                        <ArrowLeft />
-                    </IconButton>
-                </ToolbarItem>
-                <PageName pageId={id} />
-                <FillSpace />
-                <ToolbarActions>
-                    <Stack direction="row" spacing={1}>
-                        <CrudMoreActionsMenu
-                            overallActions={[
-                                {
-                                    label: <FormattedMessage id="pages.pages.page.edit.preview" defaultMessage="Site preview" />,
-                                    icon: <Preview />,
-                                    disabled: !pageState,
-                                    onClick: () => {
-                                        openSitePreviewWindow(pageState.path, contentScopeMatch.url);
+
+                        return PageContentBlock.extractTextContents?.(pageState.document.content, { includeInvisibleContent: false }) ?? [];
+                    },
+                }}
+            >
+                {hasChanges && (
+                    <RouterPrompt
+                        message={(location) => {
+                            if (location.pathname.startsWith(match.url)) {
+                                return true;
+                            } //we navigated within our self
+                            return intl.formatMessage({
+                                id: "editPage.discardChanges",
+                                defaultMessage: "Discard unsaved changes?",
+                            });
+                        }}
+                        saveAction={async () => {
+                            try {
+                                await handleSavePage();
+                                return true;
+                            } catch {
+                                return false;
+                            }
+                        }}
+                    />
+                )}
+                <Toolbar scopeIndicator={<ContentScopeIndicator />}>
+                    <ToolbarItem>
+                        <IconButton onClick={stackApi?.goBack} size="large">
+                            <ArrowLeft />
+                        </IconButton>
+                    </ToolbarItem>
+                    <PageName pageId={id} />
+                    <FillSpace />
+                    <ToolbarActions>
+                        <Stack direction="row" spacing={1}>
+                            <CrudMoreActionsMenu
+                                overallActions={[
+                                    {
+                                        label: <FormattedMessage id="pages.pages.page.edit.preview" defaultMessage="Site preview" />,
+                                        icon: <Preview />,
+                                        disabled: !pageState,
+                                        onClick: () => {
+                                            openSitePreviewWindow(pageState.path, contentScopeMatch.url);
+                                        },
                                     },
-                                },
-                                <TranslateContentMenuItem key="translate" translateContent={translateContent} disabled={!pageState?.document} />,
-                            ]}
-                        />
-                        {pageSaveButton}
-                    </Stack>
-                </ToolbarActions>
-            </Toolbar>
-            <MainContent disablePaddingBottom>
-                <BlockPreviewWithTabs previewUrl={previewUrl} previewState={previewState} previewApi={previewApi}>
-                    {[
-                        {
-                            key: "content",
-                            label: (
-                                <BlockAdminTabLabel isValid={rootBlocksApi.content.isValid}>
-                                    <FormattedMessage id="generic.blocks" defaultMessage="Blocks" />
-                                </BlockAdminTabLabel>
-                            ),
-                            content: (
-                                <BlockAdminComponentRoot
-                                    title={intl.formatMessage({ id: "pages.pages.page.edit.pageBlocks.title", defaultMessage: "Page" })}
-                                >
-                                    {rootBlocksApi.content.adminUI}
-                                </BlockAdminComponentRoot>
-                            ),
-                        },
-                        {
-                            key: "stage",
-                            label: (
-                                <BlockAdminTabLabel isValid={rootBlocksApi.stage.isValid}>
-                                    <FormattedMessage id="pages.page.edit.stage" defaultMessage="Stage" />
-                                </BlockAdminTabLabel>
-                            ),
-                            content: (
-                                <BlockAdminComponentRoot
-                                    title={intl.formatMessage({ id: "pages.pages.page.edit.stage.title", defaultMessage: "Stage" })}
-                                >
-                                    {rootBlocksApi.stage.adminUI}
-                                </BlockAdminComponentRoot>
-                            ),
-                        },
-                        {
-                            key: "config",
-                            label: (
-                                <BlockAdminTabLabel isValid={rootBlocksApi.seo.isValid}>
-                                    <FormattedMessage id="pages.pages.page.edit.config" defaultMessage="Config" />
-                                </BlockAdminTabLabel>
-                            ),
-                            content: rootBlocksApi.seo.adminUI,
-                        },
-                        {
-                            key: "dependents",
-                            label: (
-                                <BlockAdminTabLabel isValid={rootBlocksApi.seo.isValid}>
-                                    <FormattedMessage id="pages.pages.page.edit.dependents" defaultMessage="Dependents" />
-                                </BlockAdminTabLabel>
-                            ),
-                            content: (
-                                <DependentsList
-                                    query={pageTreeNodeDependentsQuery}
-                                    variables={{
-                                        id,
-                                    }}
-                                />
-                            ),
-                        },
-                        {
-                            key: "dependencies",
-                            label: (
-                                <BlockAdminTabLabel isValid={rootBlocksApi.seo.isValid}>
-                                    <FormattedMessage id="pages.pages.page.edit.dependencies" defaultMessage="Dependencies" />
-                                </BlockAdminTabLabel>
-                            ),
-                            content: (
-                                <DependenciesList
-                                    query={pageTreeNodeDependenciesQuery}
-                                    variables={{
-                                        id: pageState.document.id,
-                                    }}
-                                />
-                            ),
-                        },
-                    ]}
-                </BlockPreviewWithTabs>
-            </MainContent>
-            {dialogs}
-        </ContentGenerationConfigProvider>
+                                    <TranslateContentMenuItem key="translate" translateContent={translateContent} disabled={!pageState?.document} />,
+                                ]}
+                            />
+                            {pageSaveButton}
+                        </Stack>
+                    </ToolbarActions>
+                </Toolbar>
+                <MainContent disablePaddingBottom>
+                    <BlockPreviewWithTabs previewUrl={previewUrl} previewState={previewState} previewApi={previewApi}>
+                        {[
+                            {
+                                key: "content",
+                                label: (
+                                    <BlockAdminTabLabel isValid={rootBlocksApi.content.isValid}>
+                                        <FormattedMessage id="generic.blocks" defaultMessage="Blocks" />
+                                    </BlockAdminTabLabel>
+                                ),
+                                content: (
+                                    <BlockAdminComponentRoot
+                                        title={intl.formatMessage({ id: "pages.pages.page.edit.pageBlocks.title", defaultMessage: "Page" })}
+                                    >
+                                        {rootBlocksApi.content.adminUI}
+                                    </BlockAdminComponentRoot>
+                                ),
+                            },
+                            {
+                                key: "stage",
+                                label: (
+                                    <BlockAdminTabLabel isValid={rootBlocksApi.stage.isValid}>
+                                        <FormattedMessage id="pages.page.edit.stage" defaultMessage="Stage" />
+                                    </BlockAdminTabLabel>
+                                ),
+                                content: (
+                                    <BlockAdminComponentRoot
+                                        title={intl.formatMessage({ id: "pages.pages.page.edit.stage.title", defaultMessage: "Stage" })}
+                                    >
+                                        {rootBlocksApi.stage.adminUI}
+                                    </BlockAdminComponentRoot>
+                                ),
+                            },
+                            {
+                                key: "config",
+                                label: (
+                                    <BlockAdminTabLabel isValid={rootBlocksApi.seo.isValid}>
+                                        <FormattedMessage id="pages.pages.page.edit.config" defaultMessage="Config" />
+                                    </BlockAdminTabLabel>
+                                ),
+                                content: rootBlocksApi.seo.adminUI,
+                            },
+                            {
+                                key: "dependents",
+                                label: (
+                                    <BlockAdminTabLabel isValid={rootBlocksApi.seo.isValid}>
+                                        <FormattedMessage id="pages.pages.page.edit.dependents" defaultMessage="Dependents" />
+                                    </BlockAdminTabLabel>
+                                ),
+                                content: (
+                                    <DependentsList
+                                        query={pageTreeNodeDependentsQuery}
+                                        variables={{
+                                            id,
+                                        }}
+                                    />
+                                ),
+                            },
+                            {
+                                key: "dependencies",
+                                label: (
+                                    <BlockAdminTabLabel isValid={rootBlocksApi.seo.isValid}>
+                                        <FormattedMessage id="pages.pages.page.edit.dependencies" defaultMessage="Dependencies" />
+                                    </BlockAdminTabLabel>
+                                ),
+                                content: (
+                                    <DependenciesList
+                                        query={pageTreeNodeDependenciesQuery}
+                                        variables={{
+                                            id: pageState.document.id,
+                                        }}
+                                    />
+                                ),
+                            },
+                        ]}
+                    </BlockPreviewWithTabs>
+                </MainContent>
+                {dialogs}
+            </ContentGenerationConfigProvider>
+        </PageStateProvider>
     );
 };

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -198,6 +198,7 @@ export { useFormSaveConflict } from "./form/useFormSaveConflict";
 export { createEditPageNode } from "./pages/createEditPageNode";
 export { createUsePage, type PageState } from "./pages/createUsePage";
 export { PagesPage } from "./pages/pagesPage/PagesPage";
+export { type PageStateApi, PageStateProvider, usePageState } from "./pages/PageStateContext";
 export type { AllCategories } from "./pages/pageTree/PageTreeContext";
 export { useCopyPastePages } from "./pages/pageTree/useCopyPastePages";
 export { PageTreeSelect } from "./pages/pageTreeSelect/PageTreeSelect";

--- a/packages/admin/cms-admin/src/pages/PageStateContext.test.tsx
+++ b/packages/admin/cms-admin/src/pages/PageStateContext.test.tsx
@@ -1,0 +1,37 @@
+import { type PropsWithChildren, useState } from "react";
+import { act, renderHook } from "test-utils";
+import { describe, expect, it } from "vitest";
+
+import { PageStateProvider, usePageState } from "./PageStateContext";
+
+type TestPageState = { document: { seo: { htmlTitle: string } } };
+
+function TestEditPage({ children }: PropsWithChildren) {
+    const [pageState, setPageState] = useState<TestPageState | undefined>({ document: { seo: { htmlTitle: "Title from the api" } } });
+
+    return (
+        <PageStateProvider pageState={pageState} setPageState={setPageState}>
+            {children}
+        </PageStateProvider>
+    );
+}
+
+describe("usePageState", () => {
+    it("returns undefined outside of an edit page", () => {
+        const { result } = renderHook(() => usePageState<TestPageState>());
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it("gives nested components read and write access to the page state", () => {
+        const { result } = renderHook(() => usePageState<TestPageState>(), { wrapper: TestEditPage });
+
+        expect(result.current?.pageState?.document.seo.htmlTitle).toBe("Title from the api");
+
+        act(() => {
+            result.current?.setPageState((pageState) => (pageState ? { document: { seo: { htmlTitle: "Title set by the AI mode" } } } : pageState));
+        });
+
+        expect(result.current?.pageState?.document.seo.htmlTitle).toBe("Title set by the AI mode");
+    });
+});

--- a/packages/admin/cms-admin/src/pages/PageStateContext.tsx
+++ b/packages/admin/cms-admin/src/pages/PageStateContext.tsx
@@ -1,0 +1,35 @@
+import { createContext, type Dispatch, type PropsWithChildren, type SetStateAction, useContext, useMemo } from "react";
+
+export interface PageStateApi<PageState> {
+    pageState?: PageState;
+    /**
+     * Updates the page state, for instance, to programmatically change the content of a root block.
+     *
+     * The changes are applied locally, the page must be saved to persist them.
+     */
+    setPageState: Dispatch<SetStateAction<PageState | undefined>>;
+}
+
+// The shape of the page state depends on the page's type, therefore it can't be typed here. Consumers pass the expected shape to usePageState.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const PageStateContext = createContext<PageStateApi<any> | undefined>(undefined);
+
+/**
+ * Provides the page state of an edit page to nested components, for instance, to the Admin AI mode.
+ *
+ * Wrap the content of an edit page with it and pass the values returned by the usePage hook created with createUsePage.
+ */
+export function PageStateProvider<PageState>({ pageState, setPageState, children }: PropsWithChildren<PageStateApi<PageState>>) {
+    const value = useMemo(() => ({ pageState, setPageState }), [pageState, setPageState]);
+
+    return <PageStateContext.Provider value={value}>{children}</PageStateContext.Provider>;
+}
+
+/**
+ * Gives access to the page state of the surrounding edit page, for instance, to read or modify the page's content.
+ *
+ * Returns undefined when used outside of an edit page.
+ */
+export function usePageState<PageState = unknown>(): PageStateApi<PageState> | undefined {
+    return useContext(PageStateContext);
+}


### PR DESCRIPTION
> [!NOTE]
> Stacked on https://github.com/vivid-planet/dextinity/pull/6284 (which exposes `setPageState`), so the diff shown here contains only the context on top of it. Alternative to #6284, not a replacement — the context is only useful together with the setter.

## Problem

The page state of `createUsePage`'s `usePage` hook is only available inside the component that calls the hook (the app's `EditPage`). Anything that wants to read or modify the content of the page currently being edited has to receive it as a prop from there.

The Admin AI mode is rendered outside of the edit page's tree branches that hold the state (it lives next to the page's content, not inside a block), and it should also work when no page is being edited at all. Prop drilling the state from every `EditPage` into it doesn't scale.

## Solution

Add a `PageStateProvider` that shares `pageState` and `setPageState` with all nested components, and a `usePageState()` hook to read them. The app wraps its edit page content with the provider once, the same way `ContentGenerationConfigProvider` is already wired up.

`usePageState()` returns `undefined` outside of an edit page, so features like the AI mode can tell "no page here" from "page with empty content".

Since the shape of the page state depends on the page type, the context value is loosely typed and `usePageState<PageState>()` takes the expected shape as a type parameter.

The provider takes the state as props instead of being returned ready-made from `usePage`, because a component created inside the hook would get a new identity whenever the page state changes, which would remount the whole edit page on every keystroke.

## Example

In the app's `EditPage` (done in Demo in this PR):

```tsx
const { pageState, setPageState /* ... */ } = usePage({ pageId: id });

return (
    <PageStateProvider pageState={pageState} setPageState={setPageState}>
        {/* Toolbar, blocks, ... */}
    </PageStateProvider>
);
```

In a component nested anywhere below it:

```tsx
const pageStateApi = usePageState<PageState>();

const applySuggestedHtmlTitle = (htmlTitle: string) => {
    pageStateApi?.setPageState((pageState) => {
        if (!pageState?.document) {
            return pageState;
        }

        return {
            ...pageState,
            document: {
                ...pageState.document,
                seo: { ...pageState.document.seo, htmlTitle },
            },
        };
    });
};
```

Covered by a unit test (`PageStateContext.test.tsx`) for reading and writing through the context and for the "outside of an edit page" case.

## Open TODOs/questions

- The Demo wiring only demonstrates the integration point; nothing consumes `usePageState` in Demo yet, as the AI mode isn't there. Happy to drop that part if you'd rather keep Demo free of it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DokjgYKRsuurNZhg8fdLAk)_