### PR TITLE
mail-react: Fix head CSS lost after the first media block in Outlook

### DIFF
--- a/.changeset/mail-react-outlook-head-css-truncation.md
+++ b/.changeset/mail-react-outlook-head-css-truncation.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/mail-react": patch
+---
+
+Fix head CSS lost after the first `@media` block in Outlook.com and the Outlook apps for iOS and Android
+
+These clients stop reading a `<style>` tag at the first `}}`, which minified CSS writes at the end of every `@media` block.

--- a/packages/mail-react/src/__stories__/diagnostics/HeadCssTruncation.stories.tsx
+++ b/packages/mail-react/src/__stories__/diagnostics/HeadCssTruncation.stories.tsx
@@ -1,0 +1,111 @@
+import { MjmlColumn } from "@faire/mjml-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+
+import { MjmlMailRoot } from "../../components/mailRoot/MjmlMailRoot.js";
+import { MjmlSection } from "../../components/section/MjmlSection.js";
+import { MjmlText } from "../../components/text/MjmlText.js";
+import { registerStyles } from "../../styles/registerStyles.js";
+import { createTheme } from "../../theme/createTheme.js";
+import { css } from "../../utils/css.js";
+
+const config: Meta = {
+    title: "Diagnostics/Head CSS Truncation",
+    parameters: { mailRoot: false },
+};
+
+export default config;
+
+type Story = StoryObj;
+
+const probeBlocks = [
+    { className: "headCssTruncationProbe--block0", label: "CSS block 0", meaning: "Short: the client reads the style tag." },
+    { className: "headCssTruncationProbe--block1", label: "CSS block 1", meaning: "Short: it reads past the first CSS block." },
+    { className: "headCssTruncationProbe--block2", label: "CSS block 2", meaning: "Short: it reads past the second CSS block." },
+];
+
+/**
+ * Each bar needs its own CSS block. The minifier joins two neighboring blocks when they have the
+ * same media query, so the queries here alternate.
+ */
+registerStyles(
+    (theme) => css`
+        ${theme.breakpoints.mobile.belowMediaQuery} {
+            .headCssTruncationProbe--block0 {
+                width: 25% !important;
+            }
+        }
+
+        ${theme.breakpoints.default.belowMediaQuery} {
+            .headCssTruncationProbe--block1 {
+                width: 25% !important;
+            }
+        }
+
+        ${theme.breakpoints.mobile.belowMediaQuery} {
+            .headCssTruncationProbe--block2 {
+                width: 25% !important;
+            }
+        }
+    `,
+);
+
+const theme = createTheme({
+    text: {
+        defaultVariant: "body",
+        variants: {
+            heading: { fontSize: { default: "26px", mobile: "22px" }, lineHeight: { default: "32px", mobile: "28px" }, fontWeight: "bold" },
+            body: { fontSize: { default: "16px", mobile: "15px" }, lineHeight: { default: "22px", mobile: "20px" }, bottomSpacing: "16px" },
+            label: {
+                fontSize: { default: "13px", mobile: "12px" },
+                lineHeight: { default: "18px", mobile: "17px" },
+                fontWeight: "bold",
+                bottomSpacing: "10px",
+            },
+            caption: { fontSize: { default: "12px", mobile: "11px" }, lineHeight: { default: "17px", mobile: "16px" } },
+        },
+    },
+});
+
+function Bar({ label, meaning, className }: { label: string; meaning: string; className?: string }): ReactElement {
+    return (
+        <>
+            <MjmlText variant="label">
+                {label}
+                <div className={className} style={{ width: "100%", height: "14px", backgroundColor: "#333333" }} />
+            </MjmlText>
+            <MjmlText variant="caption" bottomSpacing>
+                {meaning}
+            </MjmlText>
+        </>
+    );
+}
+
+export const CombinedStyleTag: Story = {
+    render: () => (
+        <MjmlMailRoot theme={theme}>
+            <MjmlSection indent>
+                <MjmlColumn>
+                    <MjmlText variant="heading" bottomSpacing>
+                        How much of the head CSS arrived?
+                    </MjmlText>
+                    <MjmlText bottomSpacing>
+                        One CSS block of the head narrows one bar to 25%. A short bar means that CSS block arrived, a full-width bar means the client
+                        lost it.
+                    </MjmlText>
+                    <MjmlText bottomSpacing>
+                        The CSS blocks sit in one style tag in this order, so the last short bar is where the client stopped.
+                    </MjmlText>
+                    <Bar label="Reference, no rule" meaning="No rule narrows this bar, so it stays full width everywhere." />
+                    {probeBlocks.map(({ className, label, meaning }) => (
+                        <Bar key={className} label={label} meaning={meaning} className={className} />
+                    ))}
+                    <MjmlText variant="caption">
+                        The CSS blocks apply below {theme.breakpoints.mobile.value}px, the mobile breakpoint of this mail, so read the bars on a phone
+                        or in a narrower window.
+                    </MjmlText>
+                </MjmlColumn>
+            </MjmlSection>
+        </MjmlMailRoot>
+    ),
+};

