### PR TITLE
mail-react: Give the VML shape the public URL in Storybook previews

### DIFF
--- a/.changeset/mail-react-vml-public-url.md
+++ b/.changeset/mail-react-vml-public-url.md
@@ -1,0 +1,5 @@
+---
+"@dextinity/mail-react": patch
+---
+
+Apply the Storybook addon's **"Use public image URLs"** toggle to the Outlook VML image source

--- a/packages/mail-react/src/storybook/replaceImagesWithPublicUrl.test.ts
+++ b/packages/mail-react/src/storybook/replaceImagesWithPublicUrl.test.ts
@@ -62,6 +62,16 @@ describe("replaceImagesWithPublicUrl", () => {
         );
     });
 
+    it("gives the VML shape the same public URL as its image", () => {
+        const html =
+            '<v:roundrect style="width:300px;height:200px;"><v:fill type="frame" src="original.jpg" /></v:roundrect>' +
+            '<img src="original.jpg" width="300" height="200" />';
+        const result = replaceImagesWithPublicUrl(html);
+
+        expect(result).toContain('<v:fill type="frame" src="https://picsum.photos/seed/0/600/400" />');
+        expect(result).toContain('<img src="https://picsum.photos/seed/0/600/400" width="300" height="200" />');
+    });
+
     it("returns unchanged html when there are no img tags", () => {
         const html = "<p>Hello world</p>";
         const result = replaceImagesWithPublicUrl(html);

--- a/packages/mail-react/src/storybook/replaceImagesWithPublicUrl.ts
+++ b/packages/mail-react/src/storybook/replaceImagesWithPublicUrl.ts
@@ -1,11 +1,18 @@
 export function replaceImagesWithPublicUrl(html: string): string {
+    const { html: htmlWithPublicImages, publicUrlByOriginalSrc } = replaceImageSources(html);
+
+    return replaceOutlookVmlSources(htmlWithPublicImages, publicUrlByOriginalSrc);
+}
+
+function replaceImageSources(html: string): { html: string; publicUrlByOriginalSrc: Map<string, string> } {
+    const publicUrlByOriginalSrc = new Map<string, string>();
     let seedCounter = 0;
 
-    return html.replace(/<img\b[^>]*>/gi, (imgTag) => {
+    const htmlWithPublicImages = html.replace(/<img\b[^>]*>/gi, (imgTag) => {
         const widthMatch = imgTag.match(/\bwidth="(\d+)"/);
         const heightMatch = imgTag.match(/\bheight="(\d+)"/);
 
-        if (!widthMatch || !heightMatch) {
+        if (widthMatch === null || heightMatch === null) {
             return imgTag;
         }
 
@@ -13,7 +20,24 @@ export function replaceImagesWithPublicUrl(html: string): string {
         const retinaHeight = parseInt(heightMatch[1], 10) * 2;
         const seed = seedCounter++;
         const publicUrl = `https://picsum.photos/seed/${seed}/${retinaWidth}/${retinaHeight}`;
+        const srcMatch = imgTag.match(/\bsrc="([^"]*)"/);
+
+        if (srcMatch) {
+            publicUrlByOriginalSrc.set(srcMatch[1], publicUrl);
+        }
 
         return imgTag.replace(/\bsrc="[^"]*"/, `src="${publicUrl}"`);
+    });
+
+    return { html: htmlWithPublicImages, publicUrlByOriginalSrc };
+}
+
+/** Classic Outlook draws the VML shape instead of the `<img>`, and the shape carries its own copy of the source. */
+function replaceOutlookVmlSources(html: string, publicUrlByOriginalSrc: Map<string, string>): string {
+    return html.replace(/<v:fill\b[^>]*>/gi, (fillTag) => {
+        const srcMatch = fillTag.match(/\bsrc="([^"]*)"/);
+        const publicUrl = srcMatch === null ? undefined : publicUrlByOriginalSrc.get(srcMatch[1]);
+
+        return publicUrl === undefined ? fillTag : fillTag.replace(/\bsrc="[^"]*"/, `src="${publicUrl}"`);
     });
 }


### PR DESCRIPTION
The public-URL toggle rewrote `<img>` sources only, so classic Outlook previewed a different photo from every other client, which made side-by-side comparisons misleading.

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13730