### PR TITLE
[Backport v8] Allow declaring content scope dimensions at runtime

### DIFF
--- a/.changeset/content-scope-dimensions.md
+++ b/.changeset/content-scope-dimensions.md
@@ -1,0 +1,22 @@
+---
+"@comet/cms-api": minor
+---
+
+Allow declaring content scope dimensions at runtime
+
+Add an optional `availableContentScopeDimensions` option to the `UserPermissionsModule` to declare the content scope dimensions (with optional labels). When omitted, the dimensions are derived from the keys of `availableContentScopes`.
+
+A content scope may hold any value (including the `"*"` wildcard) for a dimension that is not part of `availableContentScopes`. Content scopes are no longer validated against `availableContentScopes`; access is enforced per request by `isAllowed`, which compares the requested scope against the user's granted scopes.
+
+**Example**
+
+```ts
+UserPermissionsModule.forRootAsync({
+    useFactory: () => ({
+        availableContentScopes: [ ... ],
+        availableContentScopeDimensions: [{ name: "domain", label: "Domain (Website)" }, { name: "language" }, { name: "product" }],
+        // ...
+    }),
+    // ...
+});
+```

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -124,6 +124,12 @@ export class AppModule {
                                 label: { domain: siteConfig.name },
                             })),
                         ),
+                        availableContentScopeDimensions: [
+                            { name: "domain", label: "Domain (Website)" },
+                            { name: "language", label: "Language" },
+                            // "product" is declared here so it shows up in the admin panel although it is not part of availableContentScopes
+                            { name: "product", label: "Product Category" },
+                        ],
                         userService,
                         accessControlService,
                         systemUsers: [SYSTEM_USER_NAME],

--- a/demo/api/src/auth/access-control.service.spec.ts
+++ b/demo/api/src/auth/access-control.service.spec.ts
@@ -61,7 +61,7 @@ describe("AccessControlService", () => {
 
             const contentScopes = service.getContentScopesForUser(nonAdminUser);
 
-            expect(contentScopes).toEqual([{ domain: "main", language: "*" }]);
+            expect(contentScopes).toEqual([{ domain: "main", language: "*", product: "*" }]);
         });
 
         it("should return limited content scopes for unknown non-admin user", () => {
@@ -74,7 +74,7 @@ describe("AccessControlService", () => {
 
             const contentScopes = service.getContentScopesForUser(unknownUser);
 
-            expect(contentScopes).toEqual([{ domain: "main", language: "*" }]);
+            expect(contentScopes).toEqual([{ domain: "main", language: "*", product: "*" }]);
         });
     });
 });

--- a/demo/api/src/auth/access-control.service.ts
+++ b/demo/api/src/auth/access-control.service.ts
@@ -15,8 +15,8 @@ export class AccessControlService extends AbstractAccessControlService {
         if (user.isAdmin) {
             return UserPermissions.allContentScopes;
         } else {
-            // Grant access to every language within the "main" domain using a wildcard dimension
-            return [{ domain: "main", language: "*" }];
+            // Grant access to every language and product within the "main" domain using wildcard dimensions
+            return [{ domain: "main", language: "*", product: "*" }];
         }
     }
 }

--- a/demo/api/src/content-scope/content-scope.interface.ts
+++ b/demo/api/src/content-scope/content-scope.interface.ts
@@ -3,6 +3,8 @@ import { ContentScope } from "@comet/cms-api";
 import { type ContentScope as BaseContentScope } from "@src/site-configs";
 
 declare module "@comet/cms-api" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-    interface ContentScope extends BaseContentScope {}
+    interface ContentScope extends BaseContentScope {
+        // Optional dimension used only by certain resolvers. Not part of `availableContentScopes` as there can be thousands of product ids.
+        product?: string;
+    }
 }

--- a/packages/api/cms-api/src/index.ts
+++ b/packages/api/cms-api/src/index.ts
@@ -284,7 +284,7 @@ export { ContentScope } from "./user-permissions/interfaces/content-scope.interf
 export { User } from "./user-permissions/interfaces/user";
 export { UserPermissionsModule } from "./user-permissions/user-permissions.module";
 export { UserPermissionsPublicService as UserPermissionsService } from "./user-permissions/user-permissions.public.service";
