### PR TITLE
Fix package name in backported changeset

### DIFF
--- a/.changeset/olive-pears-invent.md
+++ b/.changeset/olive-pears-invent.md
@@ -1,5 +1,5 @@
 ---
-"@dextinity/admin": patch
+"@comet/admin": patch
 ---
 
 Show the GraphQL error messages in the error dialog again


### PR DESCRIPTION
## Problem

The release workflow on `v8.x.x` fails when assembling the release plan:

> 🦋 error Error: Found changeset olive-pears-invent for package @dextinity/admin which is not in the workspace

No release can be published from `v8.x.x` until this is resolved.

## Cause

`.changeset/olive-pears-invent.md` was backported from a branch where the packages are already published under the `@dextinity/*` scope. On `v8.x.x` the packages still use the `@comet/*` scope, so `@dextinity/admin` does not exist in the workspace and Changesets aborts.

## Fix

Rename the package in the changeset's frontmatter to `@comet/admin`, which matches the name in `packages/admin/admin/package.json` on this branch. The changeset text is unchanged, so the released changelog entry stays the same.

## Further information

- Failing run: https://github.com/vivid-planet/dextinity/actions/runs/33611211505/job/100193055791

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fZZZNfd4R2ZKrrjzHHBEZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015fZZZNfd4R2ZKrrjzHHBEZ)_