### PR TITLE
Document two CSS limits of Yahoo Mail

### DIFF
--- a/docs/docs/3-features-modules/13-building-html-emails/1-email-basics.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/1-email-basics.md
@@ -96,3 +96,27 @@ Everything else, buttons and containers included, needs a [VML](https://learn.mi
 Set `arcsize` to the corner radius divided by the shorter side, capped at `50%` — `8px` on a `44px`-high button gives `18%`. Do not take the value from the VML specification; it is twice what Outlook needs.
 
 Campaign Monitor's [Bulletproof Email Buttons](https://www.buttons.cm/) generator and the [Litmus VML button snippet](https://litmus.com/community/snippets/7-bulletproof-button-vml-approach) are good starting points for this technique.
+
+### No CSS `calc()`
+
+Yahoo Mail (webmail and both mobile apps) and Outlook.com drop every declaration whose value contains a `calc()`, single-unit expressions such as `calc(300px - 200px)` included. The declaration disappears, so the element keeps the value the `calc()` was meant to override — a plausible wrong width rather than no width, which makes the defect hard to recognize.
+
+Where an element has to fill the space next to a fixed-width one, let the table compute the width: the fixed cells get their pixel width, and the flexible cell gets `width="100%"`, so the table gives it whatever the fixed cells leave — [Good Email Code](https://www.goodemailcode.com/email-code/columns.html) has the markup. It needs no arithmetic and holds in every client, classic Outlook included.
+
+Where a `calc()` is unavoidable, put a plain value before it in the same rule. A client that drops the `calc()` keeps the first declaration:
+
+```css
+.fluidColumn {
+    width: 40% !important;
+    width: calc(100% - 192px) !important;
+}
+```
+
+Choose that fallback so the row still fits at the narrowest viewport the media query covers, otherwise the columns wrap. The [asymmetric two-column layout](./6-layout-patterns.md#two-breakpoint-responsive-behavior) uses this fallback.
+
+### `height` Becomes `min-height` in Yahoo Mail
+
+Yahoo Mail rewrites `height` into `min-height`. `min-height` is only a lower limit — it can make an element taller, never shorter — and on a `<td>` it does nothing at all. That leads to two failures:
+
+- An `<img>` that a media query shrinks with `height` keeps its original size. Use `max-height` instead.
+- A row whose height comes only from `height` on a `<td>` collapses to nothing, and the cell's background disappears with it. Put the height on a `<div>` inside the cell, or use padding.

--- a/docs/docs/3-features-modules/13-building-html-emails/5-customization.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/5-customization.md
@@ -162,6 +162,8 @@ registerStyles(
 Always use `!important` in media query overrides. Without it, the email client's inlined styles will take precedence and your responsive styles won't apply.
 :::
 
+Two client behaviors matter for responsive overrides: Yahoo Mail and Outlook.com drop any declaration that contains a [`calc()`](./1-email-basics.md#no-css-calc), and Yahoo Mail rewrites [`height` into `min-height`](./1-email-basics.md#height-becomes-min-height-in-yahoo-mail).
+
 ### Selectors That Reach Every Client
 
 Gmail applies class, element and id selectors, and descendant and child combinators. It drops the whole rule for a pseudo-class or a pseudo-element, and of the attribute selectors it applies only `[class~="value"]`. Its mobile webmail is narrower still: no combinators, no attribute selectors, and no media queries, so no responsive rule reaches it.

--- a/docs/docs/3-features-modules/13-building-html-emails/6-layout-patterns.md
+++ b/docs/docs/3-features-modules/13-building-html-emails/6-layout-patterns.md
@@ -173,9 +173,16 @@ To place the small column on the right instead, swap the column order and move t
 
 Fixed-width columns create an overflow problem between the desktop `bodyWidth` and the mobile stacking breakpoint — the total fixed width can exceed the viewport. The solution uses two `belowMediaQuery` breakpoints stacked via CSS cascade order.
 
-Inside a group a pixel width is written inline as a percentage of the section, so the fixed column also needs its pixel width back below `bodyWidth`, where the section is narrower:
+Inside a group a pixel width is written inline as a percentage of the section, so the fixed column also needs its pixel width back below `bodyWidth`, where the section is narrower.
+
+The fluid column takes the space the fixed column leaves. A `calc()` expresses that directly, but some clients drop every declaration that contains one — see [No CSS `calc()`](./1-email-basics.md#no-css-calc). To cover them, repeat the width as a plain percentage in the same rule, before the `calc()`. Clients that support `calc()` apply the later declaration; the rest keep the percentage.
+
+The percentage cannot adapt, so pick one that fits the narrowest section the media query reaches — the section at the mobile breakpoint — and round it down. If the fixed column and the percentage together are even a fraction of a pixel wider than the section, the fluid column drops onto its own line.
 
 ```ts
+const narrowestSectionInnerWidth = theme.breakpoints.mobile.value - 2 * sectionIndent;
+const fluidColumnFallbackWidth = `${Math.floor(((narrowestSectionInnerWidth - SMALL_COLUMN_WIDTH) / narrowestSectionInnerWidth) * 100)}%`;
+
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
@@ -185,6 +192,8 @@ registerStyles(
             }
 
             .imageTextLayout__fluidColumn {
+                width: ${fluidColumnFallbackWidth} !important;
+                max-width: ${fluidColumnFallbackWidth} !important;
                 width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
                 max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
             }

--- a/packages/mail-react/src/__stories__/diagnostics/ImageBorderRadius.stories.tsx
+++ b/packages/mail-react/src/__stories__/diagnostics/ImageBorderRadius.stories.tsx
@@ -37,10 +37,16 @@ const textColumnWidth = sectionInnerWidth - AVATAR_SIZE;
 const halfColumnWidth = (sectionInnerWidth - COLUMN_GAP) / 2;
 const halfColumnImageHeight = 172;
 
+// Yahoo Mail and Outlook.com drop the calc() below, so this percentage takes over there. Floored, so the two columns never total more than the section.
+const narrowestSectionInnerWidth = theme.breakpoints.mobile.value - 2 * sectionIndent;
+const textColumnFallbackWidth = `${Math.floor(((narrowestSectionInnerWidth - AVATAR_SIZE) / narrowestSectionInnerWidth) * 100)}%`;
+
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
             .imageBorderRadius__textColumn {
+                width: ${textColumnFallbackWidth} !important;
+                max-width: ${textColumnFallbackWidth} !important;
                 width: calc(100% - ${AVATAR_SIZE}px) !important;
                 max-width: calc(100% - ${AVATAR_SIZE}px) !important;
             }

--- a/packages/mail-react/src/__stories__/layout-patterns/AsymmetricTwoColumnLayout.stories.tsx
+++ b/packages/mail-react/src/__stories__/layout-patterns/AsymmetricTwoColumnLayout.stories.tsx
@@ -32,6 +32,10 @@ const sectionIndent = getDefaultFromResponsiveValue(theme.sizes.contentIndentati
 const sectionInnerWidth = theme.sizes.bodyWidth - 2 * sectionIndent;
 const fluidColumnWidth = sectionInnerWidth - SMALL_COLUMN_WIDTH;
 
+// Yahoo Mail and Outlook.com drop the calc() below, so this percentage takes over there. Floored, so the two columns never total more than the section.
+const narrowestSectionInnerWidth = theme.breakpoints.mobile.value - 2 * sectionIndent;
+const fluidColumnFallbackWidth = `${Math.floor(((narrowestSectionInnerWidth - SMALL_COLUMN_WIDTH) / narrowestSectionInnerWidth) * 100)}%`;
+
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
@@ -41,6 +45,8 @@ registerStyles(
             }
 
             .asymmetricLayoutLeft__fluidColumn {
+                width: ${fluidColumnFallbackWidth} !important;
+                max-width: ${fluidColumnFallbackWidth} !important;
                 width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
                 max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
             }
@@ -126,6 +132,8 @@ registerStyles(
             }
 
             .asymmetricLayoutRight__fluidColumn {
+                width: ${fluidColumnFallbackWidth} !important;
+                max-width: ${fluidColumnFallbackWidth} !important;
                 width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
                 max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
             }
@@ -211,6 +219,8 @@ registerStyles(
             }
 
             .asymmetricLayoutRtl__fluidColumn {
+                width: ${fluidColumnFallbackWidth} !important;
+                max-width: ${fluidColumnFallbackWidth} !important;
                 width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
                 max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
             }

--- a/skills/dextinity-mail-react/SKILL.md
+++ b/skills/dextinity-mail-react/SKILL.md
@@ -192,6 +192,28 @@ Set `arcsize` to the corner radius divided by the shorter side, capped at `50%` 
 
 See the [Litmus VML button snippet](https://litmus.com/community/snippets/7-bulletproof-button-vml-approach).
 
+### No CSS `calc()`
+
+Yahoo Mail (webmail and both mobile apps) and Outlook.com drop every declaration whose value contains a `calc()`, single-unit expressions such as `calc(300px - 200px)` included. The declaration disappears, so the element keeps the value the `calc()` was meant to override — a plausible wrong width rather than no width.
+
+Where an element has to fill the space next to a fixed-width one, let the table compute the width: the fixed cells get their pixel width, and the flexible cell gets `width="100%"`, so the table gives it whatever the fixed cells leave ([Good Email Code](https://www.goodemailcode.com/email-code/columns.html)). Where a `calc()` is unavoidable, put a plain value before it in the same rule, chosen so the row still fits at the narrowest viewport the media query covers:
+
+```css
+.fluidColumn {
+    width: 40% !important;
+    width: calc(100% - 192px) !important;
+}
+```
+
+The asymmetric two-column layout in [`references/layout-patterns.md`](references/layout-patterns.md) uses this fallback.
+
+### `height` Becomes `min-height` in Yahoo Mail
+
+Yahoo Mail rewrites `height` into `min-height`, which is only a lower limit — it can make an element taller, never shorter — and does nothing at all on a `<td>`:
+
+- An `<img>` that a media query shrinks with `height` keeps its original size — use `max-height`.
+- A row whose height comes only from `height` on a `<td>` collapses to nothing, and the cell's background disappears with it — put the height on a `<div>` inside the cell, or use padding.
+
 ---
 
 ## Theme Setup & Type-Safety

--- a/skills/dextinity-mail-react/references/layout-patterns.md
+++ b/skills/dextinity-mail-react/references/layout-patterns.md
@@ -236,9 +236,16 @@ To place the small column on the right, swap column order and move padding to `p
 
 Fixed-width columns overflow between `bodyWidth` and the mobile stacking breakpoint. Use two stacked `belowMediaQuery` blocks — the later one overrides the earlier via cascade order.
 
-Inside a group a pixel width is written inline as a percentage of the section, so the fixed column also needs its pixel width back below `bodyWidth`, where the section is narrower:
+Inside a group a pixel width is written inline as a percentage of the section, so the fixed column also needs its pixel width back below `bodyWidth`, where the section is narrower.
+
+The fluid column takes the space the fixed column leaves. A `calc()` expresses that directly, but some clients drop every declaration that contains one — see [No CSS `calc()`](../SKILL.md#no-css-calc). Repeat the width as a plain percentage in the same rule, before the `calc()`: clients that support `calc()` apply the later declaration, the rest keep the percentage.
+
+Pick a percentage that fits the narrowest section the media query reaches — the section at the mobile breakpoint — and round it down, so the fixed column and the percentage never total more than the section.
 
 ```ts
+const narrowestSectionInnerWidth = theme.breakpoints.mobile.value - 2 * sectionIndent;
+const fluidColumnFallbackWidth = `${Math.floor(((narrowestSectionInnerWidth - SMALL_COLUMN_WIDTH) / narrowestSectionInnerWidth) * 100)}%`;
+
 registerStyles(
     (theme) => css`
         ${theme.breakpoints.default.belowMediaQuery} {
@@ -248,6 +255,8 @@ registerStyles(
             }
 
             .imageTextLayout__fluidColumn {
+                width: ${fluidColumnFallbackWidth} !important;
+                max-width: ${fluidColumnFallbackWidth} !important;
                 width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
                 max-width: calc(100% - ${SMALL_COLUMN_WIDTH}px) !important;
             }

--- a/skills/dextinity-mail-react/references/styling-and-customization.md
+++ b/skills/dextinity-mail-react/references/styling-and-customization.md
@@ -276,6 +276,8 @@ registerStyles(
 
 This keeps responsive styles in sync with the theme's breakpoint configuration.
 
+Two client behaviors matter for responsive overrides: Yahoo Mail and Outlook.com drop any declaration that contains a [`calc()`](../SKILL.md#no-css-calc), and Yahoo Mail rewrites [`height` into `min-height`](../SKILL.md#height-becomes-min-height-in-yahoo-mail).
+
 ---
 
 ## Overriding Built-In Components


### PR DESCRIPTION
Percentage columns would have removed the `calc()` altogether, but they let the narrow column shrink below `bodyWidth`, so the layout would change in every client instead of only in the ones with the defect.

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13730