### PR TITLE
Disable CodeRabbit issue assessment features

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -4,9 +4,11 @@ reviews:
         enabled: false
     high_level_summary_in_walkthrough: true
     request_changes_workflow: true
+    # We don't use GitHub issues and CodeRabbit has no access to Jira, so there is never a linked issue to assess or relate.
+    assess_linked_issues: false
+    related_issues: false
     pre_merge_checks:
         override_requested_reviewers_only: true # author can't dismiss failing checks
-        # We don't use GitHub issues and CodeRabbit has no access to Jira, so there is never a linked issue to assess.
         issue_assessment:
             mode: "off"
         custom_checks:

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -6,6 +6,9 @@ reviews:
     request_changes_workflow: true
     pre_merge_checks:
         override_requested_reviewers_only: true # author can't dismiss failing checks
+        # We don't use GitHub issues and CodeRabbit has no access to Jira, so there is never a linked issue to assess.
+        issue_assessment:
+            mode: "off"
         custom_checks:
             - name: "Requires human review"
               mode: "error"


### PR DESCRIPTION
Disable the features because we don't use GitHub issues and CodeRabbit has no access to Jira (for now).

https://claude.ai/code/session_01EqUf9DSdq63m9FJGpWr9fC