### PR TITLE
Demo Site: add unit testing setup with Vitest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
                   path: |
                       packages/*/junit-unit.xml
                       packages/*/*/junit-unit.xml
+                      demo/*/junit-unit.xml
                   overwrite: true
 
     test-storybook:

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -27,7 +27,10 @@
         "lint:prettier": "pnpm exec prettier --check '*.{ts,js,json,md,yml,yaml,css,scss}'",
         "lint:style": "pnpm exec stylelint '**/*.{css,scss}'",
         "lint:tsc": "pnpm exec next typegen && tsc --project .",
-        "serve": "NODE_ENV=production node dist/server.js"
+        "serve": "NODE_ENV=production node dist/server.js",
+        "test": "pnpm run test:unit",
+        "test:unit": "vitest --run",
+        "test:watch": "vitest --watch"
     },
     "dependencies": {
         "@base-ui/react": "^1.4.1",
@@ -78,6 +81,7 @@
         "chokidar-cli": "^3.0.0",
         "eslint": "^9.39.4",
         "graphql": "^16.14.2",
+        "jsdom": "^28.1.0",
         "npm-run-all2": "^8.0.4",
         "prettier": "^3.6.2",
         "sass": "^1.90.0",
@@ -85,7 +89,9 @@
         "stylelint": "^16.24.0",
         "stylelint-config-standard-scss": "^16.0.0",
         "typed-scss-modules": "^8.1.1",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vite-tsconfig-paths": "^6.0.4",
+        "vitest": "^4.1.8"
     },
     "engines": {
         "node": "24"

--- a/demo/site/src/util/createSitePath.test.ts
+++ b/demo/site/src/util/createSitePath.test.ts
@@ -1,0 +1,12 @@
+import { createSitePath } from "@src/util/createSitePath";
+import { describe, expect, it } from "vitest";
+
+describe("createSitePath", () => {
+    it("prefixes the path with the scope's language", () => {
+        expect(createSitePath({ path: "/news", scope: { language: "en" } })).toBe("/en/news");
+    });
+
+    it("throws when the path doesn't start with a slash", () => {
+        expect(() => createSitePath({ path: "news", scope: { language: "en" } })).toThrow("Path must start with a `/`.");
+    });
+});

--- a/demo/site/vitest.config.ts
+++ b/demo/site/vitest.config.ts
@@ -1,0 +1,12 @@
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    plugins: [tsconfigPaths()],
+    test: {
+        environment: "jsdom",
+        exclude: [".next/**", "dist/**", "node_modules/**"],
+        reporters: ["default", "junit"],
+        outputFile: { junit: "./junit.xml" },
+    },
+});

--- a/demo/site/vitest.config.ts
+++ b/demo/site/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
         environment: "jsdom",
         exclude: [".next/**", "dist/**", "node_modules/**"],
         reporters: ["default", "junit"],
-        outputFile: { junit: "./junit.xml" },
+        outputFile: { junit: "./junit-unit.xml" },
     },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,6 +654,9 @@ importers:
       graphql:
         specifier: ^16.14.2
         version: 16.14.2
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1)
       npm-run-all2:
         specifier: ^8.0.4
         version: 8.0.4
@@ -678,6 +681,12 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vite-tsconfig-paths:
+        specifier: ^6.0.4
+        version: 6.0.4(@types/node@24.13.3)(jiti@2.7.0)(sass@1.93.0)(supports-color@8.1.1)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.8)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.14.6(@types/node@24.13.3)(typescript@5.9.3))(sass@1.93.0)(terser@5.46.1)(yaml@2.8.3)
 
   docs:
     dependencies:


### PR DESCRIPTION
Adds a unit testing setup to the site. This was first proposed in https://github.com/vivid-planet/dextinity-starter/pull/395 and rejected due to no real world examples. However, since some of our projects already have a unit testing setup in the site (e.g., an online shop) and writing unit tests becomes effortless with agentic coding, I suggest to revise this decision and add a unit testing setup to the Demo/Starter.

https://claude.ai/code/session_01BTrAyuuTjXFqBTp9ip9bXp