### PR TITLE
Add pre-merge checks and request changes workflow to CodeRabbit

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -3,3 +3,15 @@ reviews:
     auto_review:
         enabled: false
     high_level_summary_in_walkthrough: true
+    request_changes_workflow: true
+    pre_merge_checks:
+        override_requested_reviewers_only: true # author can't dismiss failing checks
+        custom_checks:
+            - name: "Requires human review"
+              mode: "error"
+              instructions: |
+                  FAIL if the PR touches authentication, authorization, DB migrations,
+                  CI workflow files, or secret or credential handling, changes public API,
+                  or deletes tests.
+                  FAIL if total changed lines exceed 300.
+                  Otherwise PASS.

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -13,5 +13,9 @@ reviews:
                   FAIL if the PR touches authentication, authorization, DB migrations,
                   CI workflow files, or secret or credential handling, changes public API,
                   or deletes tests.
-                  FAIL if total changed lines exceed 300.
+                  FAIL if the PR adds or modifies more than 300 lines of hand-written source.
+                  When counting those lines, ignore deleted lines, and ignore changes to
+                  tests (*.spec.*, *.test.*, __snapshots__/), docs (docs/, *.md,
+                  .changeset/) and generated output (**/generated/, schema.gql,
+                  block-meta.json, pnpm-lock.yaml).
                   Otherwise PASS.


### PR DESCRIPTION
Enhanced CodeRabbit configuration: add a "requires human review" pre-merge check. The idea is to make CodeRabbit approve PRs that don't need a human review, but not ones that need a human.

https://claude.ai/code/session_01Qz53V4fwf7iFAoMnUBdhZi