### PR TITLE
Add .playwright-cli/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ junit-storybook.xml
 .context
 .playwright
 .playwright-mcp
+.playwright-cli/
 
 # Agent files
 .agents/skills/


### PR DESCRIPTION
## Summary
Updated `.gitignore` to exclude the `.playwright-cli/` directory from version control.

## Changes
- Added `.playwright-cli/` entry to `.gitignore` to prevent CLI-related artifacts from being tracked in the repository

## Details
This follows the existing pattern of excluding other Playwright-related directories (`.playwright` and `.playwright-mcp`) that are generated during local development and testing.

https://claude.ai/code/session_0137NeuvLqaDV1UcAMW29qMq