### PR TITLE
[test, don't merge] Add placeholder content and Playwright CLI to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ junit-storybook.xml
 # Build output of @dextinity/agent-features (copied from the skills/ and rules/ folders at the repository root)
 /packages/agent-features/skills/
 /packages/agent-features/rules/
+# Playwright CLI output (may contain credentials)
+.playwright-cli/

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -44,3 +44,9 @@ You can build two types of applications with Dextinity:
 :::note
 This terms are used throughout the documentation as some concepts heavily differ between this two types.
 :::
+
+## Lorem Ipsum
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
## Summary
This PR adds placeholder Lorem Ipsum content to the documentation index and updates the gitignore to exclude Playwright CLI output.

## Changes
- **docs/docs/index.md**: Added a new "Lorem Ipsum" section with placeholder text to the documentation index
- **.gitignore**: Added `.playwright-cli/` directory to gitignore with a comment noting it may contain credentials

## Notes
The Lorem Ipsum content appears to be placeholder text. This may be intended for future documentation or should be replaced with actual content in a follow-up PR.

https://claude.ai/code/session_01ABe7hGCB1txrxMfMceHTYH