### PR TITLE
Rename the TipTap block's `history` option to `undoRedoButtons`

### DIFF
--- a/.changeset/tiptap-feature-options.md
+++ b/.changeset/tiptap-feature-options.md
@@ -26,4 +26,4 @@ createTipTapRichTextBlock({
 });
 ```
 
-The features are named after their option: `bold`, `italic`, `underline`, `strike`, `sub`, `sup`, `heading`, `orderedList`, `unorderedList`, `nonBreakingSpace`, `softHyphen`, `link`, and `history` (Admin only). The document-level limits `maxTextBlocks` and `listLevelMax` are unchanged.
+The features are named after their option: `bold`, `italic`, `underline`, `strike`, `sub`, `sup`, `heading`, `orderedList`, `unorderedList`, `nonBreakingSpace`, `softHyphen` and `link`. Additionally, `undoRedoButtons` (Admin only) shows or hides the undo/redo buttons in the toolbar; the keyboard shortcuts work regardless. The document-level limits `maxTextBlocks` and `listLevelMax` are unchanged.

--- a/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
+++ b/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
@@ -53,7 +53,7 @@ Most features of the Draft.js `RichTextBlock` have a direct equivalent in the Ti
 | `bold`, `italic`, `strikethrough`, `sub`, `sup` | `bold`, `italic`, `strike`, `sub`, `sup`                                                     |
 | `header-one` … `header-six`                     | `heading` + the [text-block-type select](#text-block-type-and-styling-selects) (Heading 1–6) |
 | `ordered-list`, `unordered-list`                | `orderedList`, `unorderedList`                                                               |
-| `history`                                       | `history` (Admin only)                                                                       |
+| `history`                                       | `undoRedoButtons` (Admin only)                                                               |
 | `link`, `links-remove`                          | `link` (pass the link block)                                                                 |
 | `non-breaking-space`, `soft-hyphen`             | `nonBreakingSpace`, `softHyphen`                                                             |
 | `rte.blocktypeMap` (custom block types)         | [`textBlockStyles`](#text-block-type-and-styling-selects) + the styling select               |
@@ -169,7 +169,7 @@ Every editor feature has its own option in the root options object, similar to [
 | `unorderedList`    | `true`  | API + Admin  |
 | `nonBreakingSpace` | `true`  | API + Admin  |
 | `softHyphen`       | `true`  | API + Admin  |
-| `history`          | `true`  | Admin only   |
+| `undoRedoButtons`  | `true`  | Admin only   |
 
 `heading` can be configured further by passing an options object instead of `true`, which limits the allowed `levels`.
 

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapToolbar.tsx
@@ -385,7 +385,7 @@ export const TipTapToolbar = ({
                 px: "6px",
             }}
         >
-            {resolvedOptions.history && (
+            {resolvedOptions.undoRedoButtons && (
                 <ToolbarGroup>
                     <ToolbarButton
                         editor={editor}

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlock.stories.tsx
@@ -151,7 +151,7 @@ export const ReadOnly: Story = {
 };
 
 const BoldOnlyBlock = createTipTapRichTextBlock({
-    history: false,
+    undoRedoButtons: false,
     italic: false,
     strike: false,
     sub: false,
@@ -355,7 +355,7 @@ export const Placeholders: StoryObj<typeof PlaceholdersStory> = {
 };
 
 const PlaceholdersWithContentBlock = createTipTapRichTextBlock({
-    history: false,
+    undoRedoButtons: false,
     strike: false,
     sub: false,
     sup: false,
@@ -586,7 +586,7 @@ export const TextBlockStyleInteractions: StoryObj<typeof TextBlockStyleInteracti
 };
 
 const ListTextBlockStylesBlock = createTipTapRichTextBlock({
-    history: false,
+    undoRedoButtons: false,
     italic: false,
     strike: false,
     sub: false,

--- a/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlockInlineStyles.stories.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/__stories__/TipTapRichTextBlockInlineStyles.stories.tsx
@@ -34,7 +34,7 @@ const config: Meta<typeof InlineStylesBlockStory> = {
 export default config;
 
 const InlineStylesBlock = createTipTapRichTextBlock({
-    history: false,
+    undoRedoButtons: false,
     bold: false,
     italic: false,
     strike: false,

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -40,7 +40,7 @@ interface TipTapHeadingOptions {
  * The block's options with the defaults applied and the heading levels validated.
  */
 export interface TipTapResolvedOptions {
-    history: boolean;
+    undoRedoButtons: boolean;
     bold: boolean;
     italic: boolean;
     underline: boolean;
@@ -66,7 +66,7 @@ function isValidHeadingLevels(headingLevels: number[]): headingLevels is Heading
 }
 
 function resolveTipTapOptions({
-    history = true,
+    undoRedoButtons = true,
     bold = true,
     italic = true,
     underline = false,
@@ -87,7 +87,7 @@ function resolveTipTapOptions({
     }
 
     return {
-        history,
+        undoRedoButtons,
         bold,
         italic,
         underline,
@@ -168,9 +168,9 @@ export interface TipTapChildBlock {
 
 interface TipTapRichTextBlockFactoryOptions {
     /**
-     * Enables undo/redo. Defaults to `true`.
+     * Shows the undo/redo buttons in the toolbar. The keyboard shortcuts work regardless. Defaults to `true`.
      */
-    history?: boolean;
+    undoRedoButtons?: boolean;
     /**
      * Enables bold text. Defaults to `true`.
      */


### PR DESCRIPTION
The `history` option introduced in #6311 gates exactly one thing: the undo/redo button group in the toolbar. TipTap's undo/redo itself stays enabled either way, so the keyboard shortcuts keep working — which is the behavior we want, matching every other text input. The name suggests otherwise: it reads as if it turned off the editor's history tracking, which is what sent this PR down the wrong path to begin with.

Rename the option to `undoRedoButtons` and document what it actually controls. No behavior change — `resolvedOptions.undoRedoButtons` gates the same toolbar group as before, and `StarterKit` is untouched.

https://claude.ai/code/session_01AL6Fd1WgimvhAaUtUiRAcK