### PR TITLE
Configure CodeRabbit in code

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,1 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -2,3 +2,4 @@
 reviews:
     auto_review:
         enabled: false
+    high_level_summary_in_walkthrough: true

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,1 +1,4 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+    auto_review:
+        enabled: false


### PR DESCRIPTION
Moves the CodeRabbit configuration from UI to code. We currently use CodeRabbit's default settings with a few adaptions:

- Disable auto review (`reviews.auto_review.enabled: false`). Devs need to explicitly request a CodeRabbit review. We do this to keep review runs at a minimum level.
- Move summary to walkthrough (`reviews.high_level_summary_in_walkthrough: true`). CodeRabbit by default adds a summary section to the PR's description. We currently tend to write the PR description ourselves, so this would result in duplicate descriptions. This may change in the near future, therefore I decided to move it to the walkthrough instead of disabling it. This way we can still view it and assess its quality.

Note: I initially enabled the [request changes workflow](https://docs.coderabbit.ai/pr-reviews/request-changes-workflow) in the UI, but decided to disable it again for now. We have to configure CodeRabbit for a needs-human-review-triage first.