### PR TITLE
RFC: Restrict content scope values to `string | number | null | undefined`

### DIFF
--- a/.changeset/narrow-content-scope-value-types.md
+++ b/.changeset/narrow-content-scope-value-types.md
@@ -17,14 +17,15 @@ Scope dimensions are now typed as `string | number | null | undefined`:
 
 **Migration**
 
-TypeScript only gives classes an index signature when it is declared explicitly, so scope classes in your application need one:
+TypeScript only gives classes an index signature when it is declared explicitly, so scope classes in your application need one.
+It can be narrower than the interface, so a scope with only string dimensions declares `[key: string]: string`:
 
 ```ts
 @Embeddable()
 @ObjectType("PageTreeNodeScope")
 @InputType("PageTreeNodeScopeInput")
 export class PageTreeNodeScope {
-    [key: string]: string | number | null | undefined;
+    [key: string]: string;
 
     @Property({ columnType: "text" })
     @Field()

--- a/.changeset/narrow-content-scope-value-types.md
+++ b/.changeset/narrow-content-scope-value-types.md
@@ -38,13 +38,3 @@ export class PageTreeNodeScope {
     language: string;
 }
 ```
-
-Places that used a scope value where a `string` is expected (for instance a language passed to a translation service) now need an explicit conversion:
-
-```ts
-// Before
-transformToSlug(name, scope.language);
-
-// After
-transformToSlug(name, String(scope.language));
-```

--- a/.changeset/narrow-content-scope-value-types.md
+++ b/.changeset/narrow-content-scope-value-types.md
@@ -1,0 +1,49 @@
+---
+"@dextinity/cms-api": major
+"@dextinity/brevo-api": major
+"@dextinity/cms-admin": major
+"@dextinity/site-nextjs": major
+---
+
+Restrict content scope values to `string | number | null | undefined`
+
+The content scope interfaces accepted values of any type (`Record<string, any>`, `[key: string]: unknown`), which hid mistakes such as passing a scope class instead of a scope instance, or wrapping a scope in another object.
+Scope dimensions are now typed as `string | number | null | undefined`:
+
+- `ScopeInterface` (page tree), `RedirectScopeInterface` and `DamScopeInterface` in `@dextinity/cms-api`
+- `EmailCampaignScopeInterface` in `@dextinity/brevo-api`
+- `ContentScope` in `@dextinity/cms-admin`
+- `scope` in the preview params returned by `previewParams()`, `legacyPagesRouterPreviewParams()` and `setSitePreviewParams()` in `@dextinity/site-nextjs`
+
+**Migration**
+
+TypeScript only gives classes an index signature when it is declared explicitly, so scope classes in your application need one:
+
+```ts
+@Embeddable()
+@ObjectType("PageTreeNodeScope")
+@InputType("PageTreeNodeScopeInput")
+export class PageTreeNodeScope {
+    [key: string]: string | number | null | undefined;
+
+    @Property({ columnType: "text" })
+    @Field()
+    @IsString()
+    domain: string;
+
+    @Property({ columnType: "text" })
+    @Field()
+    @IsString()
+    language: string;
+}
+```
+
+Places that used a scope value where a `string` is expected (for instance a language passed to a translation service) now need an explicit conversion:
+
+```ts
+// Before
+transformToSlug(name, scope.language);
+
+// After
+transformToSlug(name, String(scope.language));
+```

