### PR TITLE
Fix release tags pointing at the wrong commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,15 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   HUSKY: 0 # https://typicode.github.io/husky/#/?id=with-env-variables
+
+            # Catches a silently broken guard on the tag step above: without this, a wrong tag
+            # would go unnoticed again.
+            - name: Verify the release tag
+              if: ${{ steps.changesets.outputs.published == 'true' }}
+              run: |
+                  git fetch --force origin "refs/tags/v$PUBLISHED_VERSION:refs/tags/v$PUBLISHED_VERSION"
+                  TAGGED_SHA=$(git rev-parse "v$PUBLISHED_VERSION^{commit}")
+                  if [ "$TAGGED_SHA" != "$GITHUB_SHA" ]; then
+                      echo "::error::Publishing succeeded, but tag v$PUBLISHED_VERSION points at $TAGGED_SHA instead of the released commit $GITHUB_SHA. Move the tag, then check the condition of the \"Create tag on released commit\" step."
+                      exit 1
+                  fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,21 @@ jobs:
                   cd packages/admin/admin
                   echo "PUBLISHED_VERSION=$(pnpm pkg get version | sed -r 's/"//g')" >> $GITHUB_ENV
 
+            # dotansimha/changesets-action creates the GitHub release without passing
+            # target_commitish, so GitHub places the tag on the default branch (main) instead of
+            # the released commit. That's wrong for every release that doesn't run on main.
+            # Creating the tag upfront fixes it: GitHub ignores target_commitish when the tag
+            # already exists.
+            - name: Create tag on released commit
+              if: ${{ contains(github.event.head_commit.message, 'Version Packages') }}
+              run: |
+                  if git ls-remote --exit-code --tags origin "v$PUBLISHED_VERSION" > /dev/null; then
+                      echo "Tag v$PUBLISHED_VERSION already exists"
+                  else
+                      git tag "v$PUBLISHED_VERSION" "$GITHUB_SHA"
+                      git push origin "v$PUBLISHED_VERSION"
+                  fi
+
             - name: Create Release Pull Request or Publish to npm
               id: changesets
               uses: dotansimha/changesets-action@v1.5.2


### PR DESCRIPTION
## Problem

Backport releases on `v8.x.x` tag the wrong commit: the tag lands on the newest `main` commit instead of the commit that was released.

For example, `v8.31.0` was released from `v8.x.x`, but its tag points at `a00f0b2` ("Support wildcard values for content scope dimensions (#6114)") — a commit that exists only on `main`.

## Cause

`dotansimha/changesets-action` calls the create-release API without `target_commitish`, so GitHub creates the tag on the repository's default branch.

## Fix

### Tag step

`release.yml` creates the `v8.Y.Z` tag"manually" before the release runs. GitHub ignores `target_commitish` when the tag already exists, so the release attaches to the correct commit.

### Verification step

A second step after the release checks if the tag ended up on the released commit and fails the job otherwise. The release isn't reversed but it's visible that the tagging is wrong, so this can't quietly break again.

## Decisions

- **Create the tag in the workflow rather than patching the action.** Doesn't require a fork like [#4702](https://github.com/vivid-planet/dextinity/pull/4702).
- **Guard the tag step with the `Version Packages` commit message.** It is the narrowest predictive signal available before the action runs — it matches the release commits and nothing else — and `release-canary.yml` already guards on the same string. 
- **Verify with `steps.changesets.outputs.published` instead of guarding on it.** It is the exact signal for "this run published", but it only exists after the action has already created the tag, so it cannot drive the tag step. 

## Verification

The end-to-end path can't be exercised outside a real release. We'll test this on the next actual v8 release.

## Next steps

- `main`, `next` (via `release-beta.yml`) and the other `vN.x.x` branches carry the same bug and each need the same steps in their own workflow. We need to port it to `main` and all other active branches.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/DEX-2597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgLEUzTiJX7Jn3WQJBWhok