### PR TITLE
mail-react: Fix the corner radius of rounded images in classic Outlook

### DIFF
--- a/.changeset/wild-donkeys-brake.md
+++ b/.changeset/wild-donkeys-brake.md
@@ -1,0 +1,5 @@
+---
+"@dextinity/mail-react": patch
+---
+
+Fix `borderRadius` on images in classic Outlook, which rounded corners twice as much as the value asked for

--- a/packages/mail-react/src/components/image/__tests__/HtmlImage.test.tsx
+++ b/packages/mail-react/src/components/image/__tests__/HtmlImage.test.tsx
@@ -37,6 +37,6 @@ describe("HtmlImage", () => {
             <HtmlImage src="image.jpg" alt="A photo" width={100} height={100} borderRadius={50} style={{ borderRadius: 10 }} />,
         );
 
-        expect(html).toContain('arcsize="20%"');
+        expect(html).toContain('arcsize="10%"');
     });
 });

--- a/packages/mail-react/src/components/image/__tests__/outlookVml.test.ts
+++ b/packages/mail-react/src/components/image/__tests__/outlookVml.test.ts
@@ -5,16 +5,16 @@ import { generateOutlookImageVml } from "../outlookVml.js";
 const image = { src: "image.jpg", width: 400, height: 200 };
 
 describe("generateOutlookImageVml", () => {
-    it("measures arcsize against the shorter side, not the width", () => {
+    it("measures arcsize against the whole shorter side", () => {
         const vml = generateOutlookImageVml({ ...image, borderRadius: 20 });
 
-        expect(vml).toContain(`arcsize="20%"`);
+        expect(vml).toContain(`arcsize="10%"`);
     });
 
     it("caps arcsize at a fully rounded side", () => {
         const vml = generateOutlookImageVml({ ...image, borderRadius: 999 });
 
-        expect(vml).toContain(`arcsize="100%"`);
+        expect(vml).toContain(`arcsize="50%"`);
     });
 
     it("draws an oval for a fully rounded radius", () => {

--- a/packages/mail-react/src/components/image/outlookVml.ts
+++ b/packages/mail-react/src/components/image/outlookVml.ts
@@ -65,9 +65,12 @@ function parsePixelLength(value: string | number | undefined): number | null {
     return pixels !== null && Number.isFinite(pixels) && pixels > 0 ? pixels : null;
 }
 
-/** VML measures `arcsize` against half the shorter side, so an equal radius needs a different value per aspect ratio. */
+/**
+ * Classic Outlook measures `arcsize` against the whole shorter side and draws no more than half of
+ * it, although ECMA-376 Part 4 says half the shorter side.
+ */
 function calculateArcsize(radius: number, width: number, height: number): string {
-    const fraction = Math.min(radius / (Math.min(width, height) / 2), 1);
+    const fraction = Math.min(radius / Math.min(width, height), 0.5);
 
     return `${Math.round(fraction * 100)}%`;
 }


### PR DESCRIPTION
Corners came out twice as round as the `borderRadius` asked for.

[ECMA-376 Part 4](https://webapp.docx4java.org/OnlineDemo/ecma376/VML/roundrect.html) defines `arcsize` on `v:roundrect` as "a percentage of half the smaller dimension of the length and width of the rectangle", but classic Outlook does not follow it: a 536x268 image with `arcsize="19%"` draws a 50px corner there, where that reading predicts 25px.

| Any other Client | Classic Outlook Previously | Classic Outlook now |
|--------|--------|--------|
| <img width="640" height="300" alt="other clients" src="https://github.com/user-attachments/assets/5b61320d-fe68-428e-a6e6-a9a28d9a0e5e" /> | <img width="640" height="300" alt="outlook prev" src="https://github.com/user-attachments/assets/1a59ff70-2dc9-4b81-a3c4-38d3f031b89a" /> | <img width="640" height="300" alt="outlook now" src="https://github.com/user-attachments/assets/dd4173ba-cb80-42e7-ac33-8dcb09520d73" /> | 

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13730