### PR TITLE
Demo: Animate blocks when they enter the viewport

### DIFF
--- a/.changeset/list-block-index.md
+++ b/.changeset/list-block-index.md
@@ -1,0 +1,20 @@
+---
+"@dextinity/site-react": minor
+---
+
+Pass the item index as second argument to `ListBlock`'s `block` function
+
+This allows rendering list items based on their position, for instance, to stagger scroll-in animations.
+
+**Example**
+
+```tsx
+<ListBlock
+    data={data}
+    block={(block, index) => (
+        <AnimateBoxInOnScroll direction="bottom" delay={200 * index}>
+            <KeyFactItemBlock data={block} />
+        </AnimateBoxInOnScroll>
+    )}
+/>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ junit-storybook.xml
 # Build output of @dextinity/agent-features (copied from the skills/ and rules/ folders at the repository root)
 /packages/agent-features/skills/
 /packages/agent-features/rules/
+# Playwright CLI output (may contain credentials)
+.playwright-cli/

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,3 @@ junit-storybook.xml
 # Build output of @dextinity/agent-features (copied from the skills/ and rules/ folders at the repository root)
 /packages/agent-features/skills/
 /packages/agent-features/rules/
-# Playwright CLI output (may contain credentials)
-.playwright-cli/

--- a/demo/site/src/app/layout.tsx
+++ b/demo/site/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "@dextinity/site-nextjs/css";
 import "@src/styles/global.scss";
 
 import { CookieApiProvider, useLocalStorageCookieApi, useOneTrustCookieApi as useProductionCookieApi } from "@dextinity/site-nextjs";
+import animateBoxInOnScrollStyles from "@src/util/animations/AnimateBoxInOnScroll.module.scss";
 import { ErrorHandler } from "@src/util/ErrorHandler";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
@@ -16,6 +17,11 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: Readonly<PropsWithChildren>) {
     return (
         <html>
+            <head>
+                <noscript>
+                    <style>{`.${animateBoxInOnScrollStyles.scrollContainer} { opacity: 1; transform: none; transition: none; }`}</style>
+                </noscript>
+            </head>
             <body className={inter.className}>
                 <CookieApiProvider api={process.env.NODE_ENV === "development" ? useLocalStorageCookieApi : useProductionCookieApi}>
                     <ErrorHandler>{children}</ErrorHandler>

--- a/demo/site/src/common/blocks/AccordionBlock.tsx
+++ b/demo/site/src/common/blocks/AccordionBlock.tsx
@@ -2,6 +2,7 @@ import { isWithPreviewPropsData, type PropsWithData, usePreview, withPreview } f
 import type { AccordionBlockData } from "@src/blocks.generated";
 import { AccordionItemBlock } from "@src/common/blocks/AccordionItemBlock";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
 import { useEffect, useMemo, useState } from "react";
 
 import styles from "./AccordionBlock.module.scss";
@@ -62,16 +63,18 @@ export const AccordionBlock = withPreview(
         };
 
         return (
-            <div className={styles.root}>
-                {data.blocks.map((block) => (
-                    <AccordionItemBlock
-                        key={block.key}
-                        data={block.props}
-                        onChange={() => handleChange(block.key)}
-                        isExpanded={expandedItems.has(block.key)}
-                    />
-                ))}
-            </div>
+            <AnimateBoxInOnScroll direction="bottom">
+                <div className={styles.root}>
+                    {data.blocks.map((block) => (
+                        <AccordionItemBlock
+                            key={block.key}
+                            data={block.props}
+                            onChange={() => handleChange(block.key)}
+                            isExpanded={expandedItems.has(block.key)}
+                        />
+                    ))}
+                </div>
+            </AnimateBoxInOnScroll>
         );
     },
     { label: "Accordion" },

--- a/demo/site/src/common/blocks/ContactFormBlock.module.scss
+++ b/demo/site/src/common/blocks/ContactFormBlock.module.scss
@@ -1,5 +1,8 @@
-.form {
+.formWrapper {
     grid-column: 2 / -2;
+}
+
+.form {
     display: flex;
     flex-direction: column;
     gap: 20px;

--- a/demo/site/src/common/blocks/ContactFormBlock.tsx
+++ b/demo/site/src/common/blocks/ContactFormBlock.tsx
@@ -124,7 +124,7 @@ export const ContactFormBlock = withPreview(
         return (
             <PageLayout grid>
                 <Script src={`https://www.google.com/recaptcha/enterprise.js?render=${recaptchaSiteKey}`} />
-                <AnimateBoxInOnScroll direction="bottom" offset={300}>
+                <AnimateBoxInOnScroll direction="bottom" offset={300} className={styles.formWrapper}>
                     <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
                         <TextField
                             name="name"

