### PR TITLE
Reduce Renovate memory usage to prevent OOM-killed jobs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["github>vivid-planet/dextinity//renovate/default"],
-    "postUpdateOptions": ["pnpmDedupe"],
+    "lockFileMaintenance": { "enabled": false },
     "toolSettings": {
-        "nodeMaxMemory": 2560
+        "nodeMaxMemory": 2048
     }
 }


### PR DESCRIPTION
## Problem

Renovate runs for this repository keep getting OOM-killed. The Mend-hosted Renovate app runs each job with a hard 3 GB memory cap that cannot be raised, and our pnpm monorepo (~3,300 lockfile entries) pushes past it whenever Renovate does a full lockfile resolution. As a result, no dependency updates have landed for weeks — the [Dependency Dashboard](https://github.com/vivid-planet/dextinity/issues/2742) has been stale since 2026-07-28 with a growing backlog of rate-limited updates.

Two config settings force that worst-case full resolution on almost every run, and a third makes the kill more likely:

- `postUpdateOptions: ["pnpmDedupe"]` runs `pnpm dedupe` — a complete re-resolution of the lockfile — on **every** update branch, so even a one-line patch bump pays the full memory cost.
- `lockFileMaintenance` (enabled by our shared `renovate/default` preset) regenerates the entire lockfile from a cold metadata cache, the most memory-intensive job of all.
- `toolSettings.nodeMaxMemory: 2560` allows the Node heap to grow to 2.5 GB inside a 3 GB VM that also hosts the Renovate process itself, so the kernel OOM-kills the job before V8 ever feels heap pressure and garbage-collects.

## Solution

Cut the memory-heavy work out of routine Renovate runs instead of trying to fit it under the cap:

- Drop `pnpmDedupe` from `postUpdateOptions` — deduping can be done manually/periodically; it doesn't need to run per update branch.
- Disable `lockFileMaintenance` for this repository only (repo-level override; the shared preset used by other repos is untouched).
- Lower `nodeMaxMemory` to 2048 so V8 garbage-collects within budget rather than growing until the kernel SIGKILLs the job.

https://claude.ai/code/session_01FFfBH9KrFMUmEneKxpdHy1