--- a/packages/mail-react/src/server/renderMailHtml.test.tsx
+++ b/packages/mail-react/src/server/renderMailHtml.test.tsx
@@ -104,6 +104,34 @@ describe("server/renderMailHtml", () => {
         expect(html).toContain("color:red;padding-bottom:8px");
     });
 
+    it("writes no two closing braces in a row, which Outlook cuts the head CSS at", () => {
+        registerStyles(css`
+            @media (max-width: 479px) {
+                .firstMediaBlock {
+                    color: red;
+                }
+            }
+            @media (max-width: 599px) {
+                .secondMediaBlock {
+                    color: green;
+                }
+            }
+        `);
+
+        const { html } = renderMailHtml(
+            <MjmlMailRoot>
+                <MjmlSection>
+                    <MjmlColumn>
+                        <MjmlText>Hello</MjmlText>
+                    </MjmlColumn>
+                </MjmlSection>
+            </MjmlMailRoot>,
+        );
+
+        expect(html).not.toContain("}}");
+        expect(html).toContain(".secondMediaBlock{color:green}");
+    });
+
     it("keeps the Outlook properties that MJML writes", () => {
         const { html } = renderMailHtml(
             <MjmlMailRoot>

--- a/packages/mail-react/src/styles/minifyHeadCss.ts
+++ b/packages/mail-react/src/styles/minifyHeadCss.ts
@@ -13,5 +13,15 @@ export function minifyHeadCss(css: string): string {
         throw new Error(`The registered styles do not parse, so they cannot be minified: ${parseErrors.join("; ")}`);
     }
 
-    return syntax.generate(syntax.compress(styleSheet).ast);
+    return separateConsecutiveClosingBraces(syntax.generate(syntax.compress(styleSheet).ast));
+}
+
+/**
+ * Outlook.com and the Outlook apps for iOS and Android drop everything that follows the first `}}`
+ * of a `<style>` tag.
+ *
+ * @see https://github.com/hteumeuleu/email-bugs/issues/92
+ */
+function separateConsecutiveClosingBraces(css: string): string {
+    return css.replace(/\}(?=\})/g, "} ");
 }


### PR DESCRIPTION
Outlook.com and the Outlook apps for iOS and Android drop everything that follows the first `}}` of a `<style>` tag.
Minified CSS ends every `@media` block with `}}`, so these clients applied the rules of the first block only and used the desktop layout for everything after it.

See https://github.com/hteumeuleu/email-bugs/issues/92


| Client | Before fix | After fix |
|--------|--------|--------|
| Outlook iOS 26 | <img width="645" height="730" alt="Outlook iOS 26 Before" src="https://github.com/user-attachments/assets/aee50844-2d0e-4064-bf27-7d329d8eaa40" /> | <img width="645" height="730" alt="Outlook iOS 26 After" src="https://github.com/user-attachments/assets/33192f58-6b89-42f2-a43e-650006300e00" /> |
| Outlook Web | <img width="390" height="562" alt="Outlook Web Before" src="https://github.com/user-attachments/assets/8e41550c-be4c-4f85-9fd3-0787de072e32" /> | <img width="390" height="562" alt="Outlook Web Now" src="https://github.com/user-attachments/assets/c94f67dd-5ba2-4c1a-b8a6-cb91d69561a4" /> | 

---

https://vivid-planet.atlassian.net/browse/PHSB2C-13931