--- a/demo/site/src/common/blocks/ContactFormBlock.tsx
+++ b/demo/site/src/common/blocks/ContactFormBlock.tsx
@@ -2,6 +2,7 @@
 import { type PropsWithData, withPreview } from "@dextinity/site-nextjs";
 import type { ContactFormBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
 import { acceptedFileTypes, maxFileSizeBytes } from "@src/util/fileUpload";
 import { getRecaptchaToken } from "@src/util/recaptcha/getRecaptchaToken";
 import { useSiteConfig } from "@src/util/SiteConfigProvider";
@@ -123,127 +124,129 @@ export const ContactFormBlock = withPreview(
         return (
             <PageLayout grid>
                 <Script src={`https://www.google.com/recaptcha/enterprise.js?render=${recaptchaSiteKey}`} />
-                <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
-                    <TextField
-                        name="name"
-                        control={control}
-                        rules={{
-                            required: intl.formatMessage({ id: "contactForm.name.required", defaultMessage: "Please enter your name" }),
-                        }}
-                        placeholder={intl.formatMessage({ id: "contactForm.name.placeholder", defaultMessage: "First and last name" })}
-                        label={intl.formatMessage({ id: "contactForm.name.label", defaultMessage: "Name" })}
-                    />
-                    <TextField
-                        name="company"
-                        control={control}
-                        placeholder={intl.formatMessage({ id: "contactForm.company.placeholder", defaultMessage: "Company name" })}
-                        label={intl.formatMessage({ id: "contactForm.company.label", defaultMessage: "Company" })}
-                    />
-                    <TextField
-                        name="email"
-                        control={control}
-                        rules={{
-                            required: intl.formatMessage({
-                                id: "contactForm.email.required",
-                                defaultMessage: "Please enter your email address",
-                            }),
-                            pattern: {
-                                value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-                                message: intl.formatMessage({ id: "contactForm.email.invalid", defaultMessage: "Invalid email address" }),
-                            },
-                        }}
-                        placeholder={intl.formatMessage({ id: "contactForm.email.placeholder", defaultMessage: "Your email address" })}
-                        label={intl.formatMessage({ id: "contactForm.email.label", defaultMessage: "Email" })}
-                    />
-                    <TextField
-                        name="phoneNumber"
-                        control={control}
-                        rules={{
-                            pattern: {
-                                value: /^[0-9+]*$/,
-                                message: intl.formatMessage({
-                                    id: "contactForm.phoneNumber.invalid",
-                                    defaultMessage: "Please enter only numbers",
+                <AnimateBoxInOnScroll direction="bottom" offset={300}>
+                    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+                        <TextField
+                            name="name"
+                            control={control}
+                            rules={{
+                                required: intl.formatMessage({ id: "contactForm.name.required", defaultMessage: "Please enter your name" }),
+                            }}
+                            placeholder={intl.formatMessage({ id: "contactForm.name.placeholder", defaultMessage: "First and last name" })}
+                            label={intl.formatMessage({ id: "contactForm.name.label", defaultMessage: "Name" })}
+                        />
+                        <TextField
+                            name="company"
+                            control={control}
+                            placeholder={intl.formatMessage({ id: "contactForm.company.placeholder", defaultMessage: "Company name" })}
+                            label={intl.formatMessage({ id: "contactForm.company.label", defaultMessage: "Company" })}
+                        />
+                        <TextField
+                            name="email"
+                            control={control}
+                            rules={{
+                                required: intl.formatMessage({
+                                    id: "contactForm.email.required",
+                                    defaultMessage: "Please enter your email address",
                                 }),
-                            },
-                        }}
-                        placeholder={intl.formatMessage({ id: "contactForm.phoneNumber.placeholder", defaultMessage: "0043123456789" })}
-                        label={intl.formatMessage({ id: "contactForm.phoneNumber.label", defaultMessage: "Phone Number" })}
-                        helperText={intl.formatMessage({
-                            id: "contactForm.phoneNumber.helperText",
-                            defaultMessage: "Please enter without special characters and spaces",
-                        })}
-                    />
-                    <SelectField
-                        name="subject"
-                        control={control}
-                        rules={{
-                            required: intl.formatMessage({
-                                id: "contactForm.subject.required",
-                                defaultMessage: "Please select a subject",
-                            }),
-                        }}
-                        label={intl.formatMessage({ id: "contactForm.subject.label", defaultMessage: "Subject" })}
-                        placeholder={intl.formatMessage({ id: "contactForm.subject.placeholder", defaultMessage: "Please select" })}
-                        options={subjectOptions}
-                    />
-                    <TextareaField
-                        name="message"
-                        control={control}
-                        rules={{
-                            required: intl.formatMessage({
-                                id: "contactForm.message.required",
-                                defaultMessage: "Please enter your message",
-                            }),
-                        }}
-                        placeholder={intl.formatMessage({ id: "contactForm.message.placeholder", defaultMessage: "Your message" })}
-                        label={intl.formatMessage({ id: "contactForm.message.label", defaultMessage: "Message" })}
-                    />
-                    <FileUploadField
-                        name="attachments"
-                        control={control}
-                        accept={acceptedFileTypes.join(",")}
-                        label={intl.formatMessage({ id: "contactForm.attachments.label", defaultMessage: "Attachments" })}
-                        validateFile={(file) => {
-                            if (file.size > maxFileSizeBytes) {
-                                return intl.formatMessage({
-                                    id: "contactForm.attachments.tooLarge",
-                                    defaultMessage: "File is too large.",
-                                });
-                            }
-                            return undefined;
-                        }}
-                    />
-                    <CheckboxField
-                        name="privacyConsent"
-                        control={control}
-                        rules={{
-                            required: intl.formatMessage({
-                                id: "contactForm.privacyConsent.required",
-                                defaultMessage: "You must agree to the privacy policy to continue",
-                            }),
-                        }}
-                        label={intl.formatMessage({
-                            id: "contactForm.privacyConsent.label",
-                            defaultMessage:
-                                "I agree that my information from the contact form will be collected and processed to answer my inquiry. Note: You can revoke your consent at any time by email to hello@your-domain.com. For more information, please see our privacy policy.",
-                        })}
-                    />
-                    <Button type="submit" variant="contained" disabled={isSubmitting || isUploading}>
-                        <FormattedMessage id="contactForm.submitButton.label" defaultMessage="Submit" />
-                    </Button>
-                    {errors.root?.serverError && <div>{errors.root.serverError.message}</div>}
-                    <Typography variant="paragraph200" bottomSpacing>
-                        <FormattedMessage
-                            id="contactForm.recaptchaDisclaimer"
-                            defaultMessage="This site is protected by reCAPTCHA and the Google <privacyLink>Privacy Policy</privacyLink> and <termsLink>Terms of Service</termsLink> apply."
-                            values={{
-                                privacyLink: (chunks) => <a href="https://policies.google.com/privacy">{chunks}</a>,
-                                termsLink: (chunks) => <a href="https://policies.google.com/terms">{chunks}</a>,
+                                pattern: {
+                                    value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                                    message: intl.formatMessage({ id: "contactForm.email.invalid", defaultMessage: "Invalid email address" }),
+                                },
+                            }}
+                            placeholder={intl.formatMessage({ id: "contactForm.email.placeholder", defaultMessage: "Your email address" })}
+                            label={intl.formatMessage({ id: "contactForm.email.label", defaultMessage: "Email" })}
+                        />
+                        <TextField
+                            name="phoneNumber"
+                            control={control}
+                            rules={{
+                                pattern: {
+                                    value: /^[0-9+]*$/,
+                                    message: intl.formatMessage({
+                                        id: "contactForm.phoneNumber.invalid",
+                                        defaultMessage: "Please enter only numbers",
+                                    }),
+                                },
+                            }}
+                            placeholder={intl.formatMessage({ id: "contactForm.phoneNumber.placeholder", defaultMessage: "0043123456789" })}
+                            label={intl.formatMessage({ id: "contactForm.phoneNumber.label", defaultMessage: "Phone Number" })}
+                            helperText={intl.formatMessage({
+                                id: "contactForm.phoneNumber.helperText",
+                                defaultMessage: "Please enter without special characters and spaces",
+                            })}
+                        />
+                        <SelectField
+                            name="subject"
+                            control={control}
+                            rules={{
+                                required: intl.formatMessage({
+                                    id: "contactForm.subject.required",
+                                    defaultMessage: "Please select a subject",
+                                }),
+                            }}
+                            label={intl.formatMessage({ id: "contactForm.subject.label", defaultMessage: "Subject" })}
+                            placeholder={intl.formatMessage({ id: "contactForm.subject.placeholder", defaultMessage: "Please select" })}
+                            options={subjectOptions}
+                        />
+                        <TextareaField
+                            name="message"
+                            control={control}
+                            rules={{
+                                required: intl.formatMessage({
+                                    id: "contactForm.message.required",
+                                    defaultMessage: "Please enter your message",
+                                }),
+                            }}
+                            placeholder={intl.formatMessage({ id: "contactForm.message.placeholder", defaultMessage: "Your message" })}
+                            label={intl.formatMessage({ id: "contactForm.message.label", defaultMessage: "Message" })}
+                        />
+                        <FileUploadField
+                            name="attachments"
+                            control={control}
+                            accept={acceptedFileTypes.join(",")}
+                            label={intl.formatMessage({ id: "contactForm.attachments.label", defaultMessage: "Attachments" })}
+                            validateFile={(file) => {
+                                if (file.size > maxFileSizeBytes) {
+                                    return intl.formatMessage({
+                                        id: "contactForm.attachments.tooLarge",
+                                        defaultMessage: "File is too large.",
+                                    });
+                                }
+                                return undefined;
                             }}
                         />
-                    </Typography>
-                </form>
+                        <CheckboxField
+                            name="privacyConsent"
+                            control={control}
+                            rules={{
+                                required: intl.formatMessage({
+                                    id: "contactForm.privacyConsent.required",
+                                    defaultMessage: "You must agree to the privacy policy to continue",
+                                }),
+                            }}
+                            label={intl.formatMessage({
+                                id: "contactForm.privacyConsent.label",
+                                defaultMessage:
+                                    "I agree that my information from the contact form will be collected and processed to answer my inquiry. Note: You can revoke your consent at any time by email to hello@your-domain.com. For more information, please see our privacy policy.",
+                            })}
+                        />
+                        <Button type="submit" variant="contained" disabled={isSubmitting || isUploading}>
+                            <FormattedMessage id="contactForm.submitButton.label" defaultMessage="Submit" />
+                        </Button>
+                        {errors.root?.serverError && <div>{errors.root.serverError.message}</div>}
+                        <Typography variant="paragraph200" bottomSpacing>
+                            <FormattedMessage
+                                id="contactForm.recaptchaDisclaimer"
+                                defaultMessage="This site is protected by reCAPTCHA and the Google <privacyLink>Privacy Policy</privacyLink> and <termsLink>Terms of Service</termsLink> apply."
+                                values={{
+                                    privacyLink: (chunks) => <a href="https://policies.google.com/privacy">{chunks}</a>,
+                                    termsLink: (chunks) => <a href="https://policies.google.com/terms">{chunks}</a>,
+                                }}
+                            />
+                        </Typography>
+                    </form>
+                </AnimateBoxInOnScroll>
             </PageLayout>
         );
     },

--- a/demo/site/src/common/blocks/MediaGalleryBlock.tsx
+++ b/demo/site/src/common/blocks/MediaGalleryBlock.tsx
@@ -6,6 +6,7 @@ import type { MediaGalleryBlockData } from "@src/blocks.generated";
 import { MediaBlock } from "@src/common/blocks/MediaBlock";
 import { Typography } from "@src/common/components/Typography";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
 import clsx from "clsx";
 import { useEffect, useRef, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -53,31 +54,33 @@ export const MediaGalleryBlock = withPreview(
                     aria-label={intl.formatMessage({ id: "mediaGalleryBlock.prevSlide", defaultMessage: "Previous slide" })}
                     disabled={activeItem === 0}
                 />
-                <BasicSwiper
-                    className={styles.swiper}
-                    slidesPerView={1}
-                    slidesPerGroup={1}
-                    modules={[Navigation]}
-                    navigation={{ prevEl: prevButtonRef.current, nextEl: nextButtonRef.current }}
-                    longSwipesRatio={0.1}
-                    threshold={3}
-                    allowTouchMove
-                    watchOverflow
-                    speed={400}
-                    onSwiper={setSwiper}
-                    onSlideChange={(swiper) => {
-                        setActiveItem(swiper.activeIndex);
-                    }}
-                >
-                    {data.items.blocks.map((block) => (
-                        <SwiperSlide key={block.key}>
-                            <MediaBlock data={block.props.media} aspectRatio={data.aspectRatio} />
-                            <Typography variant="paragraph200" className={styles.mediaCaption}>
-                                {block.props.caption}
-                            </Typography>
-                        </SwiperSlide>
-                    ))}
-                </BasicSwiper>
+                <AnimateBoxInOnScroll direction="bottom">
+                    <BasicSwiper
+                        className={styles.swiper}
+                        slidesPerView={1}
+                        slidesPerGroup={1}
+                        modules={[Navigation]}
+                        navigation={{ prevEl: prevButtonRef.current, nextEl: nextButtonRef.current }}
+                        longSwipesRatio={0.1}
+                        threshold={3}
+                        allowTouchMove
+                        watchOverflow
+                        speed={400}
+                        onSwiper={setSwiper}
+                        onSlideChange={(swiper) => {
+                            setActiveItem(swiper.activeIndex);
+                        }}
+                    >
+                        {data.items.blocks.map((block) => (
+                            <SwiperSlide key={block.key}>
+                                <MediaBlock data={block.props.media} aspectRatio={data.aspectRatio} />
+                                <Typography variant="paragraph200" className={styles.mediaCaption}>
+                                    {block.props.caption}
+                                </Typography>
+                            </SwiperSlide>
+                        ))}
+                    </BasicSwiper>
+                </AnimateBoxInOnScroll>
                 <Typography variant="paragraph300" className={styles.customPagination} role="status" aria-live="polite" aria-atomic="true">
                     <FormattedMessage
                         id="mediaGalleryBlock.pagination"

--- a/demo/site/src/common/blocks/PageTreeIndexBlock.tsx
+++ b/demo/site/src/common/blocks/PageTreeIndexBlock.tsx
@@ -1,6 +1,7 @@
 import { type PropsWithData, withPreview } from "@dextinity/site-nextjs";
 import type { PageTreeIndexBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
 import { createSitePath } from "@src/util/createSitePath";
 import NextLink from "next/link";
 import type { JSX } from "react";
@@ -43,7 +44,9 @@ export const PageTreeIndexBlock = withPreview(
         const tree = buildTree(allNodes);
         return (
             <PageLayout grid>
-                <div className={styles.root}>{renderTree(tree)}</div>
+                <AnimateBoxInOnScroll direction="bottom" className={styles.root}>
+                    {renderTree(tree)}
+                </AnimateBoxInOnScroll>
             </PageLayout>
         );
     },

--- a/demo/site/src/common/blocks/StandaloneCallToActionListBlock.tsx
+++ b/demo/site/src/common/blocks/StandaloneCallToActionListBlock.tsx
@@ -2,6 +2,7 @@
 import { type PropsWithData, withPreview } from "@dextinity/site-nextjs";
 import type { StandaloneCallToActionListBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
 import clsx from "clsx";
 
 import { CallToActionListBlock } from "./CallToActionListBlock";
@@ -12,9 +13,11 @@ type StandaloneCallToActionListBlockProps = PropsWithData<StandaloneCallToAction
 export const StandaloneCallToActionListBlock = withPreview(
     ({ data: { callToActionList, alignment } }: StandaloneCallToActionListBlockProps) => {
         return (
-            <div className={clsx(styles.root, styles[`root--${alignment}`])}>
-                <CallToActionListBlock data={callToActionList} />
-            </div>
+            <AnimateBoxInOnScroll direction="bottom" offset={300}>
+                <div className={clsx(styles.root, styles[`root--${alignment}`])}>
+                    <CallToActionListBlock data={callToActionList} />
+                </div>
+            </AnimateBoxInOnScroll>
         );
     },
     { label: "CallToActionList" },

--- a/demo/site/src/common/blocks/StandaloneHeadingBlock.tsx
+++ b/demo/site/src/common/blocks/StandaloneHeadingBlock.tsx
@@ -2,6 +2,7 @@
 import { type PropsWithData, withPreview } from "@dextinity/site-nextjs";
 import type { StandaloneHeadingBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
 import clsx from "clsx";
 
 import { HeadingBlock } from "./HeadingBlock";
@@ -12,9 +13,11 @@ type StandaloneHeadingBlockProps = PropsWithData<StandaloneHeadingBlockData>;
 export const StandaloneHeadingBlock = withPreview(
     ({ data: { heading, textAlignment } }: StandaloneHeadingBlockProps) => {
         return (
-            <div className={clsx(styles.root, textAlignment === "center" && styles.rootCenter)}>
-                <HeadingBlock data={heading} />
-            </div>
+            <AnimateBoxInOnScroll direction="bottom">
+                <div className={clsx(styles.root, textAlignment === "center" && styles.rootCenter)}>
+                    <HeadingBlock data={heading} />
+                </div>
+            </AnimateBoxInOnScroll>
         );
     },
     { label: "Heading" },

--- a/demo/site/src/common/blocks/StandaloneMediaBlock.tsx
+++ b/demo/site/src/common/blocks/StandaloneMediaBlock.tsx
@@ -2,6 +2,7 @@
 import { type PropsWithData, withPreview } from "@dextinity/site-nextjs";
 import type { StandaloneMediaBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
 
 import { MediaBlock } from "./MediaBlock";
 
@@ -9,7 +10,9 @@ export const StandaloneMediaBlock = withPreview(
     ({ data: { media, aspectRatio } }: PropsWithData<StandaloneMediaBlockData>) => {
         return (
             <PageLayout>
-                <MediaBlock data={media} aspectRatio={aspectRatio} />
+                <AnimateBoxInOnScroll direction="bottom">
+                    <MediaBlock data={media} aspectRatio={aspectRatio} />
+                </AnimateBoxInOnScroll>
             </PageLayout>
         );
     },

--- a/demo/site/src/common/blocks/StandaloneRichTextBlock.tsx
+++ b/demo/site/src/common/blocks/StandaloneRichTextBlock.tsx
@@ -2,6 +2,7 @@
 import { type PropsWithData, withPreview } from "@dextinity/site-nextjs";
 import type { StandaloneRichTextBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
 
 import { RichTextBlock } from "./RichTextBlock";
 import styles from "./StandaloneRichTextBlock.module.scss";
@@ -11,9 +12,11 @@ type StandaloneRichTextBlockProps = PropsWithData<StandaloneRichTextBlockData>;
 export const StandaloneRichTextBlock = withPreview(
     ({ data: { richText, textAlignment } }: StandaloneRichTextBlockProps) => {
         return (
-            <div className={styles[textAlignment]}>
-                <RichTextBlock data={richText} disableLastBottomSpacing />
-            </div>
+            <AnimateBoxInOnScroll direction="bottom" offset={300}>
+                <div className={styles[textAlignment]}>
+                    <RichTextBlock data={richText} disableLastBottomSpacing />
+                </div>
+            </AnimateBoxInOnScroll>
         );
     },
     { label: "RichText" },

--- a/demo/site/src/common/blocks/TableBlock.tsx
+++ b/demo/site/src/common/blocks/TableBlock.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithData } from "@dextinity/site-nextjs";
 import type { TableBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
 import clsx from "clsx";
 
 import { RichTextBlock } from "./RichTextBlock";
@@ -10,28 +11,30 @@ export const TableBlock = ({ data }: PropsWithData<TableBlockData>) => {
     return (
         <PageLayout grid>
             <div className={styles.pageLayoutContent}>
-                <table className={styles.table}>
-                    <tbody>
-                        {data.rows.map((row) => (
-                            <tr key={row.id} className={styles.row}>
-                                {data.columns.map((column) => {
-                                    const cellValue = row.cellValues.find((cellValue) => cellValue.columnId === column.id);
-                                    const highlightCell = row.highlighted || column.highlighted;
+                <AnimateBoxInOnScroll direction="bottom" offset={300}>
+                    <table className={styles.table}>
+                        <tbody>
+                            {data.rows.map((row) => (
+                                <tr key={row.id} className={styles.row}>
+                                    {data.columns.map((column) => {
+                                        const cellValue = row.cellValues.find((cellValue) => cellValue.columnId === column.id);
+                                        const highlightCell = row.highlighted || column.highlighted;
 
-                                    return (
-                                        <td key={column.id} className={clsx([styles.cell, highlightCell && styles["cell--highlighted"]])}>
-                                            {cellValue?.value && (
-                                                <div className={styles["cell__content"]}>
-                                                    <RichTextBlock data={cellValue?.value} disableLastBottomSpacing />
-                                                </div>
-                                            )}
-                                        </td>
-                                    );
-                                })}
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
+                                        return (
+                                            <td key={column.id} className={clsx([styles.cell, highlightCell && styles["cell--highlighted"]])}>
+                                                {cellValue?.value && (
+                                                    <div className={styles["cell__content"]}>
+                                                        <RichTextBlock data={cellValue?.value} disableLastBottomSpacing />
+                                                    </div>
+                                                )}
+                                            </td>
+                                        );
+                                    })}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </AnimateBoxInOnScroll>
             </div>
         </PageLayout>
     );

--- a/demo/site/src/common/blocks/TextImageBlock.tsx
+++ b/demo/site/src/common/blocks/TextImageBlock.tsx
@@ -2,6 +2,8 @@
 import { type PropsWithData, withPreview } from "@dextinity/site-nextjs";
 import type { TextImageBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
+import { AnimateGroup } from "@src/util/animations/AnimateGroup";
 import { createImageSizes } from "@src/util/createImageSizes";
 import clsx from "clsx";
 
@@ -12,14 +14,16 @@ import styles from "./TextImageBlock.module.scss";
 export const TextImageBlock = withPreview(
     ({ data: { text, image, imageAspectRatio, imagePosition } }: PropsWithData<TextImageBlockData>) => {
         return (
-            <div className={clsx(styles.root, imagePosition === "left" && styles["root--imageLeft"])}>
-                <div className={styles.imageContainer}>
-                    <DamImageBlock data={image} aspectRatio={imageAspectRatio} sizes={createImageSizes({ default: "100vw", md: "30vw" })} />
+            <AnimateGroup>
+                <div className={clsx(styles.root, imagePosition === "left" && styles["root--imageLeft"])}>
+                    <AnimateBoxInOnScroll direction={imagePosition === "left" ? "left" : "right"} className={styles.imageContainer}>
+                        <DamImageBlock data={image} aspectRatio={imageAspectRatio} sizes={createImageSizes({ default: "100vw", md: "30vw" })} />
+                    </AnimateBoxInOnScroll>
+                    <AnimateBoxInOnScroll direction="bottom" delay={100} offset={300} className={styles.textContainer}>
+                        <RichTextBlock data={text} />
+                    </AnimateBoxInOnScroll>
                 </div>
-                <div className={styles.textContainer}>
-                    <RichTextBlock data={text} />
-                </div>
-            </div>
+            </AnimateGroup>
         );
     },
     { label: "Text/Image" },

--- a/demo/site/src/common/blocks/TipTapRichTextBlock.tsx
+++ b/demo/site/src/common/blocks/TipTapRichTextBlock.tsx
@@ -13,6 +13,7 @@ import { PageLayout } from "@src/layout/PageLayout";
 import { ProductPriceBlock } from "@src/products/blocks/ProductPriceBlock";
 import { ProductTeaserBlock } from "@src/products/blocks/ProductTeaserBlock";
 import type { LoadedData as ProductTeaserLoadedData } from "@src/products/blocks/ProductTeaserBlock.loader";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
 
 import { Typography, type TypographyProps } from "../components/Typography";
 import { isValidLink } from "../helpers/HiddenIfInvalidLink";
@@ -102,7 +103,9 @@ export const TipTapRichTextBlock = withPreview(
 export const PageContentTipTapRichTextBlock = (props: PropsWithData<TipTapRichTextBlockData>) => (
     <PageLayout grid>
         <div className={styles.pageLayoutContent}>
-            <TipTapRichTextBlock {...props} />
+            <AnimateBoxInOnScroll direction="bottom" offset={300}>
+                <TipTapRichTextBlock {...props} />
+            </AnimateBoxInOnScroll>
         </div>
     </PageLayout>
 );

--- a/demo/site/src/common/blocks/TipTapTableBlock.tsx
+++ b/demo/site/src/common/blocks/TipTapTableBlock.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithData } from "@dextinity/site-nextjs";
 import type { TipTapTableBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
 import clsx from "clsx";
 
 import styles from "./TableBlock.module.scss";
@@ -10,28 +11,30 @@ export const TipTapTableBlock = ({ data }: PropsWithData<TipTapTableBlockData>) 
     return (
         <PageLayout grid>
             <div className={styles.pageLayoutContent}>
-                <table className={styles.table}>
-                    <tbody>
-                        {data.rows.map((row) => (
-                            <tr key={row.id} className={styles.row}>
-                                {data.columns.map((column) => {
-                                    const cellValue = row.cellValues.find((cellValue) => cellValue.columnId === column.id);
-                                    const highlightCell = row.highlighted || column.highlighted;
+                <AnimateBoxInOnScroll direction="bottom" offset={300}>
+                    <table className={styles.table}>
+                        <tbody>
+                            {data.rows.map((row) => (
+                                <tr key={row.id} className={styles.row}>
+                                    {data.columns.map((column) => {
+                                        const cellValue = row.cellValues.find((cellValue) => cellValue.columnId === column.id);
+                                        const highlightCell = row.highlighted || column.highlighted;
 
-                                    return (
-                                        <td key={column.id} className={clsx([styles.cell, highlightCell && styles["cell--highlighted"]])}>
-                                            {cellValue?.value && (
-                                                <div className={styles["cell__content"]}>
-                                                    <TipTapRichTextBlock data={cellValue.value} disableLastBottomSpacing />
-                                                </div>
-                                            )}
-                                        </td>
-                                    );
-                                })}
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
+                                        return (
+                                            <td key={column.id} className={clsx([styles.cell, highlightCell && styles["cell--highlighted"]])}>
+                                                {cellValue?.value && (
+                                                    <div className={styles["cell__content"]}>
+                                                        <TipTapRichTextBlock data={cellValue.value} disableLastBottomSpacing />
+                                                    </div>
+                                                )}
+                                            </td>
+                                        );
+                                    })}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </AnimateBoxInOnScroll>
             </div>
         </PageLayout>
     );

--- a/demo/site/src/documents/pages/blocks/BasicStageBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/BasicStageBlock.tsx
@@ -6,6 +6,7 @@ import { HeadingBlock } from "@src/common/blocks/HeadingBlock";
 import { MediaBlock } from "@src/common/blocks/MediaBlock";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnLoad } from "@src/util/animations/AnimateBoxInOnLoad";
 
 import styles from "./BasicStageBlock.module.scss";
 
@@ -27,9 +28,15 @@ export const BasicStageBlock = withPreview(
             <div className={styles.imageOverlay} style={{ opacity: `${overlay}%` }} />
             <PageLayout className={styles.absoluteGridRoot} grid>
                 <div className={styles.content} style={{ alignItems: alignment }}>
-                    <HeadingBlock data={heading} />
-                    <RichTextBlock data={text} />
-                    <CallToActionListBlock data={callToActionList} />
+                    <AnimateBoxInOnLoad direction="bottom">
+                        <HeadingBlock data={heading} />
+                    </AnimateBoxInOnLoad>
+                    <AnimateBoxInOnLoad direction="bottom" delay={150}>
+                        <RichTextBlock data={text} />
+                    </AnimateBoxInOnLoad>
+                    <AnimateBoxInOnLoad direction="bottom" delay={300}>
+                        <CallToActionListBlock data={callToActionList} />
+                    </AnimateBoxInOnLoad>
                 </div>
             </PageLayout>
         </div>

--- a/demo/site/src/documents/pages/blocks/BillboardTeaserBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/BillboardTeaserBlock.tsx
@@ -5,33 +5,43 @@ import { HeadingBlock } from "@src/common/blocks/HeadingBlock";
 import { MediaBlock } from "@src/common/blocks/MediaBlock";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
+import { AnimateGroup } from "@src/util/animations/AnimateGroup";
 
 import styles from "./BillboardTeaserBlock.module.scss";
 
 export const BillboardTeaserBlock = withPreview(
     ({ data: { media, heading, text, overlay, callToActionList } }: PropsWithData<BillboardTeaserBlockData>) => (
-        <div className={styles.root}>
-            <div className={styles.imageMobile}>
-                <MediaBlock data={media} aspectRatio="1x1" />
-            </div>
-            <div className={styles.imageTablet}>
-                <MediaBlock data={media} aspectRatio="4x3" />
-            </div>
-            <div className={styles.imageDesktop}>
-                <MediaBlock data={media} aspectRatio="16x9" />
-            </div>
-            <div className={styles.imageLargeDesktop}>
-                <MediaBlock data={media} aspectRatio="3x1" />
-            </div>
-            <div className={styles.imageOverlay} style={{ opacity: `${overlay}%` }} />
-            <PageLayout className={styles.absoluteGridRoot} grid>
-                <div className={styles.content}>
-                    <HeadingBlock data={heading} />
-                    <RichTextBlock data={text} />
-                    <CallToActionListBlock data={callToActionList} />
+        <AnimateGroup>
+            <div className={styles.root}>
+                <div className={styles.imageMobile}>
+                    <MediaBlock data={media} aspectRatio="1x1" />
                 </div>
-            </PageLayout>
-        </div>
+                <div className={styles.imageTablet}>
+                    <MediaBlock data={media} aspectRatio="4x3" />
+                </div>
+                <div className={styles.imageDesktop}>
+                    <MediaBlock data={media} aspectRatio="16x9" />
+                </div>
+                <div className={styles.imageLargeDesktop}>
+                    <MediaBlock data={media} aspectRatio="3x1" />
+                </div>
+                <div className={styles.imageOverlay} style={{ opacity: `${overlay}%` }} />
+                <PageLayout className={styles.absoluteGridRoot} grid>
+                    <div className={styles.content}>
+                        <AnimateBoxInOnScroll direction="bottom">
+                            <HeadingBlock data={heading} />
+                        </AnimateBoxInOnScroll>
+                        <AnimateBoxInOnScroll direction="bottom" delay={100}>
+                            <RichTextBlock data={text} />
+                        </AnimateBoxInOnScroll>
+                        <AnimateBoxInOnScroll direction="bottom" delay={200}>
+                            <CallToActionListBlock data={callToActionList} />
+                        </AnimateBoxInOnScroll>
+                    </div>
+                </PageLayout>
+            </div>
+        </AnimateGroup>
     ),
     { label: "Billboard Teaser" },
 );

--- a/demo/site/src/documents/pages/blocks/FullWidthImageBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/FullWidthImageBlock.tsx
@@ -3,23 +3,29 @@ import { OptionalBlock, type PropsWithData, withPreview } from "@dextinity/site-
 import type { FullWidthImageBlockData } from "@src/blocks.generated";
 import { DamImageBlock } from "@src/common/blocks/DamImageBlock";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
+import { AnimateGroup } from "@src/util/animations/AnimateGroup";
 
 import styles from "./FullWidthImageBlock.module.scss";
 
 export const FullWidthImageBlock = withPreview(
     ({ data: { image, content } }: PropsWithData<FullWidthImageBlockData>) => {
         return (
-            <div className={styles.root}>
-                <DamImageBlock data={image} sizes="100vw" aspectRatio="16x9" />
-                <OptionalBlock
-                    block={(props) => (
-                        <div className={styles.content}>
-                            <RichTextBlock data={props} />
-                        </div>
-                    )}
-                    data={content}
-                />
-            </div>
+            <AnimateGroup>
+                <div className={styles.root}>
+                    <AnimateBoxInOnScroll direction="bottom">
+                        <DamImageBlock data={image} sizes="100vw" aspectRatio="16x9" />
+                    </AnimateBoxInOnScroll>
+                    <OptionalBlock
+                        block={(props) => (
+                            <AnimateBoxInOnScroll direction="bottom" delay={200} className={styles.content}>
+                                <RichTextBlock data={props} />
+                            </AnimateBoxInOnScroll>
+                        )}
+                        data={content}
+                    />
+                </div>
+            </AnimateGroup>
         );
     },
     { label: "Full Width Image" },

--- a/demo/site/src/documents/pages/blocks/KeyFactsBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/KeyFactsBlock.tsx
@@ -1,19 +1,30 @@
 import { ListBlock, type PropsWithData, withPreview } from "@dextinity/site-nextjs";
 import type { KeyFactsBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
+import { AnimateGroup } from "@src/util/animations/AnimateGroup";
 
 import { KeyFactItemBlock } from "./KeyFactItemBlock";
 import styles from "./KeyFactsBlock.module.scss";
 
 export const KeyFactsBlock = withPreview(
     ({ data }: PropsWithData<KeyFactsBlockData>) => (
-        <PageLayout grid>
-            <div className={styles.pageLayoutContent}>
-                <div className={styles.itemWrapper} style={{ "--list-item-count": data.blocks.length }}>
-                    <ListBlock data={data} block={(block) => <KeyFactItemBlock data={block} />} />
+        <AnimateGroup disabledBreakpoints={["xs", "sm"]}>
+            <PageLayout grid>
+                <div className={styles.pageLayoutContent}>
+                    <div className={styles.itemWrapper} style={{ "--list-item-count": data.blocks.length }}>
+                        <ListBlock
+                            data={data}
+                            block={(block, index) => (
+                                <AnimateBoxInOnScroll direction="bottom" delay={200 * index} offset={300}>
+                                    <KeyFactItemBlock data={block} />
+                                </AnimateBoxInOnScroll>
+                            )}
+                        />
+                    </div>
                 </div>
-            </div>
-        </PageLayout>
+            </PageLayout>
+        </AnimateGroup>
     ),
     { label: "Key facts" },
 );

--- a/demo/site/src/documents/pages/blocks/SliderBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/SliderBlock.tsx
@@ -4,6 +4,8 @@ import { MediaBlock } from "@src/common/blocks/MediaBlock";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
 import { BasicSwiper } from "@src/common/components/BasicSwiper";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
+import { AnimateGroup } from "@src/util/animations/AnimateGroup";
 import { Pagination } from "swiper/modules";
 import { SwiperSlide } from "swiper/react";
 
@@ -14,34 +16,38 @@ type SliderBlockProps = PropsWithData<SliderBlockData>;
 export const SliderBlock = withPreview(
     ({ data: { sliderList } }: SliderBlockProps) => {
         return (
-            <PageLayout>
-                <div className={styles.slider}>
-                    <div className={styles.swiperContainer}>
-                        <BasicSwiper
-                            slidesPerView={3}
-                            spaceBetween={20}
-                            longSwipesRatio={0.1}
-                            modules={[Pagination]}
-                            pagination={{ clickable: true }}
-                            threshold={3}
-                            allowTouchMove
-                            watchOverflow
-                            autoHeight
-                        >
-                            {sliderList.blocks.map((block) => (
-                                <SwiperSlide key={block.key}>
-                                    <div className={styles.sliderItemBlockRoot}>
-                                        <div className={styles.mediaWrapper}>
-                                            <MediaBlock data={block.props.media} fill aspectRatio="16x9" sizes="50vw" />
-                                        </div>
-                                        <RichTextBlock data={block.props.text} />
-                                    </div>
-                                </SwiperSlide>
-                            ))}
-                        </BasicSwiper>
+            <AnimateGroup>
+                <PageLayout>
+                    <div className={styles.slider}>
+                        <div className={styles.swiperContainer}>
+                            <BasicSwiper
+                                slidesPerView={3}
+                                spaceBetween={20}
+                                longSwipesRatio={0.1}
+                                modules={[Pagination]}
+                                pagination={{ clickable: true }}
+                                threshold={3}
+                                allowTouchMove
+                                watchOverflow
+                                autoHeight
+                            >
+                                {sliderList.blocks.map((block, index) => (
+                                    <SwiperSlide key={block.key}>
+                                        <AnimateBoxInOnScroll direction="left" delay={100 * index}>
+                                            <div className={styles.sliderItemBlockRoot}>
+                                                <div className={styles.mediaWrapper}>
+                                                    <MediaBlock data={block.props.media} fill aspectRatio="16x9" sizes="50vw" />
+                                                </div>
+                                                <RichTextBlock data={block.props.text} />
+                                            </div>
+                                        </AnimateBoxInOnScroll>
+                                    </SwiperSlide>
+                                ))}
+                            </BasicSwiper>
+                        </div>
                     </div>
-                </div>
-            </PageLayout>
+                </PageLayout>
+            </AnimateGroup>
         );
     },
     { label: "Slider" },

--- a/demo/site/src/documents/pages/blocks/TeaserBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/TeaserBlock.tsx
@@ -1,19 +1,30 @@
 import { ListBlock, type PropsWithData, withPreview } from "@dextinity/site-nextjs";
 import type { TeaserBlockData } from "@src/blocks.generated";
 import { PageLayout } from "@src/layout/PageLayout";
+import { AnimateBoxInOnScroll } from "@src/util/animations/AnimateBoxInOnScroll";
+import { AnimateGroup } from "@src/util/animations/AnimateGroup";
 
 import styles from "./TeaserBlock.module.scss";
 import { TeaserItemBlock } from "./TeaserItemBlock";
 
 export const TeaserBlock = withPreview(
     ({ data }: PropsWithData<TeaserBlockData>) => (
-        <PageLayout grid>
-            <div className={styles.pageLayoutContent}>
-                <div className={styles.itemWrapper}>
-                    <ListBlock data={data} block={(block) => <TeaserItemBlock data={block} />} />
+        <AnimateGroup>
+            <PageLayout grid>
+                <div className={styles.pageLayoutContent}>
+                    <div className={styles.itemWrapper}>
+                        <ListBlock
+                            data={data}
+                            block={(block, index) => (
+                                <AnimateBoxInOnScroll direction="left" delay={100 * index}>
+                                    <TeaserItemBlock data={block} />
+                                </AnimateBoxInOnScroll>
+                            )}
+                        />
+                    </div>
                 </div>
-            </div>
-        </PageLayout>
+            </PageLayout>
+        </AnimateGroup>
     ),
     { label: "Teaser" },
 );

--- a/demo/site/src/documents/pages/blocks/TeaserBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/TeaserBlock.tsx
@@ -9,7 +9,7 @@ import { TeaserItemBlock } from "./TeaserItemBlock";
 
 export const TeaserBlock = withPreview(
     ({ data }: PropsWithData<TeaserBlockData>) => (
-        <AnimateGroup>
+        <AnimateGroup disabledBreakpoints={["xs", "sm"]}>
             <PageLayout grid>
                 <div className={styles.pageLayoutContent}>
                     <div className={styles.itemWrapper}>

--- a/demo/site/src/util/animations/AnimateBoxInOnLoad.module.scss
+++ b/demo/site/src/util/animations/AnimateBoxInOnLoad.module.scss
@@ -1,0 +1,78 @@
+@keyframes fade-in-from-left {
+    from {
+        opacity: 0;
+        transform: translate3d(-30px, 0, 0);
+    }
+
+    to {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+@keyframes fade-in-from-right {
+    from {
+        opacity: 0;
+        transform: translate3d(30px, 0, 0);
+    }
+
+    to {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+@keyframes fade-in-from-top {
+    from {
+        opacity: 0;
+        transform: translate3d(0, -30px, 0);
+    }
+
+    to {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+@keyframes fade-in-from-bottom {
+    from {
+        opacity: 0;
+        transform: translate3d(0, 30px, 0);
+    }
+
+    to {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+.root {
+    animation-duration: var(--animation-duration, 0.8s);
+    animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+    animation-fill-mode: both;
+    animation-delay: var(--animation-delay, 0ms);
+}
+
+.fromLeft {
+    animation-name: fade-in-from-left;
+}
+
+.fromRight {
+    animation-name: fade-in-from-right;
+}
+
+.fromTop {
+    animation-name: fade-in-from-top;
+}
+
+.fromBottom {
+    animation-name: fade-in-from-bottom;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .root {
+        animation: none;
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+}

--- a/demo/site/src/util/animations/AnimateBoxInOnLoad.module.scss
+++ b/demo/site/src/util/animations/AnimateBoxInOnLoad.module.scss
@@ -69,7 +69,7 @@
     animation-name: fade-in-from-bottom;
 }
 
-@media (prefers-reduced-motion: reduce) {
+@media (prefers-reduced-motion: reduce), print {
     .root {
         animation: none;
         opacity: 1;

--- a/demo/site/src/util/animations/AnimateBoxInOnLoad.module.scss
+++ b/demo/site/src/util/animations/AnimateBoxInOnLoad.module.scss
@@ -47,7 +47,7 @@
 }
 
 .root {
-    animation-duration: var(--animation-duration, 0.8s);
+    animation-duration: 0.8s;
     animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
     animation-fill-mode: both;
     animation-delay: var(--animation-delay, 0ms);

--- a/demo/site/src/util/animations/AnimateBoxInOnLoad.tsx
+++ b/demo/site/src/util/animations/AnimateBoxInOnLoad.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { usePreview } from "@dextinity/site-nextjs";
+import clsx from "clsx";
+import type { ReactElement } from "react";
+
+import styles from "./AnimateBoxInOnLoad.module.scss";
+
+interface AnimateBoxInOnLoadProps {
+    direction?: "top" | "right" | "bottom" | "left";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    children: ReactElement<any>;
+    delay?: number;
+    duration?: number;
+}
+
+export function AnimateBoxInOnLoad({ children, direction = "bottom", delay = 0, duration }: AnimateBoxInOnLoadProps) {
+    const { previewType } = usePreview();
+
+    const style = {
+        "--animation-delay": `${delay}ms`,
+        ...(duration != null && { "--animation-duration": `${duration}ms` }),
+    } as React.CSSProperties;
+
+    return (
+        <div
+            className={clsx(
+                styles.root,
+                previewType !== "BlockPreview" && direction === "left" && styles.fromLeft,
+                previewType !== "BlockPreview" && direction === "right" && styles.fromRight,
+                previewType !== "BlockPreview" && direction === "top" && styles.fromTop,
+                previewType !== "BlockPreview" && direction === "bottom" && styles.fromBottom,
+            )}
+            style={style}
+        >
+            {children}
+        </div>
+    );
+}

--- a/demo/site/src/util/animations/AnimateBoxInOnLoad.tsx
+++ b/demo/site/src/util/animations/AnimateBoxInOnLoad.tsx
@@ -2,19 +2,17 @@
 
 import { usePreview } from "@dextinity/site-nextjs";
 import clsx from "clsx";
-import type { ReactElement } from "react";
+import type { PropsWithChildren } from "react";
 
 import styles from "./AnimateBoxInOnLoad.module.scss";
 
 interface AnimateBoxInOnLoadProps {
     direction?: "top" | "right" | "bottom" | "left";
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    children: ReactElement<any>;
     delay?: number;
     duration?: number;
 }
 
-export function AnimateBoxInOnLoad({ children, direction = "bottom", delay = 0, duration }: AnimateBoxInOnLoadProps) {
+export function AnimateBoxInOnLoad({ children, direction = "bottom", delay = 0, duration }: PropsWithChildren<AnimateBoxInOnLoadProps>) {
     const { previewType } = usePreview();
 
     const style = {

--- a/demo/site/src/util/animations/AnimateBoxInOnLoad.tsx
+++ b/demo/site/src/util/animations/AnimateBoxInOnLoad.tsx
@@ -9,15 +9,13 @@ import styles from "./AnimateBoxInOnLoad.module.scss";
 interface AnimateBoxInOnLoadProps {
     direction?: "top" | "right" | "bottom" | "left";
     delay?: number;
-    duration?: number;
 }
 
-export function AnimateBoxInOnLoad({ children, direction = "bottom", delay = 0, duration }: PropsWithChildren<AnimateBoxInOnLoadProps>) {
+export function AnimateBoxInOnLoad({ children, direction = "bottom", delay = 0 }: PropsWithChildren<AnimateBoxInOnLoadProps>) {
     const { previewType } = usePreview();
 
     const style = {
         "--animation-delay": `${delay}ms`,
-        ...(duration != null && { "--animation-duration": `${duration}ms` }),
     } as React.CSSProperties;
 
     return (

--- a/demo/site/src/util/animations/AnimateBoxInOnScroll.module.scss
+++ b/demo/site/src/util/animations/AnimateBoxInOnScroll.module.scss
@@ -1,0 +1,39 @@
+.scrollContainer {
+    opacity: 0;
+    transition:
+        opacity var(--animation-duration, 500ms) ease-in-out var(--animation-delay, 0ms),
+        transform var(--animation-transform-duration, 1000ms) cubic-bezier(0.22, 1, 0.36, 1) var(--animation-delay, 0ms);
+}
+
+.fullHeight {
+    height: 100%;
+}
+
+.fromLeft {
+    transform: translate3d(-40px, 0, 0);
+}
+
+.fromRight {
+    transform: translate3d(40px, 0, 0);
+}
+
+.fromTop {
+    transform: translate3d(0, -40px, 0);
+}
+
+.fromBottom {
+    transform: translate3d(0, 40px, 0);
+}
+
+.animate {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .scrollContainer {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+        transition: none;
+    }
+}

--- a/demo/site/src/util/animations/AnimateBoxInOnScroll.module.scss
+++ b/demo/site/src/util/animations/AnimateBoxInOnScroll.module.scss
@@ -5,10 +5,6 @@
         transform var(--animation-transform-duration, 1000ms) cubic-bezier(0.22, 1, 0.36, 1) var(--animation-delay, 0ms);
 }
 
-.fullHeight {
-    height: 100%;
-}
-
 .fromLeft {
     transform: translate3d(-40px, 0, 0);
 }

--- a/demo/site/src/util/animations/AnimateBoxInOnScroll.module.scss
+++ b/demo/site/src/util/animations/AnimateBoxInOnScroll.module.scss
@@ -26,7 +26,7 @@
     transform: translate3d(0, 0, 0);
 }
 
-@media (prefers-reduced-motion: reduce) {
+@media (prefers-reduced-motion: reduce), print {
     .scrollContainer {
         opacity: 1;
         transform: translate3d(0, 0, 0);

--- a/demo/site/src/util/animations/AnimateBoxInOnScroll.tsx
+++ b/demo/site/src/util/animations/AnimateBoxInOnScroll.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { usePreview } from "@dextinity/site-nextjs";
+import { useAnimateGroup } from "@src/util/animations/AnimateGroup";
+import { useGlobalScrollSpeed } from "@src/util/animations/useGlobalScrollSpeed";
+import { useWindowSize } from "@src/util/useWindowSize";
+import clsx from "clsx";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+import styles from "./AnimateBoxInOnScroll.module.scss";
+
+interface AnimateBoxInOnScrollProps {
+    direction?: "top" | "right" | "bottom" | "left";
+    children: ReactNode;
+    offset?: number;
+    delay?: number;
+    duration?: number;
+    fullHeight?: boolean;
+    onChange?: (inView: boolean) => void;
+    className?: string;
+    innerClassName?: string;
+}
+
+export function AnimateBoxInOnScroll({
+    children,
+    direction = undefined,
+    offset = 200,
+    delay = 0,
+    duration = 500,
+    fullHeight = false,
+    onChange,
+    className,
+    innerClassName,
+    ...props
+}: AnimateBoxInOnScrollProps) {
+    const animateGroup = useAnimateGroup();
+    const refScrollContainer = useRef<HTMLDivElement | null>(null);
+    const [triggerAnimation, setTriggerAnimation] = useState<boolean>(false);
+    const { previewType } = usePreview();
+    const windowSize = useWindowSize();
+    const scrollSpeed = useGlobalScrollSpeed();
+
+    const groupForceVisible = animateGroup?.visible ?? false;
+    const groupOnVisible = animateGroup?.onVisible;
+    const groupDisabled = animateGroup?.disabled ?? false;
+
+    // When AnimateGroup is used and disabled in some breakpoints,
+    // the delay should be 0 to avoid raised delay on elements below each other
+    const effectiveDelay = groupDisabled ? 0 : delay;
+
+    // Dynamic delay and animation duration for speedup animation on faster scrolling
+    const dynamicDelay = scrollSpeed > 4 ? effectiveDelay / (scrollSpeed / 4) : effectiveDelay;
+    const dynamicAnimationDuration = scrollSpeed > 4 ? Math.min(duration / (scrollSpeed / 4), 200) : duration;
+
+    // Show immediately if element is already in view on page load
+    useEffect(() => {
+        const scrollContainer = refScrollContainer.current;
+        if (!scrollContainer || previewType === "BlockPreview") {
+            return;
+        }
+
+        const rect = scrollContainer.getBoundingClientRect();
+        if (rect.top < window.innerHeight && rect.bottom > 0) {
+            setTriggerAnimation(true);
+            onChange?.(true);
+            if (!groupDisabled) {
+                groupOnVisible?.();
+            }
+        }
+        // Mount-only: only the initial-in-view state should trigger this; re-running on prop changes would re-fire the animation.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+        const scrollContainer = refScrollContainer.current;
+        if (!scrollContainer || previewType === "BlockPreview") {
+            return;
+        }
+
+        // Dynamic offset for trigger animation earlier on faster scrolling
+        const dynamicOffsetScrollSpeed = Math.min(scrollSpeed > 2 ? scrollSpeed * 10 : 0, 300);
+        // Dynamic offset page height for adjusting offset relative to page height
+        const dynamicOffsetPageHeight = windowSize ? (windowSize?.height / 2.5) * -1 + offset : offset;
+        const triggerAnimationOffset = dynamicOffsetScrollSpeed + dynamicOffsetPageHeight;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        setTriggerAnimation(true);
+                        onChange?.(entry.isIntersecting);
+                        if (!groupDisabled) {
+                            groupOnVisible?.();
+                        }
+                    }
+                });
+            },
+            {
+                rootMargin: `0px 0px ${direction === "bottom" ? triggerAnimationOffset + 40 : direction === "top" ? triggerAnimationOffset - 40 : triggerAnimationOffset}px 0px`,
+                threshold: 0,
+            },
+        );
+
+        observer.observe(scrollContainer);
+
+        return () => {
+            if (scrollContainer) {
+                observer.unobserve(scrollContainer);
+            }
+        };
+    }, [offset, previewType, direction, windowSize, onChange, scrollSpeed, groupOnVisible, groupDisabled]);
+
+    // Set CSS variable for delay and duration
+    const style = {
+        "--animation-delay": `${dynamicDelay ?? 0}ms`,
+        "--animation-duration": `${dynamicAnimationDuration ?? 0}ms`,
+        "--animation-transform-duration": `${dynamicAnimationDuration ? dynamicAnimationDuration * 2 : 0}ms`,
+    } as React.CSSProperties;
+
+    return (
+        <div className={clsx(className)}>
+            <div
+                ref={refScrollContainer}
+                onFocus={() => {
+                    setTriggerAnimation(true);
+                    groupOnVisible?.();
+                }}
+                className={clsx(
+                    styles.scrollContainer,
+                    fullHeight && styles.fullHeight,
+                    direction === "left" && styles.fromLeft,
+                    direction === "right" && styles.fromRight,
+                    direction === "top" && styles.fromTop,
+                    direction === "bottom" && styles.fromBottom,
+                    (previewType === "BlockPreview" || triggerAnimation || groupForceVisible) && styles.animate,
+                    innerClassName,
+                )}
+                style={style}
+                {...props}
+            >
+                {children}
+            </div>
+        </div>
+    );
+}

--- a/demo/site/src/util/animations/AnimateBoxInOnScroll.tsx
+++ b/demo/site/src/util/animations/AnimateBoxInOnScroll.tsx
@@ -36,6 +36,7 @@ export function AnimateBoxInOnScroll({
     const animateGroup = useAnimateGroup();
     const refScrollContainer = useRef<HTMLDivElement | null>(null);
     const [triggerAnimation, setTriggerAnimation] = useState<boolean>(false);
+    const [visibleOnMount, setVisibleOnMount] = useState<boolean>(false);
     const { previewType } = usePreview();
     const windowSize = useWindowSize();
     const scrollSpeed = useGlobalScrollSpeed();
@@ -43,6 +44,8 @@ export function AnimateBoxInOnScroll({
     const groupForceVisible = animateGroup?.visible ?? false;
     const groupOnVisible = animateGroup?.onVisible;
     const groupDisabled = animateGroup?.disabled ?? false;
+    // Without a group there is nothing to wait for; with one, the breakpoint has to be measured first.
+    const groupInitialized = animateGroup?.initialized ?? true;
 
     // When AnimateGroup is used and disabled in some breakpoints,
     // the delay should be 0 to avoid raised delay on elements below each other
@@ -63,13 +66,19 @@ export function AnimateBoxInOnScroll({
         if (rect.top < window.innerHeight && rect.bottom > 0) {
             setTriggerAnimation(true);
             onChange?.(true);
-            if (!groupDisabled) {
-                groupOnVisible?.();
-            }
+            setVisibleOnMount(true);
         }
         // Mount-only: only the initial-in-view state should trigger this; re-running on prop changes would re-fire the animation.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    // Reporting to the group is deferred until it has measured its breakpoint. Child effects run before the group's,
+    // so notifying from the mount effect above would force the whole group visible even at a disabled breakpoint.
+    useEffect(() => {
+        if (visibleOnMount && groupInitialized && !groupDisabled) {
+            groupOnVisible?.();
+        }
+    }, [visibleOnMount, groupInitialized, groupDisabled, groupOnVisible]);
 
     useEffect(() => {
         const scrollContainer = refScrollContainer.current;

--- a/demo/site/src/util/animations/AnimateBoxInOnScroll.tsx
+++ b/demo/site/src/util/animations/AnimateBoxInOnScroll.tsx
@@ -3,6 +3,7 @@
 import { usePreview } from "@dextinity/site-nextjs";
 import { useAnimateGroup } from "@src/util/animations/AnimateGroup";
 import { useGlobalScrollSpeed } from "@src/util/animations/useGlobalScrollSpeed";
+import { useScrolledToPageBottom } from "@src/util/animations/useScrolledToPageBottom";
 import { useWindowSize } from "@src/util/useWindowSize";
 import clsx from "clsx";
 import { type PropsWithChildren, useEffect, useRef, useState } from "react";
@@ -33,6 +34,7 @@ export function AnimateBoxInOnScroll({
     const { previewType } = usePreview();
     const windowSize = useWindowSize();
     const scrollSpeed = useGlobalScrollSpeed();
+    const scrolledToPageBottom = useScrolledToPageBottom();
 
     const groupForceVisible = animateGroup?.visible ?? false;
     const groupOnVisible = animateGroup?.onVisible;
@@ -63,6 +65,18 @@ export function AnimateBoxInOnScroll({
         // Mount-only: only the initial-in-view state should trigger this; re-running on prop changes would re-fire the animation.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    // The bottom rootMargin below is negative, so the trigger line sits above the viewport bottom. A block that only
+    // ever reaches that band — the last one above a short footer — would never intersect and stay hidden for good.
+    useEffect(() => {
+        if (!scrolledToPageBottom || previewType === "BlockPreview") {
+            return;
+        }
+        setTriggerAnimation(true);
+        if (!groupDisabled) {
+            groupOnVisible?.();
+        }
+    }, [scrolledToPageBottom, previewType, groupDisabled, groupOnVisible]);
 
     // Reporting to the group is deferred until it has measured its breakpoint. Child effects run before the group's,
     // so notifying from the mount effect above would force the whole group visible even at a disabled breakpoint.

--- a/demo/site/src/util/animations/AnimateBoxInOnScroll.tsx
+++ b/demo/site/src/util/animations/AnimateBoxInOnScroll.tsx
@@ -5,20 +5,17 @@ import { useAnimateGroup } from "@src/util/animations/AnimateGroup";
 import { useGlobalScrollSpeed } from "@src/util/animations/useGlobalScrollSpeed";
 import { useWindowSize } from "@src/util/useWindowSize";
 import clsx from "clsx";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type PropsWithChildren, useEffect, useRef, useState } from "react";
 
 import styles from "./AnimateBoxInOnScroll.module.scss";
 
+const animationDuration = 500;
+
 interface AnimateBoxInOnScrollProps {
     direction?: "top" | "right" | "bottom" | "left";
-    children: ReactNode;
     offset?: number;
     delay?: number;
-    duration?: number;
-    fullHeight?: boolean;
-    onChange?: (inView: boolean) => void;
     className?: string;
-    innerClassName?: string;
 }
 
 export function AnimateBoxInOnScroll({
@@ -26,13 +23,9 @@ export function AnimateBoxInOnScroll({
     direction = undefined,
     offset = 200,
     delay = 0,
-    duration = 500,
-    fullHeight = false,
-    onChange,
     className,
-    innerClassName,
     ...props
-}: AnimateBoxInOnScrollProps) {
+}: PropsWithChildren<AnimateBoxInOnScrollProps>) {
     const animateGroup = useAnimateGroup();
     const refScrollContainer = useRef<HTMLDivElement | null>(null);
     const [triggerAnimation, setTriggerAnimation] = useState<boolean>(false);
@@ -53,7 +46,7 @@ export function AnimateBoxInOnScroll({
 
     // Dynamic delay and animation duration for speedup animation on faster scrolling
     const dynamicDelay = scrollSpeed > 4 ? effectiveDelay / (scrollSpeed / 4) : effectiveDelay;
-    const dynamicAnimationDuration = scrollSpeed > 4 ? Math.min(duration / (scrollSpeed / 4), 200) : duration;
+    const dynamicAnimationDuration = scrollSpeed > 4 ? Math.min(animationDuration / (scrollSpeed / 4), 200) : animationDuration;
 
     // Show immediately if element is already in view on page load
     useEffect(() => {
@@ -65,7 +58,6 @@ export function AnimateBoxInOnScroll({
         const rect = scrollContainer.getBoundingClientRect();
         if (rect.top < window.innerHeight && rect.bottom > 0) {
             setTriggerAnimation(true);
-            onChange?.(true);
             setVisibleOnMount(true);
         }
         // Mount-only: only the initial-in-view state should trigger this; re-running on prop changes would re-fire the animation.
@@ -97,7 +89,6 @@ export function AnimateBoxInOnScroll({
                 entries.forEach((entry) => {
                     if (entry.isIntersecting) {
                         setTriggerAnimation(true);
-                        onChange?.(entry.isIntersecting);
                         if (!groupDisabled) {
                             groupOnVisible?.();
                         }
@@ -117,7 +108,7 @@ export function AnimateBoxInOnScroll({
                 observer.unobserve(scrollContainer);
             }
         };
-    }, [offset, previewType, direction, windowSize, onChange, scrollSpeed, groupOnVisible, groupDisabled]);
+    }, [offset, previewType, direction, windowSize, scrollSpeed, groupOnVisible, groupDisabled]);
 
     // Set CSS variable for delay and duration
     const style = {
@@ -136,13 +127,11 @@ export function AnimateBoxInOnScroll({
                 }}
                 className={clsx(
                     styles.scrollContainer,
-                    fullHeight && styles.fullHeight,
                     direction === "left" && styles.fromLeft,
                     direction === "right" && styles.fromRight,
                     direction === "top" && styles.fromTop,
                     direction === "bottom" && styles.fromBottom,
                     (previewType === "BlockPreview" || triggerAnimation || groupForceVisible) && styles.animate,
-                    innerClassName,
                 )}
                 style={style}
                 {...props}

--- a/demo/site/src/util/animations/AnimateBoxInOnScroll.tsx
+++ b/demo/site/src/util/animations/AnimateBoxInOnScroll.tsx
@@ -74,7 +74,9 @@ export function AnimateBoxInOnScroll({
 
     useEffect(() => {
         const scrollContainer = refScrollContainer.current;
-        if (!scrollContainer || previewType === "BlockPreview") {
+        // Once the animation has run the element never reverts, so it does not need to stay observed. Without this the
+        // observer of every already-animated box is torn down and rebuilt on each scroll-speed and viewport change.
+        if (!scrollContainer || previewType === "BlockPreview" || triggerAnimation) {
             return;
         }
 
@@ -108,7 +110,7 @@ export function AnimateBoxInOnScroll({
                 observer.unobserve(scrollContainer);
             }
         };
-    }, [offset, previewType, direction, windowSize, scrollSpeed, groupOnVisible, groupDisabled]);
+    }, [offset, previewType, direction, windowSize, scrollSpeed, groupOnVisible, groupDisabled, triggerAnimation]);
 
     // Set CSS variable for delay and duration
     const style = {

--- a/demo/site/src/util/animations/AnimateGroup.tsx
+++ b/demo/site/src/util/animations/AnimateGroup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from "react";
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 const breakpoints = {
     xs: 0,
@@ -14,6 +14,8 @@ interface AnimateGroupContextValue {
     visible: boolean;
     onVisible: () => void;
     disabled: boolean;
+    /** False until the breakpoint has been measured on the client. Children must not report visibility before that. */
+    initialized: boolean;
 }
 
 const AnimateGroupContext = createContext<AnimateGroupContextValue | null>(null);
@@ -48,19 +50,41 @@ function isInDisabledRange(width: number, ranges: Array<[number, number]>) {
 
 export function AnimateGroup({ children, disabledBreakpoints = [] }: { children: ReactNode; disabledBreakpoints?: BreakpointKey[] }) {
     const [visible, setVisible] = useState(false);
-    const onVisible = useCallback(() => setVisible(true), []);
-    const [disableAnimateGroup, setDisableAnimateGroup] = useState(false);
+    // null until measured: the width is only known on the client, and rendering it into the markup would break hydration.
+    const [disabled, setDisabled] = useState<boolean | null>(null);
+    const disabledRef = useRef<boolean | null>(null);
+
+    const onVisible = useCallback(() => {
+        // Ignore reports until the breakpoint is known, and while the group is disabled. Child effects run before the
+        // effect below, so an initially visible child would otherwise force every sibling visible at a disabled breakpoint.
+        if (disabledRef.current !== false) {
+            return;
+        }
+        setVisible(true);
+    }, []);
+
+    // The prop defaults to a new array on every render, so key the effect on its content instead of its identity.
+    const disabledBreakpointsKey = disabledBreakpoints.join(",");
+    const ranges = useMemo(
+        () => getDisabledRanges(disabledBreakpointsKey ? (disabledBreakpointsKey.split(",") as BreakpointKey[]) : []),
+        [disabledBreakpointsKey],
+    );
 
     useEffect(() => {
         function checkDisabledBreakpoints() {
-            const width = window.innerWidth;
-            const ranges = getDisabledRanges(disabledBreakpoints);
-            setDisableAnimateGroup(isInDisabledRange(width, ranges));
+            const isDisabled = isInDisabledRange(window.innerWidth, ranges);
+            disabledRef.current = isDisabled;
+            setDisabled(isDisabled);
         }
         checkDisabledBreakpoints();
         window.addEventListener("resize", checkDisabledBreakpoints);
         return () => window.removeEventListener("resize", checkDisabledBreakpoints);
-    }, [disabledBreakpoints]);
+    }, [ranges]);
 
-    return <AnimateGroupContext.Provider value={{ visible, onVisible, disabled: disableAnimateGroup }}>{children}</AnimateGroupContext.Provider>;
+    const value = useMemo(
+        () => ({ visible, onVisible, disabled: disabled ?? false, initialized: disabled !== null }),
+        [visible, onVisible, disabled],
+    );
+
+    return <AnimateGroupContext.Provider value={value}>{children}</AnimateGroupContext.Provider>;
 }

--- a/demo/site/src/util/animations/AnimateGroup.tsx
+++ b/demo/site/src/util/animations/AnimateGroup.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from "react";
+
+const breakpoints = {
+    xs: 0,
+    sm: 600,
+    md: 900,
+    lg: 1200,
+    xl: 1600,
+};
+
+interface AnimateGroupContextValue {
+    visible: boolean;
+    onVisible: () => void;
+    disabled: boolean;
+}
+
+const AnimateGroupContext = createContext<AnimateGroupContextValue | null>(null);
+
+export function useAnimateGroup() {
+    return useContext(AnimateGroupContext);
+}
+
+type BreakpointKey = keyof typeof breakpoints;
+
+function getDisabledRanges(disabledBreakpoints: BreakpointKey[]) {
+    const keys = Object.keys(breakpoints) as BreakpointKey[];
+    const sorted = [...disabledBreakpoints].sort((a, b) => breakpoints[a] - breakpoints[b]);
+    const ranges: Array<[number, number]> = [];
+
+    for (const breakpoint of sorted) {
+        const idx = keys.indexOf(breakpoint);
+        if (idx < keys.length - 1) {
+            // Disable from this breakpoint up to the next one
+            ranges.push([breakpoints[breakpoint], breakpoints[keys[idx + 1]]]);
+        } else {
+            // Last breakpoint: disable from its value to Infinity
+            ranges.push([breakpoints[breakpoint], Infinity]);
+        }
+    }
+    return ranges;
+}
+
+function isInDisabledRange(width: number, ranges: Array<[number, number]>) {
+    return ranges.some(([min, max]) => width >= min && width < max);
+}
+
+export function AnimateGroup({ children, disabledBreakpoints = [] }: { children: ReactNode; disabledBreakpoints?: BreakpointKey[] }) {
+    const [visible, setVisible] = useState(false);
+    const onVisible = useCallback(() => setVisible(true), []);
+    const [disableAnimateGroup, setDisableAnimateGroup] = useState(false);
+
+    useEffect(() => {
+        function checkDisabledBreakpoints() {
+            const width = window.innerWidth;
+            const ranges = getDisabledRanges(disabledBreakpoints);
+            setDisableAnimateGroup(isInDisabledRange(width, ranges));
+        }
+        checkDisabledBreakpoints();
+        window.addEventListener("resize", checkDisabledBreakpoints);
+        return () => window.removeEventListener("resize", checkDisabledBreakpoints);
+    }, [disabledBreakpoints]);
+
+    return <AnimateGroupContext.Provider value={{ visible, onVisible, disabled: disableAnimateGroup }}>{children}</AnimateGroupContext.Provider>;
+}

--- a/demo/site/src/util/animations/useGlobalScrollSpeed.ts
+++ b/demo/site/src/util/animations/useGlobalScrollSpeed.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from "react";
+
+const listeners: Set<(speed: number) => void> = new Set();
+let lastScrollY = typeof window !== "undefined" ? window.scrollY : 0;
+let lastTime = Date.now();
+
+function notifyListeners(speed: number) {
+    listeners.forEach((cb) => cb(speed));
+}
+
+function onScroll() {
+    const now = Date.now();
+    const newY = window.scrollY;
+    const deltaY = Math.abs(newY - lastScrollY);
+    const deltaTime = now - lastTime;
+    const speed = deltaY / (deltaTime || 1);
+    notifyListeners(speed);
+    lastScrollY = newY;
+    lastTime = now;
+}
+
+export function useGlobalScrollSpeed() {
+    const [speed, setSpeed] = useState(0);
+    const setSpeedRef = useRef(setSpeed);
+
+    useEffect(() => {
+        // Update ref to always have the latest callback
+        setSpeedRef.current = setSpeed;
+    }, [setSpeed]);
+
+    useEffect(() => {
+        const callback = (newSpeed: number) => {
+            setSpeedRef.current(newSpeed);
+        };
+
+        // Only add event listener if this is the first listener
+        if (listeners.size === 0) {
+            lastScrollY = window.scrollY;
+            lastTime = Date.now();
+            window.addEventListener("scroll", onScroll, { passive: true });
+        }
+
+        // Use Set to prevent duplicates
+        listeners.add(callback);
+
+        return () => {
+            listeners.delete(callback);
+            // Remove event listener when no more listeners
+            if (listeners.size === 0) {
+                window.removeEventListener("scroll", onScroll);
+            }
+        };
+    }, []);
+
+    return speed;
+}

--- a/demo/site/src/util/animations/useGlobalScrollSpeed.ts
+++ b/demo/site/src/util/animations/useGlobalScrollSpeed.ts
@@ -1,10 +1,35 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 const listeners: Set<(speed: number) => void> = new Set();
 let lastScrollY = typeof window !== "undefined" ? window.scrollY : 0;
 let lastTime = Date.now();
+let measuredSpeed = 0;
+let publishedSpeed = 0;
+let animationFrame: number | null = null;
+let idleTimeout: ReturnType<typeof setTimeout> | null = null;
 
-function notifyListeners(speed: number) {
+const speedBucketSize = 5;
+const maxSpeed = 40;
+const idleDelay = 150;
+
+/**
+ * Consumers only branch on coarse thresholds and scale by the ratio to them, so the speed is published in buckets.
+ * A continuous value would re-render every subscriber — and rebuild its IntersectionObserver — on every scroll event.
+ */
+function toBucket(speed: number) {
+    if (speed <= 2) {
+        return 0;
+    }
+    return Math.min(Math.round(speed / speedBucketSize) * speedBucketSize, maxSpeed);
+}
+
+function publish() {
+    animationFrame = null;
+    const speed = toBucket(measuredSpeed);
+    if (speed === publishedSpeed) {
+        return;
+    }
+    publishedSpeed = speed;
     listeners.forEach((cb) => cb(speed));
 }
 
@@ -13,26 +38,30 @@ function onScroll() {
     const newY = window.scrollY;
     const deltaY = Math.abs(newY - lastScrollY);
     const deltaTime = now - lastTime;
-    const speed = deltaY / (deltaTime || 1);
-    notifyListeners(speed);
+    measuredSpeed = deltaY / (deltaTime || 1);
     lastScrollY = newY;
     lastTime = now;
+
+    // At most one update per frame, instead of one per scroll event.
+    if (animationFrame === null) {
+        animationFrame = requestAnimationFrame(publish);
+    }
+
+    // Scrolling stops without a final event, so fall back to zero explicitly.
+    if (idleTimeout !== null) {
+        clearTimeout(idleTimeout);
+    }
+    idleTimeout = setTimeout(() => {
+        idleTimeout = null;
+        measuredSpeed = 0;
+        publish();
+    }, idleDelay);
 }
 
 export function useGlobalScrollSpeed() {
     const [speed, setSpeed] = useState(0);
-    const setSpeedRef = useRef(setSpeed);
 
     useEffect(() => {
-        // Update ref to always have the latest callback
-        setSpeedRef.current = setSpeed;
-    }, [setSpeed]);
-
-    useEffect(() => {
-        const callback = (newSpeed: number) => {
-            setSpeedRef.current(newSpeed);
-        };
-
         // Only add event listener if this is the first listener
         if (listeners.size === 0) {
             lastScrollY = window.scrollY;
@@ -41,13 +70,23 @@ export function useGlobalScrollSpeed() {
         }
 
         // Use Set to prevent duplicates
-        listeners.add(callback);
+        listeners.add(setSpeed);
 
         return () => {
-            listeners.delete(callback);
+            listeners.delete(setSpeed);
             // Remove event listener when no more listeners
             if (listeners.size === 0) {
                 window.removeEventListener("scroll", onScroll);
+                if (animationFrame !== null) {
+                    cancelAnimationFrame(animationFrame);
+                    animationFrame = null;
+                }
+                if (idleTimeout !== null) {
+                    clearTimeout(idleTimeout);
+                    idleTimeout = null;
+                }
+                measuredSpeed = 0;
+                publishedSpeed = 0;
             }
         };
     }, []);

--- a/demo/site/src/util/animations/useScrolledToPageBottom.ts
+++ b/demo/site/src/util/animations/useScrolledToPageBottom.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+const listeners: Set<(isScrolledToPageBottom: boolean) => void> = new Set();
+let isScrolledToPageBottom = false;
+
+function measure() {
+    return window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 1;
+}
+
+function check() {
+    const next = measure();
+    if (next === isScrolledToPageBottom) {
+        return;
+    }
+    isScrolledToPageBottom = next;
+    listeners.forEach((cb) => cb(next));
+}
+
+/**
+ * Whether the document is scrolled all the way down. One listener is shared by all subscribers.
+ */
+export function useScrolledToPageBottom() {
+    const [scrolledToPageBottom, setScrolledToPageBottom] = useState(false);
+
+    useEffect(() => {
+        if (listeners.size === 0) {
+            window.addEventListener("scroll", check, { passive: true });
+            window.addEventListener("resize", check);
+        }
+        listeners.add(setScrolledToPageBottom);
+
+        // check() only notifies on change, so seed this subscriber with the current value.
+        isScrolledToPageBottom = measure();
+        setScrolledToPageBottom(isScrolledToPageBottom);
+
+        return () => {
+            listeners.delete(setScrolledToPageBottom);
+            if (listeners.size === 0) {
+                window.removeEventListener("scroll", check);
+                window.removeEventListener("resize", check);
+                isScrolledToPageBottom = false;
+            }
+        };
+    }, []);
+
+    return scrolledToPageBottom;
+}

--- a/demo/site/src/util/animations/useScrolledToPageBottom.ts
+++ b/demo/site/src/util/animations/useScrolledToPageBottom.ts
@@ -29,9 +29,10 @@ export function useScrolledToPageBottom() {
         }
         listeners.add(setScrolledToPageBottom);
 
-        // check() only notifies on change, so seed this subscriber with the current value.
-        isScrolledToPageBottom = measure();
+        // check() only notifies on change, so seed this subscriber with the shared value. Measuring into the shared
+        // value here instead would leave subscribers that are already mounted on a stale one, with no notification.
         setScrolledToPageBottom(isScrolledToPageBottom);
+        check();
 
         return () => {
             listeners.delete(setScrolledToPageBottom);

--- a/demo/site/src/util/useWindowSize.ts
+++ b/demo/site/src/util/useWindowSize.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+interface WindowSize {
+    width: number;
+    height: number;
+}
+
+export const useWindowSize = (): WindowSize | undefined => {
+    const [windowSize, setWindowSize] = useState<WindowSize>();
+
+    useEffect(() => {
+        const getSize = (): WindowSize => ({
+            width: window.innerWidth,
+            height: window.innerHeight,
+        });
+
+        setWindowSize(getSize());
+
+        const handleResize = () => {
+            setWindowSize(getSize());
+        };
+
+        window.addEventListener("resize", handleResize);
+        return () => {
+            window.removeEventListener("resize", handleResize);
+        };
+    }, []);
+
+    return windowSize;
+};

--- a/demo/site/src/util/useWindowSize.ts
+++ b/demo/site/src/util/useWindowSize.ts
@@ -5,26 +5,48 @@ interface WindowSize {
     height: number;
 }
 
+const listeners: Set<(windowSize: WindowSize) => void> = new Set();
+let windowSize: WindowSize | undefined;
+
+function measure(): WindowSize {
+    return { width: window.innerWidth, height: window.innerHeight };
+}
+
+function handleResize() {
+    const next = measure();
+    // The mobile URL bar collapses during normal scrolling, so resize fires without the size actually changing.
+    // Publishing a new object regardless would invalidate every subscriber's effects.
+    if (windowSize && next.width === windowSize.width && next.height === windowSize.height) {
+        return;
+    }
+    windowSize = next;
+    listeners.forEach((cb) => cb(next));
+}
+
+/**
+ * The current viewport size, measured once and shared by all subscribers.
+ */
 export const useWindowSize = (): WindowSize | undefined => {
-    const [windowSize, setWindowSize] = useState<WindowSize>();
+    const [size, setSize] = useState<WindowSize>();
 
     useEffect(() => {
-        const getSize = (): WindowSize => ({
-            width: window.innerWidth,
-            height: window.innerHeight,
-        });
+        if (listeners.size === 0) {
+            window.addEventListener("resize", handleResize);
+        }
+        listeners.add(setSize);
 
-        setWindowSize(getSize());
+        // handleResize() only notifies on change, so seed this subscriber with the current value.
+        windowSize ??= measure();
+        setSize(windowSize);
 
-        const handleResize = () => {
-            setWindowSize(getSize());
-        };
-
-        window.addEventListener("resize", handleResize);
         return () => {
-            window.removeEventListener("resize", handleResize);
+            listeners.delete(setSize);
+            if (listeners.size === 0) {
+                window.removeEventListener("resize", handleResize);
+                windowSize = undefined;
+            }
         };
     }, []);
 
-    return windowSize;
+    return size;
 };

--- a/packages/site/site-react/src/blocks/factories/ListBlock.tsx
+++ b/packages/site/site-react/src/blocks/factories/ListBlock.tsx
@@ -5,7 +5,7 @@ import { PreviewSkeleton } from "../../previewskeleton/PreviewSkeleton";
 
 interface Props {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    block: (props: any) => ReactNode;
+    block: (props: any, index: number) => ReactNode;
     data: {
         blocks: Array<{ key: string; visible: boolean; props: unknown }>;
     };
@@ -18,9 +18,9 @@ export const ListBlock = ({ block: blockFunction, data: { blocks } }: Props) => 
 
     return (
         <>
-            {blocks.map((block) => (
+            {blocks.map((block, index) => (
                 <Fragment key={block.key}>
-                    <ErrorHandlerBoundary>{blockFunction(block.props)}</ErrorHandlerBoundary>
+                    <ErrorHandlerBoundary>{blockFunction(block.props, index)}</ErrorHandlerBoundary>
                 </Fragment>
             ))}
         </>


### PR DESCRIPTION
## Problem

Blocks in Demo appear instantly, so pages feel flat and static as you scroll. Scroll-in animations are standard on current websites, and Demo showcases what a Dextinity site looks like — it should have them, and afterwards the Starter.

## Solution

The animation setup needs no dependencies — CSS transitions plus `IntersectionObserver`:

- **`AnimateBoxInOnScroll`** — fades and slides content in when it enters the viewport (`direction`, `delay`, `offset`, `fullHeight`)
- **`AnimateBoxInOnLoad`** — the same effect on mount, for the stage blocks above the fold
- **`AnimateGroup`** — reveals siblings together once one of them becomes visible; `disabledBreakpoints` drops the stagger on breakpoints where it would look wrong
- **`useGlobalScrollSpeed`** — shortens delays and triggers earlier while the page is scrolled fast

Animations are skipped in the block preview and under `prefers-reduced-motion`.

All page content blocks are animated. `ProductListBlock`, `NewsListBlock` and `NewsDetailBlock` are left alone: they are unstyled stubs demonstrating block loaders, not designed content.

## Example

```tsx
<AnimateGroup>
    <ListBlock
        data={data}
        block={(block, index) => (
            <AnimateBoxInOnScroll direction="bottom" delay={200 * index} offset={300}>
                <KeyFactItemBlock data={block} />
            </AnimateBoxInOnScroll>
        )}
    />
</AnimateGroup>
```

## `ListBlock` change

Staggering a list needs the item position. Mapping over `data.blocks` directly would lose `ListBlock`'s per-item error boundary and its empty-list preview skeleton, so `ListBlock`'s `block` function now receives the index as a second argument instead. This is backwards compatible; a changeset is included.

## Screenshots/screencasts

Recorded against the demo site running locally (Chromium, `prefers-reduced-motion` toggled per clip).

**All animated blocks, desktop** (1440×900)

[02allblocksdesktop.webm](https://github.com/user-attachments/assets/0de824af-82f7-4cc6-a83d-cbb7d383d316)

**All animated blocks, mobile** (390×844) — `AnimateGroup` stagger disabled on `xs`/`sm`

[05allblocksmobile.webm](https://github.com/user-attachments/assets/d7ac22b9-9a32-4d54-aea5-f998e714c14f)

**`prefers-reduced-motion: reduce`** — content appears instantly, no fade

[06reducedmotiondesktop.webm](https://github.com/user-attachments/assets/a5625c8b-6770-4820-842d-478e15b18ec2)


**Accordion expand** — content inside a collapsed panel animates in on expand

[07accordionexpanddesktop.webm](https://github.com/user-attachments/assets/3e63b969-a03e-42eb-b6dd-616d45a87164)

## Further information

`MediaGalleryBlock` animates only the swiper, not its navigation buttons. Animating them too would need a wrapper to carry their absolute positioning, and introducing one would mean restructuring the SCSS for little gain.

Task: [DEX-3157](https://vivid-planet.atlassian.net/browse/DEX-3157)




[DEX-3157]: ````''https://vivid-planet.atlassian.net/browse/DEX-3157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ''````