-export { type ContentScopeWithLabel } from "./user-permissions/user-permissions.types";
+export { type ContentScopeDimension, type ContentScopeWithLabel } from "./user-permissions/user-permissions.types";
 export { registerAdditionalPermissions } from "./user-permissions/user-permissions.types";
 export {
     AccessControlServiceInterface,

--- a/packages/api/cms-api/src/user-permissions/dto/content-scope.ts
+++ b/packages/api/cms-api/src/user-permissions/dto/content-scope.ts
@@ -11,3 +11,12 @@ export class ContentScopeWithLabel {
     @Field(() => GraphQLJSONObject)
     label: { [key in keyof ContentScope]: string };
 }
+
+@ObjectType()
+export class ContentScopeDimension {
+    @Field()
+    name: string;
+
+    @Field()
+    label: string;
+}

--- a/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
@@ -2,7 +2,6 @@ import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository } from "@mikro-orm/postgresql";
 import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { GraphQLJSONObject } from "graphql-scalars";
-import isEqual from "lodash.isequal";
 
 import { SkipBuild } from "../builds/skip-build.decorator";
 import { RequiredPermission } from "./decorators/required-permission.decorator";
@@ -27,7 +26,6 @@ export class UserContentScopesResolver {
         @Args("userId", { type: () => String }) userId: string,
         @Args("input", { type: () => UserContentScopesInput }) { contentScopes }: UserContentScopesInput,
     ): Promise<boolean> {
-        await this.userService.checkContentScopes(contentScopes);
         let entity = await this.repository.findOne({ userId });
         if (entity) {
             entity = this.repository.assign(entity, { userId, contentScopes });
@@ -43,10 +41,10 @@ export class UserContentScopesResolver {
         @Args("userId", { type: () => String }) userId: string,
         @Args("skipManual", { type: () => Boolean, nullable: true }) skipManual = false,
     ): Promise<ContentScope[]> {
-        const contentScopes = await this.userService.getContentScopes(await this.userService.getUser(userId), !skipManual);
-        return (await this.userService.getAvailableContentScopes())
-            .filter((availableContentScope) => contentScopes.some((contentScope) => isEqual(contentScope, availableContentScope.scope)))
-            .map((availableContentScope) => availableContentScope.scope);
+        return this.userService.filterContentScopesForUser({
+            user: await this.userService.getUser(userId),
+            includeContentScopesManual: !skipManual,
+        });
     }
 
     @Query(() => [ContentScopeWithLabel])

--- a/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permission.resolver.ts
@@ -81,7 +81,6 @@ export class UserPermissionResolver {
         @Args("input", { type: () => UserPermissionOverrideContentScopesInput }) input: UserPermissionOverrideContentScopesInput,
     ): Promise<UserPermission> {
         const permission = await this.getPermission(input.permissionId);
-        await this.service.checkContentScopes(input.contentScopes);
         permission.overrideContentScopes = input.overrideContentScopes;
         permission.contentScopes = input.contentScopes;
         await this.entityManager.persistAndFlush(permission);

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.spec.ts
@@ -1,0 +1,117 @@
+import type { DiscoveryService } from "@golevelup/nestjs-discovery";
+import { createMock } from "@golevelup/ts-jest";
+import type { EntityRepository } from "@mikro-orm/postgresql";
+
+import type { UserContentScopes } from "./entities/user-content-scopes.entity";
+import type { UserPermission } from "./entities/user-permission.entity";
+import type { ContentScope } from "./interfaces/content-scope.interface";
+import type { User } from "./interfaces/user";
+import { UserPermissionsService } from "./user-permissions.service";
+import { type AccessControlServiceInterface, UserPermissions, type UserPermissionsOptions } from "./user-permissions.types";
+
+const user: User = { id: "1", name: "User", email: "user@example.com" };
+
+function createService(
+    options: UserPermissionsOptions,
+    {
+        getContentScopesForUser,
+        manualContentScopes,
+    }: { getContentScopesForUser?: AccessControlServiceInterface["getContentScopesForUser"]; manualContentScopes?: ContentScope[] } = {},
+): UserPermissionsService {
+    return new UserPermissionsService(
+        options,
+        undefined,
+        createMock<AccessControlServiceInterface>({ isAllowed: () => true, getContentScopesForUser }),
+        createMock<EntityRepository<UserPermission>>(),
+        createMock<EntityRepository<UserContentScopes>>({
+            findOne: async () => (manualContentScopes ? ({ userId: user.id, contentScopes: manualContentScopes } as UserContentScopes) : null),
+        }),
+        createMock<DiscoveryService>(),
+    );
+}
+
+describe("UserPermissionsService", () => {
+    describe("getAvailableContentScopeDimensions", () => {
+        it("returns the configured dimensions and falls back to the name for missing labels", async () => {
+            const service = createService({
+                availableContentScopeDimensions: [{ name: "domain", label: "Domain" }, { name: "language" }, { name: "product" }],
+            });
+
+            const dimensions = await service.getAvailableContentScopeDimensions();
+
+            expect(dimensions).toEqual([
+                { name: "domain", label: "Domain" },
+                { name: "language", label: "language" },
+                { name: "product", label: "product" },
+            ]);
+        });
+
+        it("resolves a factory function", async () => {
+            const service = createService({
+                availableContentScopeDimensions: () => [{ name: "domain" }],
+            });
+
+            const dimensions = await service.getAvailableContentScopeDimensions();
+
+            expect(dimensions).toEqual([{ name: "domain", label: "domain" }]);
+        });
+
+        it("derives the dimensions from the available content scopes when not configured", async () => {
+            const service = createService({
+                availableContentScopes: [
+                    { domain: "main", language: "en" },
+                    { domain: "main", language: "de" },
+                ],
+            });
+
+            const dimensions = await service.getAvailableContentScopeDimensions();
+
+            expect(dimensions).toEqual([
+                { name: "domain", label: "domain" },
+                { name: "language", label: "language" },
+            ]);
+        });
+
+        it("returns no dimensions when nothing is configured", async () => {
+            const service = createService({});
+
+            const dimensions = await service.getAvailableContentScopeDimensions();
+
+            expect(dimensions).toEqual([]);
+        });
+    });
+
+    describe("filterContentScopesForUser", () => {
+        const options: UserPermissionsOptions = {
+            availableContentScopes: [
+                { domain: "main", language: "en" },
+                { domain: "main", language: "de" },
+            ],
+            availableContentScopeDimensions: [{ name: "domain" }, { name: "language" }, { name: "product" }],
+        };
+
+        it("returns a manual content scope as-is, including a value for a dimension outside the available content scopes", async () => {
+            const service = createService(options, { manualContentScopes: [{ domain: "main", language: "en", product: "product-42" }] });
+
+            expect(await service.filterContentScopesForUser({ user, includeContentScopesManual: true })).toEqual([
+                { domain: "main", language: "en", product: "product-42" },
+            ]);
+        });
+
+        it("returns a manual content scope even when it is not part of the available content scopes", async () => {
+            const service = createService(options, { manualContentScopes: [{ domain: "main", language: "fr", product: "product-42" }] });
+
+            expect(await service.filterContentScopesForUser({ user, includeContentScopesManual: true })).toEqual([
+                { domain: "main", language: "fr", product: "product-42" },
+            ]);
+        });
+
+        it("represents access to all content scopes as a per-dimension wildcard spanning all declared dimensions", async () => {
+            const service = createService(options, { getContentScopesForUser: () => UserPermissions.allContentScopes });
+
+            expect(await service.filterContentScopesForUser({ user, includeContentScopesManual: false })).toEqual([
+                { domain: "*", language: "*", product: "*" },
+            ]);
+        });
+    });
+});

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -4,12 +4,11 @@ import { EntityRepository } from "@mikro-orm/postgresql";
 import { Inject, Injectable, Optional } from "@nestjs/common";
 import { isFuture, isPast } from "date-fns";
 import { Request } from "express";
-import isEqual from "lodash.isequal";
 import getUuid from "uuid-by-string";
 
 import { AbstractAccessControlService } from "./access-control.service";
 import { DisablePermissionCheck, REQUIRED_PERMISSION_METADATA_KEY, RequiredPermissionMetadata } from "./decorators/required-permission.decorator";
-import { ContentScopeWithLabel } from "./dto/content-scope";
+import { ContentScopeDimension, ContentScopeWithLabel } from "./dto/content-scope";
 import { CurrentUser, CurrentUserPermission } from "./dto/current-user";
 import { FindUsersArgs } from "./dto/paginated-user-list";
 import { UserContentScopes } from "./entities/user-content-scopes.entity";
@@ -77,6 +76,23 @@ export class UserPermissionsService {
         return contentScopesWithLabel;
     }
 
+    async getAvailableContentScopeDimensions(): Promise<ContentScopeDimension[]> {
+        if (this.options.availableContentScopeDimensions) {
+            const dimensions =
+                typeof this.options.availableContentScopeDimensions === "function"
+                    ? await this.options.availableContentScopeDimensions()
+                    : this.options.availableContentScopeDimensions;
+            return dimensions.map((dimension) => ({
+                name: dimension.name,
+                label: dimension.label ?? dimension.name,
+            }));
+        }
+
+        // Derive the dimensions from the keys of the available content scopes when not explicitly configured
+        const dimensionNames = new Set((await this.getAvailableContentScopes()).flatMap((contentScope) => Object.keys(contentScope.scope)));
+        return [...dimensionNames].map((name) => ({ name, label: name }));
+    }
+
     async getAvailablePermissions(): Promise<Permission[]> {
         if (this.availablePermissions === undefined) {
             this.availablePermissions = [
@@ -110,15 +126,6 @@ export class UserPermissionsService {
     async findUsers(args: FindUsersArgs): Promise<[User[], number]> {
         if (!this.userService) throw new Error("For this functionality you need to define the userService in the UserPermissionsModule.");
         return this.userService.findUsers(args);
-    }
-
-    async checkContentScopes(contentScopes: ContentScope[]): Promise<void> {
-        const availableContentScopes = await this.getAvailableContentScopes();
-        contentScopes.forEach((scope) => {
-            if (!availableContentScopes.some((cs) => isEqual(cs.scope, scope))) {
-                throw new Error(`ContentScope does not exist: ${JSON.stringify(scope)}.`);
-            }
-        });
     }
 
     async warmupHasPermissionCache() {
@@ -179,38 +186,24 @@ export class UserPermissionsService {
             .sort((a, b) => availablePermissions.indexOf(a.permission) - availablePermissions.indexOf(b.permission));
     }
 
-    async getContentScopes(user: User, includeContentScopesManual = true): Promise<ContentScope[]> {
-        const availableContentScopes = (await this.getAvailableContentScopes()).map((cs) => cs.scope);
-        return this.filterContentScopesForUser({ user, availableContentScopes, includeContentScopesManual });
-    }
-
-    private async filterContentScopesForUser({
+    async filterContentScopesForUser({
         user,
-        availableContentScopes,
         includeContentScopesManual,
-        representAllContentScopesAsWildcard = false,
     }: {
         user: User;
-        availableContentScopes: ContentScope[];
         includeContentScopesManual: boolean;
-        representAllContentScopesAsWildcard?: boolean;
     }): Promise<ContentScope[]> {
         const contentScopes: ContentScope[] = [];
 
         if (this.accessControlService.getContentScopesForUser) {
             const userContentScopes = await this.accessControlService.getContentScopesForUser(user);
             if (userContentScopes === UserPermissions.allContentScopes) {
-                if (representAllContentScopesAsWildcard) {
-                    // For the current user, represent access to all content scopes as a single scope that grants any
-                    // value ("*") of every available dimension, so that the wildcard is preserved for content scope
-                    // checks and permission comparison (impersonation) instead of being expanded to concrete scopes.
-                    const dimensions = new Set(availableContentScopes.flatMap((contentScope) => Object.keys(contentScope)));
-                    contentScopes.push(Object.fromEntries([...dimensions].map((dimension) => [dimension, "*"])));
-                } else {
-                    // For other uses (e.g. the content scopes list in the user permissions panel), expand access to all
-                    // content scopes to the concrete available scopes.
-                    contentScopes.push(...availableContentScopes);
-                }
+                // Represent access to all content scopes as a single scope that grants any value ("*") of every
+                // dimension, so that the wildcard is preserved for permission comparison (impersonation) instead of
+                // being expanded to concrete scopes. Non-enumerable dimensions are covered because the wildcard spans
+                // all declared dimensions, not just the ones present in the available content scopes.
+                const dimensions = await this.getAvailableContentScopeDimensions();
+                contentScopes.push(Object.fromEntries(dimensions.map((dimension) => [dimension.name, "*"])));
             } else {
                 contentScopes.push(...userContentScopes);
             }
@@ -219,7 +212,7 @@ export class UserPermissionsService {
         if (includeContentScopesManual) {
             const entity = await this.contentScopeRepository.findOne({ userId: user.id });
             if (entity) {
-                contentScopes.push(...entity.contentScopes.filter((value) => availableContentScopes.some((cs) => isEqual(cs, value))));
+                contentScopes.push(...entity.contentScopes);
             }
         }
 
@@ -261,12 +254,9 @@ export class UserPermissionsService {
     }
 
     async getPermissionsAndContentScopes(user: User): Promise<CurrentUserPermission[]> {
-        const availableContentScopes = (await this.getAvailableContentScopes()).map((cs) => cs.scope);
         const userContentScopes = await this.filterContentScopesForUser({
             user,
-            availableContentScopes,
             includeContentScopesManual: true,
-            representAllContentScopesAsWildcard: true,
         });
         return (await this.getPermissions(user))
             .filter((p) => (!p.validFrom || isPast(p.validFrom)) && (!p.validTo || isFuture(p.validTo)))

--- a/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.types.ts
@@ -49,8 +49,20 @@ export type ContentScopeWithLabel = {
 };
 export type AvailableContentScope = ContentScope | ContentScopeWithLabel;
 
+export type ContentScopeDimension = {
+    name: string;
+    label?: string;
+};
+
 export interface UserPermissionsOptions {
     availableContentScopes?: AvailableContentScope[] | (() => Promise<AvailableContentScope[]> | AvailableContentScope[]);
+    /**
+     * Declares the content scope dimensions (e.g. `domain`, `language`) available in the system. Use this to make dimensions
+     * that are not part of `availableContentScopes` (e.g. an optional dimension with too many values to enumerate) known at
+     * runtime, so they are shown in the user permissions admin panel. When omitted, the dimensions are derived from the keys
+     * of `availableContentScopes`.
+     */
+    availableContentScopeDimensions?: ContentScopeDimension[] | (() => Promise<ContentScopeDimension[]> | ContentScopeDimension[]);
     systemUsers?: string[];
 }
 export interface UserPermissionsModuleSyncOptions extends UserPermissionsOptions {


### PR DESCRIPTION
Backport of #6115 to `v8.x.x`.

> [!NOTE]
> This PR is stacked on #6292 (the backport of #6114 to `v8.x.x`, layer 1). It targets `claude/backport-v8-6114` because `v8.x.x` doesn't have the wildcard content scope dimension support (#6114) yet. Once #6292 is merged into `v8.x.x`, this PR's base will need to be retargeted to `v8.x.x` (or GitHub will do so automatically once #6292 merges, matching how the original stacked PRs behaved).

## Original description

### Problem

Content scope dimensions were only known implicitly from the keys of the `availableContentScopes` values. An optional dimension that is not part of `availableContentScopes` (e.g. one with too many values to enumerate) therefore had no runtime representation at all — it could neither be declared nor used with arbitrary values.

### Solution

Add an optional `availableContentScopeDimensions` option to the `UserPermissionsModule` to declare the content scope dimensions (with optional labels) at runtime. When omitted, the dimensions are derived from the keys of `availableContentScopes` as before, so existing apps are unaffected. The declared dimensions are used to represent access to all content scopes as a per-dimension wildcard (`{ domain: "*", ... }`), which therefore also covers dimensions that are not part of `availableContentScopes`.

A content scope for a dimension that is not part of `availableContentScopes` may now hold any value (including the `"*"` wildcard).

#### Removing `checkContentScopes`

Content scopes are no longer validated against `availableContentScopes` (the `checkContentScopes` method is removed) — see the original PR (#6115) for the full rationale.

## Backport notes

Cherry-picking the squash commit (`f4d091fa71ffe1c3c0f72431bbdb6151b6e93faa`) from `main` onto `claude/backport-v8-6114` produced conflicts in two files, both resolved by applying the incoming change against `v8.x.x`'s existing code:

- `packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts`: the incoming code used `userService.findUserOrThrow(userId)`, but `findUserOrThrow` doesn't exist on `v8.x.x` (it was introduced by a later, unrelated `main` commit). Kept using `v8.x.x`'s existing `userService.getUser(userId)` instead, combined with the new `filterContentScopesForUser` (already present via #6114's backport).
- `demo/api/src/content-scope/content-scope.interface.ts`: module augmentation naming conflict (`@dextinity/cms-api` vs. `@comet/cms-api`, matching `v8.x.x`'s pre-rename package naming — see #6280 for precedent). Kept `@comet/cms-api` and added the new `product` dimension.

Also converted the cherry-picked `user-permissions.service.spec.ts` from `vitest` to `jest` (matching `@comet/cms-api`'s test runner on this branch — same adjustment as #6144/#6280), and updated the changeset package name from `@dextinity/cms-api` to `@comet/cms-api` (per the pre-rename naming convention, per the routine's own caveat).

## Verification

- `@comet/cms-api`: build, lint (prettier/eslint/tsc) pass.
- `@comet/cms-api` full test suite: 204/204 passing, including the 7 new tests for `getAvailableContentScopeDimensions`/`filterContentScopesForUser`.
- `demo/api`: `api-generator` regenerates cleanly with no diff to the generated files; lint (prettier/eslint/tsc) passes.
- `demo/api` `AppModule`/`GraphQLModule` initialize correctly via `pnpm run console --help` (schema/block-meta regenerate); it only fails afterwards on connecting to Postgres, since the full Docker demo could not be started in this sandbox — Docker Hub image pulls are blocked by the environment's network policy (403 from CloudFront), consistent with the same limitation noted on prior v8 backport PRs (e.g. #6280, #6292). Please verify the runtime-declared content scope dimensions manually before merging.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeZZCJgNydRxnbPuRBkTjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeZZCJgNydRxnbPuRBkTjp)_