--- a/demo/api/src/brevo/brevo-contact/dto/brevo-contact-subscribe.scope.ts
+++ b/demo/api/src/brevo/brevo-contact/dto/brevo-contact-subscribe.scope.ts
@@ -1,7 +1,7 @@
 import { IsString, MaxLength } from "class-validator";
 
 export class EmailContactSubscribeScope {
-    [key: string]: string | number | null | undefined;
+    [key: string]: string;
 
     @IsString()
     @MaxLength(64)

--- a/demo/api/src/brevo/brevo-contact/dto/brevo-contact-subscribe.scope.ts
+++ b/demo/api/src/brevo/brevo-contact/dto/brevo-contact-subscribe.scope.ts
@@ -1,6 +1,8 @@
 import { IsString, MaxLength } from "class-validator";
 
 export class EmailContactSubscribeScope {
+    [key: string]: string | number | null | undefined;
+
     @IsString()
     @MaxLength(64)
     domain: string;

--- a/demo/api/src/brevo/email-campaign/email-campaign-content-scope.ts
+++ b/demo/api/src/brevo/email-campaign/email-campaign-content-scope.ts
@@ -6,6 +6,8 @@ import { IsString } from "class-validator";
 @ObjectType()
 @InputType("EmailCampaignContentScopeInput")
 export class EmailCampaignContentScope {
+    [key: string]: string | number | null | undefined;
+
     @Property({ columnType: "text" })
     @Field()
     @IsString()

--- a/demo/api/src/brevo/email-campaign/email-campaign-content-scope.ts
+++ b/demo/api/src/brevo/email-campaign/email-campaign-content-scope.ts
@@ -6,7 +6,7 @@ import { IsString } from "class-validator";
 @ObjectType()
 @InputType("EmailCampaignContentScopeInput")
 export class EmailCampaignContentScope {
-    [key: string]: string | number | null | undefined;
+    [key: string]: string;
 
     @Property({ columnType: "text" })
     @Field()

--- a/demo/api/src/dam/dto/dam-scope.ts
+++ b/demo/api/src/dam/dto/dam-scope.ts
@@ -6,6 +6,8 @@ import { IsString } from "class-validator";
 @ObjectType()
 @InputType("DamScopeInput")
 export class DamScope {
+    [key: string]: string | number | null | undefined;
+
     @Property({ columnType: "text" })
     @Field()
     @IsString()

--- a/demo/api/src/dam/dto/dam-scope.ts
+++ b/demo/api/src/dam/dto/dam-scope.ts
@@ -6,7 +6,7 @@ import { IsString } from "class-validator";
 @ObjectType()
 @InputType("DamScopeInput")
 export class DamScope {
-    [key: string]: string | number | null | undefined;
+    [key: string]: string;
 
     @Property({ columnType: "text" })
     @Field()

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -51,6 +51,8 @@ registerEnumType(NewsCategory, {
 @ObjectType("")
 @InputType("NewsContentScopeInput")
 export class NewsContentScope {
+    [key: string]: string | number | null | undefined;
+
     @Property({ columnType: "text" })
     @Field()
     @IsString()

--- a/demo/api/src/news/entities/news.entity.ts
+++ b/demo/api/src/news/entities/news.entity.ts
@@ -51,7 +51,7 @@ registerEnumType(NewsCategory, {
 @ObjectType("")
 @InputType("NewsContentScopeInput")
 export class NewsContentScope {
-    [key: string]: string | number | null | undefined;
+    [key: string]: string;
 
     @Property({ columnType: "text" })
     @Field()

--- a/demo/api/src/page-tree/dto/page-tree-node-scope.ts
+++ b/demo/api/src/page-tree/dto/page-tree-node-scope.ts
@@ -7,6 +7,8 @@ import { IsString } from "class-validator";
 @InputType("PageTreeNodeScopeInput") // name must not be changed in the app
 // @TODO: disguise @ObjectType("PageTreeContentScope") and @InputType("PageTreeContentScopeInput") decorators under a custom decorator: f.i. @PageTreeNodeScope
 export class PageTreeNodeScope {
+    [key: string]: string | number | null | undefined;
+
     @Property({ columnType: "text" })
     @Field()
     @IsString()

--- a/demo/api/src/page-tree/dto/page-tree-node-scope.ts
+++ b/demo/api/src/page-tree/dto/page-tree-node-scope.ts
@@ -7,7 +7,7 @@ import { IsString } from "class-validator";
 @InputType("PageTreeNodeScopeInput") // name must not be changed in the app
 // @TODO: disguise @ObjectType("PageTreeContentScope") and @InputType("PageTreeContentScopeInput") decorators under a custom decorator: f.i. @PageTreeNodeScope
 export class PageTreeNodeScope {
-    [key: string]: string | number | null | undefined;
+    [key: string]: string;
 
     @Property({ columnType: "text" })
     @Field()

--- a/demo/api/src/redirects/dto/redirect-scope.ts
+++ b/demo/api/src/redirects/dto/redirect-scope.ts
@@ -7,6 +7,8 @@ import { IsString } from "class-validator";
 @InputType("RedirectScopeInput") // name must not be changed in the app
 // @TODO: disguise @ObjectType("RedirectScope") and @InputType("RedirectScopeInput") decorators under a custom decorator: f.i. @RedirectScope
 export class RedirectScope {
+    [key: string]: string | number | null | undefined;
+
     @Index() // this does nothing, migration has to be created manually as the entity is in library
     @Property({ columnType: "text" })
     @Field()

--- a/demo/api/src/redirects/dto/redirect-scope.ts
+++ b/demo/api/src/redirects/dto/redirect-scope.ts
@@ -7,7 +7,7 @@ import { IsString } from "class-validator";
 @InputType("RedirectScopeInput") // name must not be changed in the app
 // @TODO: disguise @ObjectType("RedirectScope") and @InputType("RedirectScopeInput") decorators under a custom decorator: f.i. @RedirectScope
 export class RedirectScope {
-    [key: string]: string | number | null | undefined;
+    [key: string]: string;
 
     @Index() // this does nothing, migration has to be created manually as the entity is in library
     @Property({ columnType: "text" })

--- a/packages/admin/brevo-admin/src/brevoConfiguration/BrevoConfigPage.tsx
+++ b/packages/admin/brevo-admin/src/brevoConfiguration/BrevoConfigPage.tsx
@@ -1,4 +1,4 @@
-import { useContentScope } from "@dextinity/cms-admin";
+import { type ContentScope, useContentScope } from "@dextinity/cms-admin";
 import type { JSX } from "react";
 
 import { useBrevoConfig } from "../common/BrevoConfigProvider";
@@ -8,13 +8,10 @@ export function BrevoConfigPage(): JSX.Element {
     const { scopeParts } = useBrevoConfig();
     const { scope: completeScope } = useContentScope();
 
-    const scope = scopeParts.reduce(
-        (acc, scopePart) => {
-            acc[scopePart] = completeScope[scopePart];
-            return acc;
-        },
-        {} as { [key: string]: unknown },
-    );
+    const scope = scopeParts.reduce((acc, scopePart) => {
+        acc[scopePart] = completeScope[scopePart];
+        return acc;
+    }, {} as ContentScope);
 
     return <BrevoConfigForm scope={scope} />;
 }

--- a/packages/admin/brevo-admin/src/brevoContacts/BrevoContactsPage.tsx
+++ b/packages/admin/brevo-admin/src/brevoContacts/BrevoContactsPage.tsx
@@ -1,5 +1,5 @@
 import { type GridColDef, Stack, StackPage, StackSwitch, StackToolbar } from "@dextinity/admin";
-import { ContentScopeIndicator, useContentScope } from "@dextinity/cms-admin";
+import { type ContentScope, ContentScopeIndicator, useContentScope } from "@dextinity/cms-admin";
 import type { DocumentNode } from "graphql";
 import type { JSX, ReactNode } from "react";
 import { useIntl } from "react-intl";
@@ -27,13 +27,10 @@ function createBrevoContactsPage({
         const { scopeParts } = useBrevoConfig();
         const { scope: completeScope } = useContentScope();
 
-        const scope = scopeParts.reduce(
-            (acc, scopePart) => {
-                acc[scopePart] = completeScope[scopePart];
-                return acc;
-            },
-            {} as { [key: string]: unknown },
-        );
+        const scope = scopeParts.reduce((acc, scopePart) => {
+            acc[scopePart] = completeScope[scopePart];
+            return acc;
+        }, {} as ContentScope);
 
         return (
             <ConfigVerification scope={scope}>

--- a/packages/admin/brevo-admin/src/brevoTestContacts/BrevoTestContactsPage.tsx
+++ b/packages/admin/brevo-admin/src/brevoTestContacts/BrevoTestContactsPage.tsx
@@ -1,5 +1,5 @@
 import { type GridColDef, Stack, StackPage, StackSwitch, StackToolbar } from "@dextinity/admin";
-import { ContentScopeIndicator, useContentScope } from "@dextinity/cms-admin";
+import { type ContentScope, ContentScopeIndicator, useContentScope } from "@dextinity/cms-admin";
 import type { DocumentNode } from "graphql";
 import type { JSX, ReactNode } from "react";
 import { useIntl } from "react-intl";
@@ -31,13 +31,10 @@ function createBrevoTestContactsPage({
         const scopeParts = passedScopeParts ?? brevoConfig.scopeParts;
         const { scope: completeScope } = useContentScope();
 
-        const scope = scopeParts.reduce(
-            (acc, scopePart) => {
-                acc[scopePart] = completeScope[scopePart];
-                return acc;
-            },
-            {} as { [key: string]: unknown },
-        );
+        const scope = scopeParts.reduce((acc, scopePart) => {
+            acc[scopePart] = completeScope[scopePart];
+            return acc;
+        }, {} as ContentScope);
 
         return (
             <ConfigVerification scope={scope}>

--- a/packages/admin/brevo-admin/src/emailCampaigns/EmailCampaignsPage.tsx
+++ b/packages/admin/brevo-admin/src/emailCampaigns/EmailCampaignsPage.tsx
@@ -1,5 +1,5 @@
 import { Stack, StackPage, StackSwitch, StackToolbar } from "@dextinity/admin";
-import { type BlockInterface, ContentScopeIndicator, useContentScope } from "@dextinity/cms-admin";
+import { type BlockInterface, type ContentScope, ContentScopeIndicator, useContentScope } from "@dextinity/cms-admin";
 import type { JSX } from "react";
 import { useIntl } from "react-intl";
 
@@ -20,13 +20,10 @@ export function createEmailCampaignsPage({ EmailCampaignContentBlock }: CreateEm
         const { scope: completeScope } = useContentScope();
         const intl = useIntl();
 
-        const scope = scopeParts.reduce(
-            (acc, scopePart) => {
-                acc[scopePart] = completeScope[scopePart];
-                return acc;
-            },
-            {} as { [key: string]: unknown },
-        );
+        const scope = scopeParts.reduce((acc, scopePart) => {
+            acc[scopePart] = completeScope[scopePart];
+            return acc;
+        }, {} as ContentScope);
 
         return (
             <ConfigVerification scope={scope}>

--- a/packages/admin/brevo-admin/src/emailCampaigns/form/TestEmailCampaignForm.tsx
+++ b/packages/admin/brevo-admin/src/emailCampaigns/form/TestEmailCampaignForm.tsx
@@ -1,7 +1,7 @@
 import { gql, useApolloClient, useQuery } from "@apollo/client";
 import { Field, FinalForm, FinalFormSelect, SaveButton, Tooltip } from "@dextinity/admin";
 import { Info, Newsletter } from "@dextinity/admin-icons";
-import { BlockAdminComponentPaper, BlockAdminComponentSectionGroup, useContentScope } from "@dextinity/cms-admin";
+import { BlockAdminComponentPaper, BlockAdminComponentSectionGroup, type ContentScope, useContentScope } from "@dextinity/cms-admin";
 import { Card } from "@mui/material";
 import { FormattedMessage } from "react-intl";
 
@@ -50,13 +50,10 @@ export const TestEmailCampaignForm = ({ id, isSendable = false, isCampaignCreate
     const { scopeParts } = useBrevoConfig();
     const { scope: completeScope } = useContentScope();
 
-    const scope = scopeParts.reduce(
-        (acc, scopePart) => {
-            acc[scopePart] = completeScope[scopePart];
-            return acc;
-        },
-        {} as { [key: string]: unknown },
-    );
+    const scope = scopeParts.reduce((acc, scopePart) => {
+        acc[scopePart] = completeScope[scopePart];
+        return acc;
+    }, {} as ContentScope);
 
     // Contact creation is limited to 100 at a time. Therefore, 100 contacts are queried without using pagination.
     const { data, loading, error } = useQuery(brevoTestContactsSelectQuery, {

--- a/packages/admin/brevo-admin/src/targetGroups/TargetGroupsPage.tsx
+++ b/packages/admin/brevo-admin/src/targetGroups/TargetGroupsPage.tsx
@@ -1,5 +1,5 @@
 import { Stack, StackPage, StackSwitch, Toolbar } from "@dextinity/admin";
-import { ContentScopeIndicator, useContentScope } from "@dextinity/cms-admin";
+import { type ContentScope, ContentScopeIndicator, useContentScope } from "@dextinity/cms-admin";
 import type { DocumentNode } from "graphql";
 import type { JSX, ReactNode } from "react";
 import { useIntl } from "react-intl";
@@ -26,13 +26,10 @@ export function createTargetGroupsPage({ additionalFormFields, nodeFragment, inp
         const { scope: completeScope } = useContentScope();
         const intl = useIntl();
 
-        const scope = scopeParts.reduce(
-            (acc, scopePart) => {
-                acc[scopePart] = completeScope[scopePart];
-                return acc;
-            },
-            {} as { [key: string]: unknown },
-        );
+        const scope = scopeParts.reduce((acc, scopePart) => {
+            acc[scopePart] = completeScope[scopePart];
+            return acc;
+        }, {} as ContentScope);
 
         return (
             <ConfigVerification scope={scope}>

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
@@ -25,7 +25,7 @@ export const ContentScopeIndicator = ({ global = false, scope: passedScope, chil
         const label = values.find((value) => {
             return value.scope[scopePart] === scope[scopePart];
         })?.label;
-        return (label && label[scopePart]) ?? (scope[scopePart] ? capitalizeString(scope[scopePart]) : undefined);
+        return (label && label[scopePart]) ?? (scope[scopePart] ? capitalizeString(String(scope[scopePart])) : undefined);
     };
 
     let content: ReactNode;

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeSelect.tsx
@@ -60,8 +60,11 @@ export function ContentScopeSelect({
     if (searchable) {
         filteredOptions = options.filter((option) => {
             return (
-                Object.values(option.scope).some((value) => value.toLowerCase().includes(searchValue.toLowerCase())) ||
-                Object.values(option.label || []).some((value) => value?.toLowerCase().includes(searchValue.toLowerCase()))
+                Object.values(option.scope).some((value) =>
+                    String(value ?? "")
+                        .toLowerCase()
+                        .includes(searchValue.toLowerCase()),
+                ) || Object.values(option.label || []).some((value) => value?.toLowerCase().includes(searchValue.toLowerCase()))
             );
         });
     }
@@ -71,12 +74,13 @@ export function ContentScopeSelect({
     if (groupBy) {
         if (hasMultipleDimensions) {
             for (const option of filteredOptions) {
-                const groupForOption = groups.find((group) => group.value === option.scope[groupBy]);
+                const groupValue = String(option.scope[groupBy] ?? "");
+                const groupForOption = groups.find((group) => group.value === groupValue);
 
                 if (groupForOption) {
                     groupForOption.options.push(option);
                 } else {
-                    groups.push({ value: option.scope[groupBy], label: option.label ? option.label[groupBy] : undefined, options: [option] });
+                    groups.push({ value: groupValue, label: option.label ? option.label[groupBy] : undefined, options: [option] });
                 }
             }
         } else {
@@ -125,7 +129,7 @@ export function ContentScopeSelect({
     if (!renderSelectedOption) {
         renderSelectedOption = (option) => {
             return Object.keys(option.scope)
-                .map((key) => humanReadableLabel({ label: option.label ? option.label[key] : undefined, value: option.scope[key] }))
+                .map((key) => humanReadableLabel({ label: option.label ? option.label[key] : undefined, value: String(option.scope[key] ?? "") }))
                 .join(" / ");
         };
     }

--- a/packages/admin/cms-admin/src/contentScope/Provider.tsx
+++ b/packages/admin/cms-admin/src/contentScope/Provider.tsx
@@ -8,8 +8,7 @@ import { NoContentScopeFallback } from "./noContentScopeFallback/NoContentScopeF
 import { defaultCreatePath } from "./utils/defaultCreatePath";
 
 export interface ContentScope {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any;
+    [key: string]: string | number | null | undefined;
 }
 
 type ContentScopeLocation = {
@@ -36,10 +35,7 @@ const defaultContentScopeContext: ContentScopeContext = {
     location: defaultContentScopeLocation,
 };
 
-type NonNull<T> = T extends null ? never : T;
-type NonNullRecord<T> = {
-    [P in keyof T]: NonNull<T[P]>;
-};
+type ContentScopeRouterParams = Record<string, string>;
 
 type SetContentScopeAction = (state: ContentScope) => ContentScope;
 
@@ -64,7 +60,7 @@ const Context = createContext<ContentScopeContext>(defaultContentScopeContext);
 
 const NullValueAsString = "-"; // used to represent null-values in the url
 
-function parseScopeFromRouterMatchParams(params: NonNullRecord<ContentScope>): ContentScope {
+function parseScopeFromRouterMatchParams(params: ContentScopeRouterParams): ContentScope {
     return Object.entries(params).reduce((a, [key, value]) => {
         return {
             ...a,
@@ -73,13 +69,13 @@ function parseScopeFromRouterMatchParams(params: NonNullRecord<ContentScope>): C
     }, {} as ContentScope);
 }
 
-function formatScopeToRouterMatchParams(scope: Partial<ContentScope>): NonNullRecord<ContentScope> {
+function formatScopeToRouterMatchParams(scope: ContentScope): ContentScopeRouterParams {
     return Object.entries(scope).reduce((a, [key, value]) => {
         return {
             ...a,
-            [key]: !value || value === null ? NullValueAsString : value,
+            [key]: value === null || value === undefined || value === "" ? NullValueAsString : String(value),
         };
-    }, {} as NonNullRecord<ContentScope>);
+    }, {} as ContentScopeRouterParams);
 }
 
 function defaultCreateUrl(scope: ContentScope) {
@@ -93,7 +89,7 @@ function defaultCreateUrl(scope: ContentScope) {
 export function useContentScope(): UseContentScopeApi {
     const context = useContext(Context);
     const history = useHistory();
-    const matchContextScope = useRouteMatch<NonNullRecord<ContentScope>>(context?.path || "");
+    const matchContextScope = useRouteMatch<ContentScopeRouterParams>(context?.path || "");
     const matchDefault = useRouteMatch();
     const match = matchContextScope || matchDefault;
 
@@ -124,7 +120,7 @@ export function useContentScope(): UseContentScopeApi {
 export interface ContentScopeProviderProps {
     defaultValue?: ContentScope;
     values?: ContentScopeValues;
-    children: (p: { match: match<NonNullRecord<ContentScope>> }) => ReactNode;
+    children: (p: { match: match<ContentScopeRouterParams> }) => ReactNode;
     location?: ContentScopeLocation;
 
     /**
@@ -151,7 +147,7 @@ export function ContentScopeProvider({
     }
 
     const path = location.createPath(values);
-    const match = useRouteMatch<NonNullRecord<ContentScope>>(path);
+    const match = useRouteMatch<ContentScopeRouterParams>(path);
     const [redirectPathAfterChange, setRedirectPathAfterChange] = useState<undefined | string>("");
 
     if (values.length === 0) {

--- a/packages/admin/cms-admin/src/contentScope/__stories__/ContentScopeSelect.stories.tsx
+++ b/packages/admin/cms-admin/src/contentScope/__stories__/ContentScopeSelect.stories.tsx
@@ -297,9 +297,9 @@ export const GroupingWithOptionalScopeParts = {
                 renderOption={(option, query, isSelected) => {
                     let text: string;
                     if (option.scope.company === undefined) {
-                        text = option.label?.country ?? option.scope.country;
+                        text = option.label?.country ?? String(option.scope.country);
                     } else {
-                        text = option.label?.company ?? option.scope.company;
+                        text = option.label?.company ?? String(option.scope.company);
                     }
 
                     const matches = findTextMatches(text, query);

--- a/packages/admin/cms-admin/src/dam/config/DamScopeContext.ts
+++ b/packages/admin/cms-admin/src/dam/config/DamScopeContext.ts
@@ -1,3 +1,5 @@
 import { createContext } from "react";
 
-export const DamScopeContext = createContext<Record<string, unknown>>({});
+import type { ContentScope } from "../../contentScope/Provider";
+
+export const DamScopeContext = createContext<ContentScope>({});

--- a/packages/admin/cms-admin/src/dam/config/DamScopeProvider.tsx
+++ b/packages/admin/cms-admin/src/dam/config/DamScopeProvider.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { useContentScope } from "../../contentScope/Provider";
+import { type ContentScope, useContentScope } from "../../contentScope/Provider";
 import { useDamConfig } from "./damConfig";
 import { DamScopeContext } from "./DamScopeContext";
 
@@ -8,15 +8,12 @@ export function DamScopeProvider({ children }: { children?: ReactNode }) {
     const { scopeParts = [] } = useDamConfig();
     const { scope: completeScope } = useContentScope();
 
-    const damScope = scopeParts.reduce(
-        (damScope, scope) => {
-            if (completeScope[scope] !== undefined) {
-                damScope[scope] = completeScope[scope];
-            }
-            return damScope;
-        },
-        {} as Record<string, unknown>,
-    );
+    const damScope = scopeParts.reduce((damScope, scope) => {
+        if (completeScope[scope] !== undefined) {
+            damScope[scope] = completeScope[scope];
+        }
+        return damScope;
+    }, {} as ContentScope);
 
     return <DamScopeContext.Provider value={damScope}>{children}</DamScopeContext.Provider>;
 }

--- a/packages/admin/cms-admin/src/dam/config/useDamScope.ts
+++ b/packages/admin/cms-admin/src/dam/config/useDamScope.ts
@@ -1,8 +1,9 @@
 import { useContext } from "react";
 
+import type { ContentScope } from "../../contentScope/Provider";
 import { DamScopeContext } from "./DamScopeContext";
 
-function useDamScope(): Record<string, unknown> {
+function useDamScope(): ContentScope {
     return useContext(DamScopeContext);
 }
 

--- a/packages/admin/cms-admin/src/form/file/upload.ts
+++ b/packages/admin/cms-admin/src/form/file/upload.ts
@@ -1,9 +1,10 @@
+import type { ContentScope } from "../../contentScope/Provider";
 import type { GQLUpdateDamFileInput } from "../../graphql.generated";
 
 interface UploadFileData {
     file: File &
         Pick<GQLUpdateDamFileInput, "license" | "title" | "altText"> & { importSource?: { importSourceType: string; importSourceId: string } };
-    scope: Record<string, unknown>;
+    scope: ContentScope;
     folderId?: string;
     /**
      * @deprecated Set `file.importSource.importSourceId` instead

--- a/packages/admin/cms-admin/src/pages/pageTree/findAvailableSlug.ts
+++ b/packages/admin/cms-admin/src/pages/pageTree/findAvailableSlug.ts
@@ -1,6 +1,8 @@
 import { type ApolloClient, gql } from "@apollo/client";
 import { LocalErrorScopeApolloContext } from "@dextinity/admin";
 
+import type { ContentScope } from "../../contentScope/Provider";
+
 const slugAvailableQuery = gql`
     query FindAvailableSlug($parentId: ID, $slug: String!, $scope: PageTreeNodeScopeInput!) {
         pageTreeNodeSlugAvailable(parentId: $parentId, slug: $slug, scope: $scope)
@@ -9,7 +11,7 @@ const slugAvailableQuery = gql`
 
 export async function findAvailableSlug(
     apolloClient: ApolloClient<unknown>,
-    { slug, name, parentId, scope }: { slug: string; name: string; parentId: string | null; scope: Record<string, unknown> },
+    { slug, name, parentId, scope }: { slug: string; name: string; parentId: string | null; scope: ContentScope },
 ): Promise<{ slug: string; name: string }> {
     let candidateSlug = slug;
     let candidateName = name;

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/createInboxFolder.ts
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/createInboxFolder.ts
@@ -2,6 +2,7 @@ import { type ApolloClient, gql } from "@apollo/client";
 import { LocalErrorScopeApolloContext } from "@dextinity/admin";
 import { format } from "date-fns";
 
+import type { ContentScope } from "../../../contentScope/Provider";
 import type { GQLCreateInboxFolderMutation, GQLCreateInboxFolderMutationVariables } from "./createInboxFolder.generated";
 
 export const createInboxFolder = async ({
@@ -10,8 +11,8 @@ export const createInboxFolder = async ({
     sourceScopes,
 }: {
     client: ApolloClient<unknown>;
-    targetScope: Record<string, unknown>;
-    sourceScopes: Record<string, unknown>[];
+    targetScope: ContentScope;
+    sourceScopes: ContentScope[];
 }) => {
     const scopeString = sourceScopes.length === 0 ? "unknown" : sourceScopes.map((scope) => Object.values(scope).join("-")).join(", ");
     const date = new Date();

--- a/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useCopyPastePages/sendPages.tsx
@@ -61,7 +61,7 @@ interface SendPagesDependencies {
     scope: ContentScope;
     documentTypes: PageTreeConfig["documentTypes"];
     apiUrl: string;
-    damScope: Record<string, unknown>;
+    damScope: ContentScope;
     currentCategory: string;
     damBasePath: string;
 }
@@ -96,7 +96,7 @@ export async function sendPages(
     updateProgress(0, <FormattedMessage id="dextinity.pages.paste.analyzingPages" defaultMessage="analyzing pages" />);
     {
         let progressPages = 0;
-        const sourceScopes: Record<string, unknown>[] = [];
+        const sourceScopes: ContentScope[] = [];
         for (const sourcePage of pages) {
             const documentType = documentTypes[sourcePage.documentType];
             if (!documentType) {
@@ -341,7 +341,7 @@ function unhandledDependenciesFromDocument(
         existingReplacements,
         hasDamScope = false,
         targetDamScope,
-    }: { existingReplacements: ReplaceDependencyObject[]; hasDamScope?: boolean; targetDamScope: Record<string, unknown> },
+    }: { existingReplacements: ReplaceDependencyObject[]; hasDamScope?: boolean; targetDamScope: ContentScope },
 ) {
     const unhandledDependencies = documentType.dependencies(document).filter((dependency) => {
         if (isDamFileDependency(dependency)) {
@@ -391,7 +391,7 @@ function fileDependenciesFromDocument(documentType: DocumentInterface, document:
 
 function isDamFileDependency(
     dependency: BlockDependency,
-): dependency is BlockDependency & { data: { damFile: GQLDamFile & { scope?: Record<string, unknown> } } } {
+): dependency is BlockDependency & { data: { damFile: GQLDamFile & { scope?: ContentScope } } } {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return dependency.targetGraphqlObjectType === "DamFile" && dependency.data && (dependency.data as any).damFile;
 }

--- a/packages/admin/cms-admin/src/pages/pageTree/useTranslatePagesAction.tsx
+++ b/packages/admin/cms-admin/src/pages/pageTree/useTranslatePagesAction.tsx
@@ -108,7 +108,7 @@ export function useTranslatePagesAction({ pages, documentTypes }: Props): {
                     const [translatedName, ...rest] = translatedTexts;
                     translatedContentTexts = rest;
 
-                    const translatedSlug = transformToSlug(translatedName, scope.language);
+                    const translatedSlug = transformToSlug(translatedName, String(scope.language));
 
                     if (translatedName !== page.name || translatedSlug !== page.slug) {
                         const available = await findAvailableSlug(apolloClient, {

--- a/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectForm.tsx
@@ -24,6 +24,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { createFinalFormBlock } from "../blocks/form/createFinalFormBlock";
 import type { BlockInterface, BlockState } from "../blocks/types";
 import { ContentScopeIndicator } from "../contentScope/ContentScopeIndicator";
+import type { ContentScope } from "../contentScope/Provider";
 import type { GQLRedirectSourceType } from "../graphql.generated";
 import type { GQLRedirectSourceAvailableQuery, GQLRedirectSourceAvailableQueryVariables } from "./RedirectForm.generated";
 import { redirectDetailQuery } from "./RedirectForm.gql";
@@ -42,7 +43,7 @@ interface Props {
     id?: string;
     mode: "edit" | "add";
     linkBlock: BlockInterface;
-    scope: Record<string, unknown>;
+    scope: ContentScope;
 }
 
 export interface FormValues {

--- a/packages/admin/cms-admin/src/redirects/RedirectsGrid.tsx
+++ b/packages/admin/cms-admin/src/redirects/RedirectsGrid.tsx
@@ -35,6 +35,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { BlockPreviewContent } from "../blocks/common/blockRow/BlockPreviewContent";
 import type { BlockInterface } from "../blocks/types";
+import type { ContentScope } from "../contentScope/Provider";
 import { DataGrid } from "../dataGrid/DataGrid";
 import RedirectActiveness from "./RedirectActiveness";
 import { deleteRedirectMutation, deleteRedirectsMutation, paginatedRedirectsQuery } from "./RedirectsGrid.gql";
@@ -48,7 +49,7 @@ import {
 
 interface Props {
     linkBlock: BlockInterface;
-    scope: Record<string, unknown>;
+    scope: ContentScope;
 }
 
 interface RedirectsGridToolbarProps extends GridToolbarProps {

--- a/packages/admin/cms-admin/src/redirects/redirectsConfig.ts
+++ b/packages/admin/cms-admin/src/redirects/redirectsConfig.ts
@@ -1,5 +1,5 @@
 import { useDextinityConfig } from "../config/DextinityConfigContext";
-import { useContentScope } from "../contentScope/Provider";
+import { type ContentScope, useContentScope } from "../contentScope/Provider";
 
 export interface RedirectsConfig {
     scopeParts?: string[];
@@ -15,18 +15,15 @@ function useRedirectsConfig(): RedirectsConfig {
     return dextinityConfig.redirects;
 }
 
-export function useRedirectsScope(): { [key: string]: unknown } {
+export function useRedirectsScope(): ContentScope {
     const { scopeParts } = useRedirectsConfig();
     const { scope: completeScope } = useContentScope();
 
     const redirectScope = scopeParts?.length
-        ? scopeParts.reduce(
-              (acc, scopePart) => {
-                  acc[scopePart] = completeScope[scopePart];
-                  return acc;
-              },
-              {} as { [key: string]: unknown },
-          )
+        ? scopeParts.reduce((acc, scopePart) => {
+              acc[scopePart] = completeScope[scopePart];
+              return acc;
+          }, {} as ContentScope)
         : completeScope;
 
     return redirectScope;

--- a/packages/admin/cms-admin/src/redirects/submitMutation.ts
+++ b/packages/admin/cms-admin/src/redirects/submitMutation.ts
@@ -3,6 +3,7 @@ import type { ApolloError } from "@apollo/client/errors";
 import type { FetchResult } from "@apollo/client/link/core";
 
 import type { BlockInterface } from "../blocks/types";
+import type { ContentScope } from "../contentScope/Provider";
 import type { GQLRedirectInput } from "../graphql.generated";
 import {
     createRedirectMutation,
@@ -28,7 +29,7 @@ export const useSubmitMutation = (
     mode: "edit" | "add",
     id: string | undefined,
     linkBlock: BlockInterface,
-    scope: Record<string, unknown>,
+    scope: ContentScope,
 ): [
     (values: FormValues) => Promise<FetchResult<GQLCreateRedirectMutation | GQLUpdateRedirectMutation>>,
     { loading: boolean; error: ApolloError | undefined },

--- a/packages/admin/cms-admin/src/translation/AzureAiTranslatorProvider.tsx
+++ b/packages/admin/cms-admin/src/translation/AzureAiTranslatorProvider.tsx
@@ -23,7 +23,7 @@ export const AzureAiTranslatorProvider = ({ children, enabled = false, ...rest }
                 const { data } = await apolloClient.query<GQLTranslateQuery, GQLTranslateQueryVariables>({
                     query: translationQuery,
                     variables: {
-                        input: { text, targetLanguage: scope.language },
+                        input: { text, targetLanguage: String(scope.language) },
                     },
                 });
                 return data.azureAiTranslate;
@@ -32,7 +32,7 @@ export const AzureAiTranslatorProvider = ({ children, enabled = false, ...rest }
                 const { data } = await apolloClient.query<{ azureAiTranslateBatch: string[] }>({
                     query: batchTranslationQuery,
                     variables: {
-                        input: { texts, targetLanguage: scope.language },
+                        input: { texts, targetLanguage: String(scope.language) },
                     },
                     fetchPolicy: "no-cache",
                 });

--- a/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
+++ b/packages/admin/cms-admin/src/warnings/WarningsGrid.tsx
@@ -94,7 +94,7 @@ export function WarningsGrid() {
             if (item.label && item.label[key]) {
                 label.push(item.label[key]);
             } else if (value) {
-                label.push(capitalCase(value));
+                label.push(capitalCase(String(value)));
             }
         }
 

--- a/packages/api/brevo-api/generate-schema.ts
+++ b/packages/api/brevo-api/generate-schema.ts
@@ -26,7 +26,7 @@ import { BrevoPermission } from "./src";
 @ObjectType("EmailCampaignContentScope")
 @InputType("EmailCampaignContentScopeInput")
 class EmailCampaignScope implements EmailCampaignScopeInterface {
-    [key: string]: unknown;
+    [key: string]: string | number | null | undefined;
     // empty scope
     @Field({ nullable: true })
     thisScopeHasNoFields____?: string; // just anything so this class has at least one field and can be interpreted as a gql-object/input type

--- a/packages/api/brevo-api/src/blacklisted-contacts/entity/blacklisted-contacts.entity.factory.ts
+++ b/packages/api/brevo-api/src/blacklisted-contacts/entity/blacklisted-contacts.entity.factory.ts
@@ -44,7 +44,7 @@ export function createBlacklistedContactsEntity({ Scope }: { Scope: Type<EmailCa
 
         @Embedded(() => Scope)
         @Field(() => Scope)
-        scope: typeof Scope;
+        scope: EmailCampaignScopeInterface;
     }
 
     return BrevoBlacklistedContacts;

--- a/packages/api/brevo-api/src/brevo-config/brevo-config.resolver.ts
+++ b/packages/api/brevo-api/src/brevo-config/brevo-config.resolver.ts
@@ -73,7 +73,7 @@ export function createBrevoConfigResolver({
         @Query(() => [BrevoApiSender], { nullable: true })
         async brevoSenders(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
-            scope: typeof Scope,
+            scope: EmailCampaignScopeInterface,
         ): Promise<Array<BrevoApiSender> | undefined> {
             const senders = await this.brevoSenderApiService.getSenders(scope);
             return senders;
@@ -83,7 +83,7 @@ export function createBrevoConfigResolver({
         @Query(() => [BrevoApiEmailTemplate], { nullable: true })
         async brevoDoubleOptInTemplates(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
-            scope: typeof Scope,
+            scope: EmailCampaignScopeInterface,
         ): Promise<Array<BrevoApiEmailTemplate> | undefined> {
             const { templates } = await this.brevoTransactionalEmailsApiService.getEmailTemplates(scope);
             const doubleOptInTemplates = templates?.filter((template) => template.tag === "optin" && template.isActive);
@@ -94,7 +94,7 @@ export function createBrevoConfigResolver({
         @RequiredPermission("brevoNewsletter")
         async isBrevoConfigDefined(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
-            scope: typeof Scope,
+            scope: EmailCampaignScopeInterface,
         ): Promise<boolean> {
             const brevoConfig = await this.repository.findOne({ scope });
             return !!brevoConfig;
@@ -103,7 +103,7 @@ export function createBrevoConfigResolver({
         @Query(() => BrevoConfig, { nullable: true })
         async brevoConfig(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
-            scope: typeof Scope,
+            scope: EmailCampaignScopeInterface,
         ): Promise<BrevoConfigInterface | null> {
             const brevoConfig = await this.repository.findOne({ scope });
             return brevoConfig;
@@ -112,7 +112,7 @@ export function createBrevoConfigResolver({
         @Mutation(() => BrevoConfig)
         async createBrevoConfig(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
-            scope: typeof Scope,
+            scope: EmailCampaignScopeInterface,
             @Args("input", { type: () => BrevoConfigInput }) input: BrevoConfigInput,
         ): Promise<BrevoConfigInterface> {
             if (!(await this.brevoIsValidSender({ email: input.senderMail, name: input.senderName, scope }))) {

--- a/packages/api/brevo-api/src/brevo-config/entities/brevo-config-entity.factory.ts
+++ b/packages/api/brevo-api/src/brevo-config/entities/brevo-config-entity.factory.ts
@@ -72,7 +72,7 @@ export class BrevoConfigEntityFactory {
 
             @Embedded(() => Scope)
             @Field(() => Scope)
-            scope: typeof Scope;
+            scope: EmailCampaignScopeInterface;
         }
 
         return BrevoConfig;

--- a/packages/api/brevo-api/src/brevo-contact/brevo-contact-import.console.ts
+++ b/packages/api/brevo-api/src/brevo-contact/brevo-contact-import.console.ts
@@ -15,7 +15,7 @@ import { EmailCampaignScopeInterface } from "../types";
 
 interface CommandOptions {
     path: string;
-    scope: Type<EmailCampaignScopeInterface>;
+    scope: EmailCampaignScopeInterface;
     targetGroupIds: string[];
     sendDoubleOptIn: boolean;
 }
@@ -59,8 +59,8 @@ export function createBrevoContactImportConsole({ Scope }: { Scope: Type<EmailCa
             required: true,
             description: "scope for current import file",
         })
-        parseScope(scope: string): Type<EmailCampaignScopeInterface> {
-            const parsedScope = JSON.parse(scope) as typeof Scope;
+        parseScope(scope: string): EmailCampaignScopeInterface {
+            const parsedScope = JSON.parse(scope) as EmailCampaignScopeInterface;
             const validateErrors = validateSync(parsedScope);
 
             if (validateErrors.length) {
@@ -111,7 +111,7 @@ export function createBrevoContactImportConsole({ Scope }: { Scope: Type<EmailCa
             this.logger.log(result);
         }
 
-        async validateRedirectUrl(urlToValidate: string, scope: Type<EmailCampaignScopeInterface>): Promise<boolean> {
+        async validateRedirectUrl(urlToValidate: string, scope: EmailCampaignScopeInterface): Promise<boolean> {
             const configForScope = await this.brevoConfigRepository.findOneOrFail({ scope });
 
             if (!configForScope) {

--- a/packages/api/brevo-api/src/brevo-contact/brevo-contact.console.ts
+++ b/packages/api/brevo-api/src/brevo-contact/brevo-contact.console.ts
@@ -30,14 +30,12 @@ export class DeleteUnsubscribedBrevoContactsConsole extends CommandRunner {
             let offset = 0;
 
             do {
-                const contacts = await this.brevoApiContactsService.findContacts(limit, offset, {
-                    scope: targetGroup.scope,
-                });
+                const contacts = await this.brevoApiContactsService.findContacts(limit, offset, targetGroup.scope);
 
                 const blacklistedContacts = contacts.filter((contact) => contact.emailBlacklisted === true);
 
                 if (blacklistedContacts.length > 0) {
-                    await this.brevoApiContactsService.deleteContacts(blacklistedContacts, { scope: targetGroup.scope });
+                    await this.brevoApiContactsService.deleteContacts(blacklistedContacts, targetGroup.scope);
                 }
 
                 hasMoreContacts = !(contacts.length < limit);

--- a/packages/api/brevo-api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/brevo-api/src/brevo-contact/brevo-contact.resolver.ts
@@ -61,7 +61,7 @@ export function createBrevoContactResolver({
         @AffectedEntity(BrevoContact)
         async brevoContact(
             @Args("id", { type: () => Int }) id: number,
-            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
+            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: EmailCampaignScopeInterface,
         ): Promise<BrevoContactInterface> {
             const brevoContact = await this.brevoContactsApiService.findContact(id, scope);
 
@@ -158,7 +158,7 @@ export function createBrevoContactResolver({
         @AffectedEntity(BrevoContact)
         async updateBrevoContact(
             @Args("id", { type: () => Int }) id: number,
-            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
+            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: EmailCampaignScopeInterface,
             @Args("input", { type: () => BrevoContactUpdateInput }) input: BrevoContactUpdateInputInterface,
         ): Promise<BrevoContactInterface> {
             // update attributes of contact before (un)assigning to target groups because they cannot be correctly validated for completeness
@@ -206,7 +206,7 @@ export function createBrevoContactResolver({
         @Mutation(() => SubscribeResponse)
         @RequiredPermission(["brevoNewsletter"], { skipScopeCheck: true })
         async createBrevoContact(
-            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
+            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: EmailCampaignScopeInterface,
             @Args("input", { type: () => BrevoContactInput })
             input: BrevoContactInputInterface,
             @GetCurrentUser() user: CurrentUser,
@@ -232,7 +232,7 @@ export function createBrevoContactResolver({
         @Mutation(() => SubscribeResponse)
         @RequiredPermission(["brevoNewsletter"], { skipScopeCheck: true })
         async createBrevoTestContact(
-            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
+            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: EmailCampaignScopeInterface,
             @Args("input", { type: () => BrevoTestContactInput })
             input: BrevoContactInputInterface,
         ): Promise<SubscribeResponse> {
@@ -278,7 +278,7 @@ export function createBrevoContactResolver({
         @AffectedEntity(BrevoContact)
         async deleteBrevoContact(
             @Args("id", { type: () => Int }) id: number,
-            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
+            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: EmailCampaignScopeInterface,
         ): Promise<boolean> {
             const contact = await this.brevoContactsApiService.findContact(id, scope);
             if (!contact) {
@@ -312,7 +312,7 @@ export function createBrevoContactResolver({
         @AffectedEntity(BrevoContact)
         async deleteBrevoTestContact(
             @Args("id", { type: () => Int }) id: number,
-            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
+            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: EmailCampaignScopeInterface,
         ): Promise<boolean> {
             const contact = await this.brevoContactsApiService.findContact(id, scope);
             if (!contact) {
@@ -347,7 +347,7 @@ export function createBrevoContactResolver({
         async subscribeBrevoContact(
             @Args("input", { type: () => BrevoContactSubscribeInput }) data: SubscribeInputInterface,
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
-            scope: typeof Scope,
+            scope: EmailCampaignScopeInterface,
         ): Promise<SubscribeResponse> {
             return this.brevoContactsService.subscribeBrevoContact(data, scope);
         }

--- a/packages/api/brevo-api/src/brevo-contact/validator/redirect-url.validator.ts
+++ b/packages/api/brevo-api/src/brevo-contact/validator/redirect-url.validator.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Type } from "@nestjs/common";
 import { registerDecorator, ValidationArguments, ValidationOptions, ValidatorConstraint, ValidatorConstraintInterface } from "class-validator";
 import { BrevoConfigInterface } from "src/brevo-config/entities/brevo-config-entity.factory";
 import { EmailCampaignScopeInterface } from "src/types";
@@ -8,7 +8,7 @@ import { EmailCampaignScopeInterface } from "src/types";
 import { BrevoModuleConfig } from "../../config/brevo-module.config";
 import { BREVO_MODULE_CONFIG } from "../../config/brevo-module.constants";
 
-export const IsValidRedirectURL = (scope: EmailCampaignScopeInterface, validationOptions?: ValidationOptions) => {
+export const IsValidRedirectURL = (scope: Type<EmailCampaignScopeInterface>, validationOptions?: ValidationOptions) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (object: Record<string, any>, propertyName: string): void => {
         registerDecorator({

--- a/packages/api/brevo-api/src/brevo-email-import-log/entity/brevo-email-import-log.entity.factory.ts
+++ b/packages/api/brevo-api/src/brevo-email-import-log/entity/brevo-email-import-log.entity.factory.ts
@@ -56,7 +56,7 @@ export function createBrevoEmailImportLogEntity({ Scope }: { Scope: Type<EmailCa
 
         @Embedded(() => Scope)
         @Field(() => Scope)
-        scope: typeof Scope;
+        scope: EmailCampaignScopeInterface;
 
         @Property({ columnType: "uuid" })
         @IsUndefinable()

--- a/packages/api/brevo-api/src/email-campaign/email-campaign.resolver.ts
+++ b/packages/api/brevo-api/src/email-campaign/email-campaign.resolver.ts
@@ -91,7 +91,7 @@ export function createEmailCampaignsResolver({
         @Mutation(() => BrevoEmailCampaign)
         async createBrevoEmailCampaign(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
-            scope: typeof Scope,
+            scope: EmailCampaignScopeInterface,
             @Args("input", { type: () => EmailCampaignInput }, new DynamicDtoValidationPipe(EmailCampaignInput)) input: EmailCampaignInputInterface,
         ): Promise<EmailCampaignInterface> {
             const campaign = this.repository.create({

--- a/packages/api/brevo-api/src/email-campaign/entities/email-campaign-entity.factory.ts
+++ b/packages/api/brevo-api/src/email-campaign/entities/email-campaign-entity.factory.ts
@@ -87,7 +87,7 @@ export function createEmailCampaignEntity({
 
         @Embedded(() => Scope)
         @Field(() => Scope)
-        scope: typeof Scope;
+        scope: EmailCampaignScopeInterface;
     }
 
     return BrevoEmailCampaign;

--- a/packages/api/brevo-api/src/target-group/entity/target-group-entity.factory.ts
+++ b/packages/api/brevo-api/src/target-group/entity/target-group-entity.factory.ts
@@ -71,7 +71,7 @@ export function createTargetGroupEntity({
 
         @Embedded(() => Scope)
         @Field(() => Scope)
-        scope: typeof Scope;
+        scope: EmailCampaignScopeInterface;
 
         @Property({ columnType: "int", nullable: true })
         @Field(() => Int, { nullable: true })

--- a/packages/api/brevo-api/src/target-group/target-group.resolver.ts
+++ b/packages/api/brevo-api/src/target-group/target-group.resolver.ts
@@ -85,7 +85,7 @@ export function createTargetGroupsResolver({
         @Mutation(() => BrevoTargetGroup)
         async createBrevoTargetGroup(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
-            scope: typeof Scope,
+            scope: EmailCampaignScopeInterface,
             @Args("input", { type: () => TargetGroupInput }, new DynamicDtoValidationPipe(TargetGroupInput)) input: TargetGroupInputInterface,
         ): Promise<TargetGroupInterface> {
             const brevoId = await this.brevoApiContactsService.createBrevoContactList(input.title, scope);

--- a/packages/api/brevo-api/src/types.ts
+++ b/packages/api/brevo-api/src/types.ts
@@ -4,5 +4,4 @@ export type BrevoContactAttributesInterface = Record<string, any>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type BrevoContactFilterAttributesInterface = Record<string, Array<any> | undefined>;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type EmailCampaignScopeInterface = Record<string, any>;
+export type EmailCampaignScopeInterface = Record<string, string | number | null | undefined>;

--- a/packages/api/cms-api/src/dam/files/dto/empty-dam-scope.ts
+++ b/packages/api/cms-api/src/dam/files/dto/empty-dam-scope.ts
@@ -6,7 +6,7 @@ import { DamScopeInterface } from "../../types";
 @ObjectType("DamScope")
 @InputType("DamScopeInput")
 export class EmptyDamScope implements DamScopeInterface {
-    [key: string]: unknown;
+    [key: string]: string | number | null | undefined;
     // empty scope
     @Field({ nullable: true })
     @IsUndefinable()

--- a/packages/api/cms-api/src/dam/files/dto/find-copies-of-file-in-scope.args.ts
+++ b/packages/api/cms-api/src/dam/files/dto/find-copies-of-file-in-scope.args.ts
@@ -21,7 +21,7 @@ export function createFindCopiesOfFileInScopeArgs({ Scope, hasNonEmptyScope }: {
 
         @Field(() => Scope, { defaultValue: hasNonEmptyScope ? undefined : {} })
         @ValidateNested()
-        scope: typeof Scope;
+        scope: DamScopeInterface;
 
         @Field(() => ImageCropAreaInput, { nullable: true })
         @ValidateNested()

--- a/packages/api/cms-api/src/dam/files/entities/file.entity.ts
+++ b/packages/api/cms-api/src/dam/files/entities/file.entity.ts
@@ -180,7 +180,7 @@ export function createFileEntity({ Scope, Folder }: { Scope?: Type<DamScopeInter
         class DamFile extends FileBase {
             @Embedded(() => Scope)
             @Field(() => Scope)
-            scope: typeof Scope;
+            scope: DamScopeInterface;
         }
         return DamFile;
     } else {

--- a/packages/api/cms-api/src/dam/files/entities/folder.entity.ts
+++ b/packages/api/cms-api/src/dam/files/entities/folder.entity.ts
@@ -119,7 +119,7 @@ export function createFolderEntity({ Scope }: { Scope?: Type<DamScopeInterface> 
         class DamFolder extends FolderBase {
             @Embedded(() => Scope)
             @Field(() => Scope)
-            scope: typeof Scope;
+            scope: DamScopeInterface;
 
             @Field(() => DamFolder, { nullable: true })
             parent: DamFolder | null;

--- a/packages/api/cms-api/src/dam/files/files.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/files.resolver.ts
@@ -188,7 +188,7 @@ export function createFilesResolver({
         @Query(() => Boolean)
         async damIsFilenameOccupied(
             @Args("filename") filename: string,
-            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: typeof Scope,
+            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: DamScopeInterface,
             @Args("folderId", { nullable: true }) folderId?: string,
         ): Promise<boolean> {
             const extension = extname(filename);
@@ -203,7 +203,7 @@ export function createFilesResolver({
         @Query(() => [FilenameResponse])
         async damAreFilenamesOccupied(
             @Args("filenames", { type: () => [FilenameInput] }) filenames: Array<FilenameInput>,
-            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: typeof Scope,
+            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: DamScopeInterface,
         ): Promise<Array<FilenameResponse>> {
             const response: Array<FilenameResponse> = [];
 

--- a/packages/api/cms-api/src/dam/files/folders.resolver.ts
+++ b/packages/api/cms-api/src/dam/files/folders.resolver.ts
@@ -43,7 +43,7 @@ export function createFoldersResolver({
 
         @Query(() => [Folder])
         async damFoldersFlat(
-            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: typeof Scope,
+            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: DamScopeInterface,
         ): Promise<FolderInterface[]> {
             return this.foldersService.findAllFlat(nonEmptyScopeOrNothing(scope));
         }
@@ -75,7 +75,7 @@ export function createFoldersResolver({
         @SkipBuild()
         async createDamFolder(
             @Args("input", { type: () => CreateFolderInput }) input: CreateFolderInput,
-            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: typeof Scope,
+            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: DamScopeInterface,
         ): Promise<FolderInterface> {
             return this.foldersService.create(input, nonEmptyScopeOrNothing(scope));
         }
@@ -95,7 +95,7 @@ export function createFoldersResolver({
         async moveDamFolders(
             @Args("folderIds", { type: () => [ID] }) folderIds: string[],
             @Args("targetFolderId", { type: () => ID, nullable: true }) targetFolderId: string,
-            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: typeof Scope,
+            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: DamScopeInterface,
         ): Promise<FolderInterface[]> {
             return this.foldersService.moveBatch({ folderIds, targetFolderId }, nonEmptyScopeOrNothing(scope));
         }

--- a/packages/api/cms-api/src/dam/types.ts
+++ b/packages/api/cms-api/src/dam/types.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type DamScopeInterface = Record<string, any>;
+type DamScopeInterface = Record<string, string | number | null | undefined>;
 
 export type { DamScopeInterface };

--- a/packages/api/cms-api/src/page-tree/blocks/internal-link-block-transformer.service.ts
+++ b/packages/api/cms-api/src/page-tree/blocks/internal-link-block-transformer.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 
 import { BlockTransformerServiceInterface } from "../../blocks/block";
 import { PageTreeReadApiService } from "../page-tree-read-api.service";
+import type { ScopeInterface } from "../types";
 import type { InternalLinkBlockData } from "./internal-link.block";
 
 type TransformResponse = {
@@ -10,7 +11,7 @@ type TransformResponse = {
         name: string;
         path: string;
         documentType: string;
-        scope: Record<string, string> | null;
+        scope: ScopeInterface | null;
     } | null;
     targetPageAnchor?: string;
 };

--- a/packages/api/cms-api/src/page-tree/dto/empty-page-tree-node-scope.ts
+++ b/packages/api/cms-api/src/page-tree/dto/empty-page-tree-node-scope.ts
@@ -5,7 +5,7 @@ import { ScopeInterface } from "../types";
 @ObjectType("PageTreeNodeScope")
 @InputType("PageTreeNodeScopeInput")
 export class EmptyPageTreeNodeScope implements ScopeInterface {
-    [key: string]: unknown;
+    [key: string]: string | number | null | undefined;
     // empty scope
     @Field({ nullable: true })
     thisScopeHasNoFields____?: string; // just anything so this class has at least one field and can be interpreted as a gql-object/input type

--- a/packages/api/cms-api/src/page-tree/types.ts
+++ b/packages/api/cms-api/src/page-tree/types.ts
@@ -3,8 +3,7 @@ import { registerEnumType } from "@nestjs/graphql";
 import type { PageTreeNodeBaseCreateInput, PageTreeNodeBaseUpdateInput } from "./dto/page-tree-node.input";
 import type { PageTreeNodeBase } from "./entities/page-tree-node-base.entity";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ScopeInterface = Record<string, any>; //@TODO: move to general scope (other modules (redirect, dam) need this too)
+export type ScopeInterface = Record<string, string | number | null | undefined>; //@TODO: move to general scope (other modules (redirect, dam) need this too)
 export type PageTreeNodeCategory = string;
 export type PageTreeNodeInterface = PageTreeNodeBase & { scope?: ScopeInterface };
 export type PageTreeNodeCreateInputInterface = PageTreeNodeBaseCreateInput;

--- a/packages/api/cms-api/src/redirects/dto/empty-redirect-scope.ts
+++ b/packages/api/cms-api/src/redirects/dto/empty-redirect-scope.ts
@@ -5,7 +5,7 @@ import { RedirectScopeInterface } from "../types";
 @ObjectType("RedirectScope")
 @InputType("RedirectScopeInput")
 export class EmptyRedirectScope implements RedirectScopeInterface {
-    [key: string]: unknown;
+    [key: string]: string | number | null | undefined;
     // empty scope
     @Field({ nullable: true })
     thisScopeHasNoFields____?: string; // just anything so this class has at least one field and can be interpreted as a gql-object/input type

--- a/packages/api/cms-api/src/redirects/entities/redirect-entity.factory.ts
+++ b/packages/api/cms-api/src/redirects/entities/redirect-entity.factory.ts
@@ -97,7 +97,7 @@ export class RedirectEntityFactory {
             class Redirect extends RedirectBase {
                 @Embedded(() => RedirectScope)
                 @Field(() => RedirectScope)
-                scope: typeof RedirectScope;
+                scope: RedirectScopeInterface;
             }
             return Redirect;
         } else {

--- a/packages/api/cms-api/src/redirects/redirects.resolver.ts
+++ b/packages/api/cms-api/src/redirects/redirects.resolver.ts
@@ -184,7 +184,7 @@ export function createRedirectsResolver({
 
         @Query(() => Redirect, { nullable: true })
         async redirectBySource(
-            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: typeof Scope,
+            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: RedirectScopeInterface,
             @Args("source", { type: () => String }) source: string,
             @Args("sourceType", { type: () => RedirectSourceType }) sourceType: RedirectSourceType,
         ): Promise<RedirectInterface | null> {
@@ -198,7 +198,7 @@ export function createRedirectsResolver({
 
         @Query(() => Boolean)
         async redirectSourceAvailable(
-            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: typeof Scope,
+            @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }) scope: RedirectScopeInterface,
             @Args("source", { type: () => String }) source: string,
         ): Promise<boolean> {
             return this.redirectService.isRedirectSourceAvailable(source, nonEmptyScopeOrNothing(scope));
@@ -207,7 +207,7 @@ export function createRedirectsResolver({
         @Mutation(() => Redirect)
         async createRedirect(
             @Args("scope", { type: () => Scope, defaultValue: hasNonEmptyScope ? undefined : {} }, new DynamicDtoValidationPipe(Scope))
-            scope: typeof Scope,
+            scope: RedirectScopeInterface,
             @Args("input", { type: () => RedirectInput }, new DynamicDtoValidationPipe(RedirectInput)) input: RedirectInputInterface,
         ): Promise<RedirectInterface> {
             if (!(await this.redirectService.isRedirectSourceAvailable(input.source, nonEmptyScopeOrNothing(scope)))) {

--- a/packages/api/cms-api/src/redirects/types.ts
+++ b/packages/api/cms-api/src/redirects/types.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type RedirectScopeInterface = Record<string, any>; //@TODO: move to general scope (other modules (page-tree, dam) need this too)
+export type RedirectScopeInterface = Record<string, string | number | null | undefined>; //@TODO: move to general scope (other modules (page-tree, dam) need this too)

--- a/packages/site/site-nextjs/src/sitePreview/previewUtils.ts
+++ b/packages/site/site-nextjs/src/sitePreview/previewUtils.ts
@@ -5,8 +5,7 @@ import { cookies, draftMode, headers as getHeaders } from "next/headers";
 
 // Return type of previewParams function
 type PreviewParams = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    scope: Record<string, any>;
+    scope: Record<string, string | number | null | undefined>;
     previewData?: PreviewData;
 };
 


### PR DESCRIPTION
Currently, the content scope is often typed as `Record<string, unknown>` or `Record<string, any>`, whereas our content scope system only supports literal values, mostly strings or numbers. I noticed that AI reviewers repeatedly stumbled over this mismatch. I therefore propose to change the content scope types to only have the values we actually support: `string | number | null | undefined`.

## Migration Notes

Scope classes in applications need to declare an index signature. For scopes with only string dimensions, use `[key: string]: string`:

```ts
@Embeddable()
@ObjectType("PageTreeNodeScope")
@InputType("PageTreeNodeScopeInput")
export class PageTreeNodeScope {
    [key: string]: string;

    @Property({ columnType: "text" })
    @Field()
    @IsString()
    domain: string;

    @Property({ columnType: "text" })
    @Field()
    @IsString()
    language: string;
}
```

https://claude.ai/code/session_01NnYJ1LdUKw9FxdKdFAdWAr