### PR TITLE
Support scopes in dependencies and dependents lists

### DIFF
--- a/.changeset/gentle-clouds-invite.md
+++ b/.changeset/gentle-clouds-invite.md
@@ -1,0 +1,34 @@
+---
+"@dextinity/cms-admin": minor
+"@dextinity/cms-api": minor
+---
+
+Support scopes in `DependentsList` and `DependenciesList`
+
+Entities can be used across scopes, for instance a DAM that is shared between multiple sites. Until now, the links in both lists always pointed to the currently active scope, leading to a wrong or non-existent page. In addition, the lists didn't show which scope an entry belongs to.
+
+The `Dependency` type now has a `scope` field, which is resolved from the entity's `scope` property or its `@ScopedEntity()` decorator (documents are scoped by their page tree node). Both lists use it to link to the entry in its own scope and show a scope column when more than one scope exists.
+
+**Example**
+
+Request the new field in your dependents/dependencies queries:
+
+```diff
+    dependents(offset: $offset, limit: $limit, forceRefresh: $forceRefresh, filter: $filter, sort: $sort) {
+        nodes {
+            rootGraphqlObjectType
+            rootId
+            rootColumnName
+            jsonPath
+            name
+            secondaryInformation
+            visible
++           scope
+        }
+        totalCount
+    }
+```
+
+Entities using a `@ScopedEntity()` callback or service report no scope, as it cannot be resolved in SQL. Use the field-path string (e.g. `@ScopedEntity("company.scope")`) or the object mapping (e.g. `@ScopedEntity({ companyId: "company.id" })`) variant to make the scope available.
+
+The block index views must be recreated (`npm run console createBlockIndexViews`) for the scope to be available.

--- a/demo/admin/src/documents/pages/EditPage.tsx
+++ b/demo/admin/src/documents/pages/EditPage.tsx
@@ -61,6 +61,7 @@ const pageTreeNodeDependentsQuery = gql`
                     name
                     secondaryInformation
                     visible
+                    scope
                 }
                 totalCount
             }
@@ -88,6 +89,7 @@ const pageTreeNodeDependenciesQuery = gql`
                     name
                     secondaryInformation
                     visible
+                    scope
                 }
                 totalCount
             }

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -547,6 +547,7 @@ type Dependency {
   rootColumnName: String!
   rootGraphqlObjectType: String!
   rootId: String!
+  scope: JSONObject
   secondaryInformation: String
   targetGraphqlObjectType: String!
   targetId: String!

--- a/docs/docs/2-core-concepts/7-dependencies/index.md
+++ b/docs/docs/2-core-concepts/7-dependencies/index.md
@@ -311,7 +311,13 @@ Each component requires two props:
         ) {
             item: damFile(id: $id) {
                 id
-                dependents(offset: $offset, limit: $limit, forceRefresh: $forceRefresh, filter: $filter, sort: $sort) {
+                dependents(
+                    offset: $offset
+                    limit: $limit
+                    forceRefresh: $forceRefresh
+                    filter: $filter
+                    sort: $sort
+                ) {
                     nodes {
                         rootGraphqlObjectType
                         rootId
@@ -320,6 +326,7 @@ Each component requires two props:
                         name
                         secondaryInformation
                         visible
+                        scope
                     }
                     totalCount
                 }
@@ -333,3 +340,13 @@ Each component requires two props:
 ```
 
 </details>
+
+#### 6. Scopes
+
+Both lists use the `scope` field to link to the entry in the scope it actually belongs to.
+This matters when an entity is used across scopes, for instance a DAM that is shared between multiple sites.
+Make sure to request the field in your query, otherwise the links point to the currently active scope.
+
+The scope is resolved from the entity's `scope` property or its `@ScopedEntity()` decorator (documents are scoped by their page tree node).
+Entities using a `@ScopedEntity()` callback or service report no scope, as it cannot be resolved in SQL.
+Use the field-path string (e.g. `@ScopedEntity("company.scope")`) or the object mapping (e.g. `@ScopedEntity({ companyId: "company.id" })`) variant to make the scope available.

--- a/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
+++ b/packages/admin/cms-admin/src/contentScope/ContentScopeIndicator.tsx
@@ -6,10 +6,7 @@ import type { PropsWithChildren, ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { type ContentScope, useContentScope } from "./Provider";
-
-const capitalizeString = (string: string) => {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-};
+import { getContentScopeLabel } from "./utils/getContentScopeLabel";
 
 interface ContentScopeIndicatorProps {
     global?: boolean;
@@ -21,20 +18,11 @@ export const ContentScopeIndicator = ({ global = false, scope: passedScope, chil
     const { scope: contentScope, values } = useContentScope();
     const scope = passedScope ?? contentScope;
 
-    const findLabelForScopePart = (scopePart: keyof ContentScope) => {
-        const label = values.find((value) => {
-            return value.scope[scopePart] === scope[scopePart];
-        })?.label;
-        return (label && label[scopePart]) ?? (scope[scopePart] ? capitalizeString(scope[scopePart]) : undefined);
-    };
-
     let content: ReactNode;
     if (global) {
         content = <FormattedMessage {...messages.globalContentScope} />;
     } else {
-        const scopeParts = Object.keys(scope);
-        const scopeLabels = scopeParts.map((scopePart) => findLabelForScopePart(scopePart)).filter((label) => typeof label === "string") as string[];
-        content = scopeLabels.join(" / ");
+        content = getContentScopeLabel({ scope, values });
     }
 
     return (

--- a/packages/admin/cms-admin/src/contentScope/utils/getContentScopeLabel.test.ts
+++ b/packages/admin/cms-admin/src/contentScope/utils/getContentScopeLabel.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import type { ContentScopeValues } from "../Provider";
+import { getContentScopeLabel } from "./getContentScopeLabel";
+
+const values: ContentScopeValues = [
+    { scope: { domain: "main", language: "de" }, label: { domain: "Main Domain", language: "DE" } },
+    { scope: { domain: "secondary", language: "en" }, label: { language: "EN" } },
+];
+
+describe("getContentScopeLabel", () => {
+    it("should use the labels of the content scope values", () => {
+        expect(getContentScopeLabel({ scope: { domain: "main", language: "de" }, values })).toBe("Main Domain / DE");
+    });
+
+    it("should fall back to the capitalized value when no label exists", () => {
+        expect(getContentScopeLabel({ scope: { domain: "secondary", language: "en" }, values })).toBe("Secondary / EN");
+    });
+
+    it("should support incomplete scopes", () => {
+        expect(getContentScopeLabel({ scope: { domain: "main" }, values })).toBe("Main Domain");
+    });
+
+    it("should omit dimensions without a value", () => {
+        expect(getContentScopeLabel({ scope: { domain: "main", language: null }, values })).toBe("Main Domain");
+    });
+});

--- a/packages/admin/cms-admin/src/contentScope/utils/getContentScopeLabel.ts
+++ b/packages/admin/cms-admin/src/contentScope/utils/getContentScopeLabel.ts
@@ -1,0 +1,21 @@
+import type { ContentScope, ContentScopeValues } from "../Provider";
+
+function capitalizeString(string: string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+/**
+ * Builds a human-readable label for a scope, for instance "Main Domain / English".
+ *
+ * The label of each scope dimension is taken from the matching content scope value, falling back to the capitalized
+ * value itself. Dimensions without a value are omitted, which also supports incomplete scopes.
+ */
+export function getContentScopeLabel({ scope, values }: { scope: ContentScope; values: ContentScopeValues }): string {
+    return Object.keys(scope)
+        .map((dimension) => {
+            const label = values.find((value) => value.scope[dimension] === scope[dimension])?.label;
+            return label?.[dimension] ?? (scope[dimension] ? capitalizeString(scope[dimension]) : undefined);
+        })
+        .filter((label) => typeof label === "string")
+        .join(" / ");
+}

--- a/packages/admin/cms-admin/src/contentScope/utils/isScopePartOf.test.ts
+++ b/packages/admin/cms-admin/src/contentScope/utils/isScopePartOf.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { isScopePartOf } from "./isScopePartOf";
+
+describe("isScopePartOf", () => {
+    it("should match an equal scope", () => {
+        expect(isScopePartOf({ domain: "main", language: "de" }, { domain: "main", language: "de" })).toBe(true);
+    });
+
+    it("should match a scope with fewer dimensions", () => {
+        expect(isScopePartOf({ domain: "main" }, { domain: "main", language: "de" })).toBe(true);
+    });
+
+    it("should not match a scope with a differing dimension", () => {
+        expect(isScopePartOf({ domain: "main", language: "en" }, { domain: "main", language: "de" })).toBe(false);
+    });
+
+    it("should not match a scope with an additional dimension", () => {
+        expect(isScopePartOf({ domain: "main", language: "de" }, { domain: "main" })).toBe(false);
+    });
+
+    it("should match an empty scope", () => {
+        expect(isScopePartOf({}, { domain: "main" })).toBe(true);
+    });
+
+    it("should match null values", () => {
+        expect(isScopePartOf({ domain: null }, { domain: null, language: "de" })).toBe(true);
+    });
+});

--- a/packages/admin/cms-admin/src/contentScope/utils/isScopePartOf.ts
+++ b/packages/admin/cms-admin/src/contentScope/utils/isScopePartOf.ts
@@ -1,0 +1,13 @@
+import isEqual from "lodash.isequal";
+
+import type { ContentScope } from "../Provider";
+
+/**
+ * Checks whether a (possibly incomplete) scope is contained in another scope.
+ *
+ * Scopes can have fewer dimensions than the content scope, for instance a DAM file that is scoped by domain only while
+ * the content scope consists of domain and language.
+ */
+export function isScopePartOf(scope: ContentScope, otherScope: ContentScope): boolean {
+    return Object.entries(scope).every(([dimension, value]) => isEqual(otherScope[dimension], value));
+}

--- a/packages/admin/cms-admin/src/dam/FileForm/EditFile.gql.ts
+++ b/packages/admin/cms-admin/src/dam/FileForm/EditFile.gql.ts
@@ -79,6 +79,7 @@ export const damFileDependentsQuery = gql`
                     name
                     secondaryInformation
                     visible
+                    scope
                 }
                 totalCount
             }

--- a/packages/admin/cms-admin/src/dependencies/DependenciesList.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependenciesList.tsx
@@ -1,4 +1,4 @@
-import { type QueryResult, type TypedDocumentNode, useApolloClient, useQuery } from "@apollo/client";
+import { type QueryResult, type TypedDocumentNode, useQuery } from "@apollo/client";
 import {
     Alert,
     DataGridToolbar,
@@ -15,28 +15,28 @@ import {
     useDataGridRemote,
     usePersistentColumnState,
 } from "@dextinity/admin";
-import { ArrowRight, OpenNewTab, Reload, ThreeDotSaving } from "@dextinity/admin-icons";
-import { Box, Chip, IconButton } from "@mui/material";
+import { Reload, ThreeDotSaving } from "@dextinity/admin-icons";
+import { Chip, IconButton } from "@mui/material";
 import type { GridSlotsComponent, GridToolbarProps } from "@mui/x-data-grid";
 import { useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { useHistory } from "react-router";
 
 import { useContentScope } from "../contentScope/Provider";
+import { getContentScopeLabel } from "../contentScope/utils/getContentScopeLabel";
 import { DataGrid } from "../dataGrid/DataGrid";
 import type { GQLDependency } from "../graphql.generated";
 import { useDependenciesConfig } from "./dependenciesConfig";
+import { DependencyActions } from "./DependencyActions";
 import { getDisplayNameString } from "./getDisplayNameString";
-import type { DependencyInterface } from "./types";
 
-type DependencyItem = Pick<GQLDependency, "name" | "secondaryInformation" | "visible" | "rootColumnName" | "jsonPath"> & {
+type DependencyItem = Pick<GQLDependency, "name" | "secondaryInformation" | "visible" | "rootColumnName" | "jsonPath" | "scope"> & {
     id: string;
     targetGraphqlObjectType: string;
 };
 
 type Dependency = Pick<
     GQLDependency,
-    "targetGraphqlObjectType" | "targetId" | "rootColumnName" | "jsonPath" | "name" | "secondaryInformation" | "visible"
+    "targetGraphqlObjectType" | "targetId" | "rootColumnName" | "jsonPath" | "name" | "secondaryInformation" | "visible" | "scope"
 >;
 
 interface DependenciesListQuery {
@@ -94,8 +94,6 @@ export const DependenciesList = ({ query, variables }: DependenciesListProps) =>
     const intl = useIntl();
     const { entityDependencyMap } = useDependenciesConfig();
     const contentScope = useContentScope();
-    const apolloClient = useApolloClient();
-    const history = useHistory();
 
     const dataGridProps = {
         ...useDataGridRemote({
@@ -107,6 +105,9 @@ export const DependenciesList = ({ query, variables }: DependenciesListProps) =>
         }),
         ...usePersistentColumnState("DependenciesList"),
     };
+
+    // Scopes are only worth showing when the entries can actually originate from different scopes.
+    const showScopeColumn = contentScope.values.length > 1;
 
     const columns: GridColDef<DependencyItem>[] = useMemo(
         () => [
@@ -148,59 +149,36 @@ export const DependenciesList = ({ query, variables }: DependenciesListProps) =>
                 visible: false,
                 sortBy: "visible",
             },
+            ...(showScopeColumn
+                ? [
+                      {
+                          field: "scope",
+                          headerName: intl.formatMessage({ id: "dextinity.dependencies.dataGrid.scope", defaultMessage: "Scope" }),
+                          width: 160,
+                          filterable: false,
+                          sortable: false,
+                          valueGetter: (params, row) => (row.scope ? getContentScopeLabel({ scope: row.scope, values: contentScope.values }) : null),
+                      } satisfies GridColDef<DependencyItem>,
+                  ]
+                : []),
             {
                 field: "actions",
                 type: "actions",
                 headerName: "",
                 filterable: false,
                 sortable: false,
-                renderCell: ({ row }) => {
-                    const dependencyObject = entityDependencyMap[row.targetGraphqlObjectType] as DependencyInterface | undefined;
-
-                    if (dependencyObject === undefined) {
-                        if (process.env.NODE_ENV === "development") {
-                            console.warn(
-                                `Cannot load URL because no implementation of DependencyInterface for ${row.targetGraphqlObjectType} was provided via the DependenciesConfig`,
-                            );
-                        }
-                        return <FormattedMessage id="dextinity.dependencies.dataGrid.cannotLoadUrl" defaultMessage="Cannot determine URL" />;
-                    }
-
-                    const loadUrl = async () => {
-                        const path = await dependencyObject.resolvePath({
-                            rootColumnName: row.rootColumnName,
-                            jsonPath: row.jsonPath,
-                            apolloClient,
-                            id: row.id,
-                        });
-                        return contentScope.match.url + path;
-                    };
-
-                    return (
-                        <Box display="flex">
-                            <IconButton
-                                onClick={async () => {
-                                    const url = await loadUrl();
-                                    window.open(url, "_blank");
-                                }}
-                            >
-                                <OpenNewTab />
-                            </IconButton>
-                            <IconButton
-                                onClick={async () => {
-                                    const url = await loadUrl();
-
-                                    history.push(url);
-                                }}
-                            >
-                                <ArrowRight />
-                            </IconButton>
-                        </Box>
-                    );
-                },
+                renderCell: ({ row }) => (
+                    <DependencyActions
+                        graphqlObjectType={row.targetGraphqlObjectType}
+                        id={row.id}
+                        rootColumnName={row.rootColumnName}
+                        jsonPath={row.jsonPath}
+                        scope={row.scope ?? undefined}
+                    />
+                ),
             },
         ],
-        [intl, entityDependencyMap, apolloClient, contentScope, history],
+        [intl, entityDependencyMap, showScopeColumn, contentScope.values],
     );
 
     const { filter: gqlFilter } = muiGridFilterToGql(columns, dataGridProps.filterModel);

--- a/packages/admin/cms-admin/src/dependencies/DependencyActions.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependencyActions.tsx
@@ -6,8 +6,8 @@ import { FormattedMessage } from "react-intl";
 import { useHistory } from "react-router";
 
 import { type ContentScope, useContentScope } from "../contentScope/Provider";
-import { isScopePartOf } from "../contentScope/utils/isScopePartOf";
 import { useDependenciesConfig } from "./dependenciesConfig";
+import { resolveDependencyScope } from "./resolveDependencyScope";
 import type { DependencyInterface } from "./types";
 
 interface DependencyActionsProps {
@@ -39,9 +39,9 @@ export const DependencyActions = ({ graphqlObjectType, id, rootColumnName, jsonP
         return <FormattedMessage id="dextinity.dependencies.dataGrid.cannotLoadUrl" defaultMessage="Cannot determine URL" />;
     }
 
-    const isScopeAllowed = scope === undefined || contentScope.values.some(({ scope: allowedScope }) => isScopePartOf(scope, allowedScope));
+    const scopeToOpen = scope && resolveDependencyScope({ scope, activeScope: contentScope.scope, availableScopes: contentScope.values });
 
-    if (!isScopeAllowed) {
+    if (scope !== undefined && scopeToOpen === undefined) {
         return (
             <Tooltip
                 title={
@@ -71,9 +71,7 @@ export const DependencyActions = ({ graphqlObjectType, id, rootColumnName, jsonP
             id,
         });
 
-        // A scope can be incomplete (e.g. a DAM file scoped by domain only), therefore it is merged into the active
-        // scope instead of replacing it.
-        const scopeUrl = scope ? contentScope.createUrl({ ...contentScope.scope, ...scope }) : contentScope.match.url;
+        const scopeUrl = scopeToOpen ? contentScope.createUrl(scopeToOpen) : contentScope.match.url;
 
         return scopeUrl + path;
     };

--- a/packages/admin/cms-admin/src/dependencies/DependencyActions.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependencyActions.tsx
@@ -1,0 +1,106 @@
+import { useApolloClient } from "@apollo/client";
+import { messages, Tooltip } from "@dextinity/admin";
+import { ArrowRight, OpenNewTab } from "@dextinity/admin-icons";
+import { Box, IconButton } from "@mui/material";
+import { FormattedMessage } from "react-intl";
+import { useHistory } from "react-router";
+
+import { type ContentScope, useContentScope } from "../contentScope/Provider";
+import { isScopePartOf } from "../contentScope/utils/isScopePartOf";
+import { useDependenciesConfig } from "./dependenciesConfig";
+import type { DependencyInterface } from "./types";
+
+interface DependencyActionsProps {
+    graphqlObjectType: string;
+    id: string;
+    rootColumnName?: string;
+    jsonPath?: string;
+    /**
+     * Scope of the linked entity. Entities can be used across scopes (e.g. a DAM file shared between sites), which is
+     * why the link must not be built with the currently active scope.
+     */
+    scope?: ContentScope;
+}
+
+export const DependencyActions = ({ graphqlObjectType, id, rootColumnName, jsonPath, scope }: DependencyActionsProps) => {
+    const { entityDependencyMap } = useDependenciesConfig();
+    const apolloClient = useApolloClient();
+    const history = useHistory();
+    const contentScope = useContentScope();
+
+    const dependencyObject = entityDependencyMap[graphqlObjectType] as DependencyInterface | undefined;
+
+    if (dependencyObject === undefined) {
+        if (process.env.NODE_ENV === "development") {
+            console.warn(
+                `Cannot load URL because no implementation of DependencyInterface for ${graphqlObjectType} was provided via the DependenciesConfig`,
+            );
+        }
+        return <FormattedMessage id="dextinity.dependencies.dataGrid.cannotLoadUrl" defaultMessage="Cannot determine URL" />;
+    }
+
+    const isScopeAllowed = scope === undefined || contentScope.values.some(({ scope: allowedScope }) => isScopePartOf(scope, allowedScope));
+
+    if (!isScopeAllowed) {
+        return (
+            <Tooltip
+                title={
+                    <FormattedMessage
+                        id="dextinity.dependencies.dataGrid.scopeNotAllowed"
+                        defaultMessage="You don't have access to the scope of this item."
+                    />
+                }
+            >
+                <Box display="flex">
+                    <IconButton disabled>
+                        <OpenNewTab />
+                    </IconButton>
+                    <IconButton disabled>
+                        <ArrowRight />
+                    </IconButton>
+                </Box>
+            </Tooltip>
+        );
+    }
+
+    const loadUrl = async () => {
+        const path = await dependencyObject.resolvePath({
+            rootColumnName,
+            jsonPath,
+            apolloClient,
+            id,
+        });
+
+        // A scope can be incomplete (e.g. a DAM file scoped by domain only), therefore it is merged into the active
+        // scope instead of replacing it.
+        const scopeUrl = scope ? contentScope.createUrl({ ...contentScope.scope, ...scope }) : contentScope.match.url;
+
+        return scopeUrl + path;
+    };
+
+    return (
+        <Box display="flex">
+            <Tooltip title={<FormattedMessage {...messages.openInNewTab} />}>
+                <IconButton
+                    onClick={async () => {
+                        const url = await loadUrl();
+                        window.open(url, "_blank");
+                    }}
+                >
+                    <OpenNewTab />
+                </IconButton>
+            </Tooltip>
+            <Tooltip title={<FormattedMessage {...messages.openInThisTab} />}>
+                <IconButton
+                    onClick={async () => {
+                        const url = await loadUrl();
+
+                        history.push(url);
+                    }}
+                >
+                    <ArrowRight />
+                </IconButton>
+            </Tooltip>
+        </Box>
+    );
+};

--- a/packages/admin/cms-admin/src/dependencies/DependentsList.tsx
+++ b/packages/admin/cms-admin/src/dependencies/DependentsList.tsx
@@ -1,4 +1,4 @@
-import { type QueryResult, type TypedDocumentNode, useApolloClient, useQuery } from "@apollo/client";
+import { type QueryResult, type TypedDocumentNode, useQuery } from "@apollo/client";
 import {
     Alert,
     DataGridToolbar,
@@ -15,28 +15,28 @@ import {
     useDataGridRemote,
     usePersistentColumnState,
 } from "@dextinity/admin";
-import { ArrowRight, OpenNewTab, Reload, ThreeDotSaving } from "@dextinity/admin-icons";
-import { Box, Chip, IconButton } from "@mui/material";
+import { Reload, ThreeDotSaving } from "@dextinity/admin-icons";
+import { Chip, IconButton } from "@mui/material";
 import type { GridSlotsComponent, GridToolbarProps } from "@mui/x-data-grid";
 import { useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { useHistory } from "react-router";
 
 import { useContentScope } from "../contentScope/Provider";
+import { getContentScopeLabel } from "../contentScope/utils/getContentScopeLabel";
 import { DataGrid } from "../dataGrid/DataGrid";
 import type { GQLDependency } from "../graphql.generated";
 import { useDependenciesConfig } from "./dependenciesConfig";
+import { DependencyActions } from "./DependencyActions";
 import { getDisplayNameString } from "./getDisplayNameString";
-import type { DependencyInterface } from "./types";
 
-type DependencyItem = Pick<GQLDependency, "name" | "secondaryInformation" | "visible" | "rootColumnName" | "jsonPath"> & {
+type DependencyItem = Pick<GQLDependency, "name" | "secondaryInformation" | "visible" | "rootColumnName" | "jsonPath" | "scope"> & {
     id: string;
     rootGraphqlObjectType: string;
 };
 
 type Dependent = Pick<
     GQLDependency,
-    "rootGraphqlObjectType" | "rootId" | "rootColumnName" | "jsonPath" | "name" | "secondaryInformation" | "visible"
+    "rootGraphqlObjectType" | "rootId" | "rootColumnName" | "jsonPath" | "name" | "secondaryInformation" | "visible" | "scope"
 >;
 
 interface DependentsListQuery {
@@ -94,8 +94,6 @@ export const DependentsList = ({ query, variables }: DependentsListProps) => {
     const intl = useIntl();
     const { entityDependencyMap } = useDependenciesConfig();
     const contentScope = useContentScope();
-    const apolloClient = useApolloClient();
-    const history = useHistory();
 
     const dataGridProps = {
         ...useDataGridRemote({
@@ -107,6 +105,9 @@ export const DependentsList = ({ query, variables }: DependentsListProps) => {
         }),
         ...usePersistentColumnState("DependentsList"),
     };
+
+    // Scopes are only worth showing when the entries can actually originate from different scopes.
+    const showScopeColumn = contentScope.values.length > 1;
 
     const columns: GridColDef<DependencyItem>[] = useMemo(
         () => [
@@ -146,59 +147,36 @@ export const DependentsList = ({ query, variables }: DependentsListProps) => {
                 visible: false,
                 sortBy: "visible",
             },
+            ...(showScopeColumn
+                ? [
+                      {
+                          field: "scope",
+                          headerName: intl.formatMessage({ id: "dextinity.dependencies.dataGrid.scope", defaultMessage: "Scope" }),
+                          width: 160,
+                          filterable: false,
+                          sortable: false,
+                          valueGetter: (params, row) => (row.scope ? getContentScopeLabel({ scope: row.scope, values: contentScope.values }) : null),
+                      } satisfies GridColDef<DependencyItem>,
+                  ]
+                : []),
             {
                 field: "actions",
                 type: "actions",
                 headerName: "",
                 filterable: false,
                 sortable: false,
-                renderCell: ({ row }) => {
-                    const dependencyObject = entityDependencyMap[row.rootGraphqlObjectType] as DependencyInterface | undefined;
-
-                    if (dependencyObject === undefined) {
-                        if (process.env.NODE_ENV === "development") {
-                            console.warn(
-                                `Cannot load URL because no implementation of DependencyInterface for ${row.rootGraphqlObjectType} was provided via the DependenciesConfig`,
-                            );
-                        }
-                        return <FormattedMessage id="dextinity.dependencies.dataGrid.cannotLoadUrl" defaultMessage="Cannot determine URL" />;
-                    }
-
-                    const loadUrl = async () => {
-                        const path = await dependencyObject.resolvePath({
-                            rootColumnName: row.rootColumnName,
-                            jsonPath: row.jsonPath,
-                            apolloClient,
-                            id: row.id,
-                        });
-                        return contentScope.match.url + path;
-                    };
-
-                    return (
-                        <Box display="flex">
-                            <IconButton
-                                onClick={async () => {
-                                    const url = await loadUrl();
-                                    window.open(url, "_blank");
-                                }}
-                            >
-                                <OpenNewTab />
-                            </IconButton>
-                            <IconButton
-                                onClick={async () => {
-                                    const url = await loadUrl();
-
-                                    history.push(url);
-                                }}
-                            >
-                                <ArrowRight />
-                            </IconButton>
-                        </Box>
-                    );
-                },
+                renderCell: ({ row }) => (
+                    <DependencyActions
+                        graphqlObjectType={row.rootGraphqlObjectType}
+                        id={row.id}
+                        rootColumnName={row.rootColumnName}
+                        jsonPath={row.jsonPath}
+                        scope={row.scope ?? undefined}
+                    />
+                ),
             },
         ],
-        [intl, entityDependencyMap, apolloClient, contentScope, history],
+        [intl, entityDependencyMap, showScopeColumn, contentScope.values],
     );
 
     const { filter: gqlFilter } = muiGridFilterToGql(columns, dataGridProps.filterModel);

--- a/packages/admin/cms-admin/src/dependencies/resolveDependencyScope.test.ts
+++ b/packages/admin/cms-admin/src/dependencies/resolveDependencyScope.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import type { ContentScopeValues } from "../contentScope/Provider";
+import { resolveDependencyScope } from "./resolveDependencyScope";
+
+const availableScopes: ContentScopeValues = [{ scope: { domain: "main", language: "de" } }, { scope: { domain: "secondary", language: "en" } }];
+
+describe("resolveDependencyScope", () => {
+    it("should keep the active scope for an entry from that scope", () => {
+        expect(
+            resolveDependencyScope({
+                scope: { domain: "secondary", language: "en" },
+                activeScope: { domain: "secondary", language: "en" },
+                availableScopes,
+            }),
+        ).toEqual({ domain: "secondary", language: "en" });
+    });
+
+    it("should merge an incomplete scope into the active scope", () => {
+        expect(
+            resolveDependencyScope({
+                scope: { domain: "main" },
+                activeScope: { domain: "main", language: "de" },
+                availableScopes,
+            }),
+        ).toEqual({ domain: "main", language: "de" });
+    });
+
+    it("should use an available scope when the merged scope is not available", () => {
+        expect(
+            resolveDependencyScope({
+                scope: { domain: "main" },
+                activeScope: { domain: "secondary", language: "en" },
+                availableScopes,
+            }),
+        ).toEqual({ domain: "main", language: "de" });
+    });
+
+    it("should return undefined when no available scope contains the entry's scope", () => {
+        expect(
+            resolveDependencyScope({
+                scope: { domain: "third" },
+                activeScope: { domain: "main", language: "de" },
+                availableScopes,
+            }),
+        ).toBeUndefined();
+    });
+
+    it("should merge into the active scope when no scopes are available for comparison", () => {
+        expect(
+            resolveDependencyScope({
+                scope: { domain: "main" },
+                activeScope: { domain: "secondary", language: "en" },
+                availableScopes: [],
+            }),
+        ).toEqual({ domain: "main", language: "en" });
+    });
+});

--- a/packages/admin/cms-admin/src/dependencies/resolveDependencyScope.ts
+++ b/packages/admin/cms-admin/src/dependencies/resolveDependencyScope.ts
@@ -1,0 +1,31 @@
+import type { ContentScope, ContentScopeValues } from "../contentScope/Provider";
+import { isScopePartOf } from "../contentScope/utils/isScopePartOf";
+
+/**
+ * Determines the scope an entry must be opened in, or undefined when the user has access to none.
+ *
+ * An entry's scope can be incomplete (e.g. a DAM file scoped by domain only), which is why it is merged into the active
+ * scope instead of replacing it. Should the user have no access to that combination, the first of their scopes
+ * containing the entry's scope is used.
+ */
+export function resolveDependencyScope({
+    scope,
+    activeScope,
+    availableScopes,
+}: {
+    scope: ContentScope;
+    activeScope: ContentScope;
+    availableScopes: ContentScopeValues;
+}): ContentScope | undefined {
+    const scopeInActiveScope = { ...activeScope, ...scope };
+
+    if (availableScopes.length === 0) {
+        return scopeInActiveScope;
+    }
+
+    if (availableScopes.some(({ scope: availableScope }) => isScopePartOf(scopeInActiveScope, availableScope))) {
+        return scopeInActiveScope;
+    }
+
+    return availableScopes.find(({ scope: availableScope }) => isScopePartOf(scope, availableScope))?.scope;
+}

--- a/packages/api/brevo-api/schema.gql
+++ b/packages/api/brevo-api/schema.gql
@@ -50,6 +50,7 @@ type Dependency {
   targetId: String!
   name: String
   secondaryInformation: String
+  scope: JSONObject
 }
 
 type DamMediaAlternative {

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -91,6 +91,7 @@ type Dependency {
   targetId: String!
   name: String
   secondaryInformation: String
+  scope: JSONObject
 }
 
 type PaginatedDependencies {

--- a/packages/api/cms-api/src/dependencies/dependencies.service.ts
+++ b/packages/api/cms-api/src/dependencies/dependencies.service.ts
@@ -131,8 +131,10 @@ export class DependenciesService {
                         blockIndex."targetId",
                         ei_root."name"                                                              "rootName",
                         ei_root."secondaryInformation"                                              "rootSecondaryInformation",
+                        ei_root."scopes"->0                                                         "rootScope",
                         ei_target."name"                                                            "targetName",
-                        ei_target."secondaryInformation"                                            "targetSecondaryInformation"
+                        ei_target."secondaryInformation"                                            "targetSecondaryInformation",
+                        ei_target."scopes"->0                                                       "targetScope"
                     FROM (
                         ${indexSelects.join("\n UNION ALL \n")}
                     ) blockIndex
@@ -443,6 +445,7 @@ export class DependenciesService {
         Object.assign(result, entity);
         result.name = context === "dependents" ? entity.rootName : entity.targetName;
         result.secondaryInformation = context === "dependents" ? entity.rootSecondaryInformation : entity.targetSecondaryInformation;
+        result.scope = context === "dependents" ? entity.rootScope : entity.targetScope;
         return result;
     }
 }

--- a/packages/api/cms-api/src/dependencies/dto/dependency.ts
+++ b/packages/api/cms-api/src/dependencies/dto/dependency.ts
@@ -1,5 +1,7 @@
 import { Field, ObjectType } from "@nestjs/graphql";
+import { GraphQLJSONObject } from "graphql-scalars";
 
+import { ContentScope } from "../../user-permissions/interfaces/content-scope.interface";
 import { BaseDependencyInterface } from "./base-dependency.interface";
 
 @ObjectType()
@@ -44,4 +46,11 @@ export class Dependency implements BaseDependencyInterface {
 
     @Field({ nullable: true })
     secondaryInformation?: string;
+
+    /**
+     * Content scope of the dependent (root) resp. depended-on (target) entity. Undefined for entities without a scope
+     * and for entities whose scope cannot be resolved. Entities with multiple scopes report their first scope.
+     */
+    @Field(() => GraphQLJSONObject, { nullable: true })
+    scope?: ContentScope;
 }

--- a/packages/api/cms-api/src/dependencies/entities/block-index-dependency.object.ts
+++ b/packages/api/cms-api/src/dependencies/entities/block-index-dependency.object.ts
@@ -1,5 +1,7 @@
 import { Entity, PrimaryKey, Property } from "@mikro-orm/core";
 
+import { ContentScope } from "../../user-permissions/interfaces/content-scope.interface";
+
 // Note: This file is intentionally not named *.entity.ts to exclude it from MikroORM's CLI migration glob pattern.
 // The "block_index_dependencies" materialized view is created dynamically at startup by DependenciesService, not via migrations.
 
@@ -59,9 +61,15 @@ export class BlockIndexDependencyObject {
     @Property({ type: "text", nullable: true })
     rootSecondaryInformation?: string;
 
+    @Property({ type: "jsonb", nullable: true })
+    rootScope?: ContentScope;
+
     @Property({ type: "text", nullable: true })
     targetName?: string;
 
     @Property({ type: "text", nullable: true })
     targetSecondaryInformation?: string;
+
+    @Property({ type: "jsonb", nullable: true })
+    targetScope?: ContentScope;
 }

--- a/packages/api/cms-api/src/entity-info/entity-info.service.ts
+++ b/packages/api/cms-api/src/entity-info/entity-info.service.ts
@@ -1,12 +1,15 @@
-import { AnyEntity, EntityManager } from "@mikro-orm/postgresql";
+import { AnyEntity, EntityManager, EntityMetadata } from "@mikro-orm/postgresql";
 import { Injectable, Logger } from "@nestjs/common";
 
 import { DiscoverService } from "../dependencies/discover.service";
+import { PAGE_TREE_ENTITY } from "../page-tree/page-tree.constants";
 import { REQUIRED_PERMISSION_METADATA_KEY, RequiredPermissionMetadata } from "../user-permissions/decorators/required-permission.decorator";
+import { SCOPED_ENTITY_METADATA_KEY, ScopedEntityMeta } from "../user-permissions/decorators/scoped-entity.decorator";
 import { ENTITY_INFO_METADATA_KEY, EntityInfo } from "./entity-info.decorator";
 import { EntityInfoObject } from "./entity-info.object";
 import { isEntityInfoSql, requiredPermissionToSql } from "./entity-info.utils";
 import { resolveFieldToSql } from "./resolve-field-to-sql";
+import { NO_SCOPES_SQL, resolveScopesToSql } from "./resolve-scopes-to-sql";
 
 @Injectable()
 export class EntityInfoService {
@@ -33,8 +36,18 @@ export class EntityInfoService {
                     | undefined;
                 const requiredPermissionSql = requiredPermissionToSql(permissionMetadata?.requiredPermission);
 
+                const { metadata } = targetEntity;
+                const scopesSql = this.resolveScopesSql(targetEntity);
+
+                // The raw SQL may select from a dedicated view that doesn't know about the entity's scope. Join the
+                // entity's own table (on the id the SQL is required to return) to resolve the scope from it.
+                const scopeJoin =
+                    scopesSql === NO_SCOPES_SQL
+                        ? ""
+                        : ` LEFT JOIN "${metadata.tableName}" ON "${metadata.tableName}"."${metadata.primaryKeys[0]}"::text = sub."id"`;
+
                 indexSelects.push(
-                    `SELECT sub."name", sub."secondaryInformation", sub."visible", sub."id", sub."entityName", ${requiredPermissionSql} AS "requiredPermission" FROM (${sql}) sub`,
+                    `SELECT sub."name", sub."secondaryInformation", sub."visible", sub."id", sub."entityName", ${requiredPermissionSql} AS "requiredPermission", ${scopesSql} AS "scopes" FROM (${sql}) sub${scopeJoin}`,
                 );
             } else {
                 const { entityName, metadata } = targetEntity;
@@ -72,16 +85,27 @@ export class EntityInfoService {
                                 ${visibleSql} AS "visible",
                                 "${metadata.tableName}"."${primary}"::text "id",
                                 '${entityName}' "entityName",
-                                ${requiredPermissionSql} AS "requiredPermission"
+                                ${requiredPermissionSql} AS "requiredPermission",
+                                ${this.resolveScopesSql(targetEntity)} AS "scopes"
                             FROM "${metadata.tableName}"`;
                 indexSelects.push(select);
             }
         }
 
         // add all PageTreeNode Documents (Page, Link etc) thru PageTreeNodeDocument (no @EntityInfo needed on Page/Link)
-        indexSelects.push(`SELECT "PageTreeNodeEntityInfo"."name", "PageTreeNodeEntityInfo"."secondaryInformation", "PageTreeNodeEntityInfo"."visible", "PageTreeNodeDocument"."documentId"::text "id", "type" "entityName", ARRAY['pageTree']::text[] AS "requiredPermission"
+        // Documents are scoped by their page tree node, which is why the scope is resolved from it instead of from the
+        // document entity (whose @ScopedEntity is a service and therefore not convertible to SQL).
+        const pageTreeNode = targetEntities.find((targetEntity) => targetEntity.metadata.tableName === PAGE_TREE_ENTITY);
+        const pageTreeNodeScopesSql = pageTreeNode ? this.resolveScopesSql(pageTreeNode) : NO_SCOPES_SQL;
+        const pageTreeNodeScopeJoin =
+            pageTreeNodeScopesSql === NO_SCOPES_SQL
+                ? ""
+                : `LEFT JOIN "${PAGE_TREE_ENTITY}" ON "${PAGE_TREE_ENTITY}"."id" = "PageTreeNodeDocument"."pageTreeNodeId"`;
+
+        indexSelects.push(`SELECT "PageTreeNodeEntityInfo"."name", "PageTreeNodeEntityInfo"."secondaryInformation", "PageTreeNodeEntityInfo"."visible", "PageTreeNodeDocument"."documentId"::text "id", "type" "entityName", ARRAY['pageTree']::text[] AS "requiredPermission", ${pageTreeNodeScopesSql} AS "scopes"
             FROM "PageTreeNodeDocument"
             JOIN "PageTreeNodeEntityInfo" ON "PageTreeNodeEntityInfo"."id" = "PageTreeNodeDocument"."pageTreeNodeId"::text
+            ${pageTreeNodeScopeJoin}
         `);
 
         const viewSql = indexSelects.join("\n UNION ALL \n");
@@ -90,6 +114,14 @@ export class EntityInfoService {
         await this.entityManager.getConnection().execute(`DROP VIEW IF EXISTS "EntityInfo"`);
         await this.entityManager.getConnection().execute(`CREATE VIEW "EntityInfo" AS ${viewSql}`);
         console.timeEnd("creating EntityInfo view");
+    }
+
+    private resolveScopesSql(targetEntity: { entity: AnyEntity; metadata: EntityMetadata }): string {
+        const scopedEntity = Reflect.getMetadata(SCOPED_ENTITY_METADATA_KEY, targetEntity.entity) as ScopedEntityMeta | undefined;
+
+        // The EntityInfo view is created on every application start, so an entity whose scope cannot be resolved must
+        // not break the view creation. It contributes no scope instead.
+        return resolveScopesToSql({ metadata: targetEntity.metadata, scopedEntity, onUnsupported: "null" });
     }
 
     async dropEntityInfoView() {

--- a/packages/api/cms-api/src/entity-info/resolve-scopes-to-sql.spec.ts
+++ b/packages/api/cms-api/src/entity-info/resolve-scopes-to-sql.spec.ts
@@ -144,5 +144,12 @@ describe("resolveScopesToSql", () => {
                 /cannot be converted to SQL/,
             );
         });
+
+        it("returns NULL::jsonb instead of throwing when onUnsupported is null", () => {
+            expect(resolveScopesToSql({ metadata: metadataFor("NewsComment"), scopedEntity: () => ({}), onUnsupported: "null" })).toBe("NULL::jsonb");
+            expect(resolveScopesToSql({ metadata: metadataFor("NewsComment"), scopedEntity: NewsCommentScopeService, onUnsupported: "null" })).toBe(
+                "NULL::jsonb",
+            );
+        });
     });
 });

--- a/packages/api/cms-api/src/entity-info/resolve-scopes-to-sql.ts
+++ b/packages/api/cms-api/src/entity-info/resolve-scopes-to-sql.ts
@@ -4,15 +4,30 @@ import { isEntityScopeMapping, type ScopedEntityMeta, type SingleEntityScopeMapp
 import { resolveFieldToSql } from "./resolve-field-to-sql";
 
 /**
+ * SQL expression used when an entity's scope cannot be determined (no scope at all, or a `@ScopedEntity` that cannot
+ * be converted to SQL).
+ */
+export const NO_SCOPES_SQL = "NULL::jsonb";
+
+/**
  * Resolves the scope(s) of an entity to a SQL expression returning a `jsonb` array of scopes (or `NULL::jsonb`).
  *
  * The scopes are taken from (in order of precedence):
  * 1. a `scope` property on the entity (simple case)
  * 2. a SQL-convertible `@ScopedEntity` mapping (string field path, object mapping, or an array of these for multiple scopes)
  *
- * A callback or service `@ScopedEntity` cannot be converted to SQL and therefore throws.
+ * A callback or service `@ScopedEntity` cannot be converted to SQL. Depending on `onUnsupported`, this either throws
+ * (default) or resolves to `NULL::jsonb`, which is used where a missing scope must not break the view creation.
  */
-export function resolveScopesToSql({ metadata, scopedEntity }: { metadata: EntityMetadata; scopedEntity: ScopedEntityMeta | undefined }): string {
+export function resolveScopesToSql({
+    metadata,
+    scopedEntity,
+    onUnsupported = "throw",
+}: {
+    metadata: EntityMetadata;
+    scopedEntity: ScopedEntityMeta | undefined;
+    onUnsupported?: "throw" | "null";
+}): string {
     const scopeProp = metadata.props.find((prop) => prop.name === "scope");
     if (scopeProp) {
         return `jsonb_build_array(${scopePropertyToJsonbSql(scopeProp, metadata.tableName)})`;
@@ -20,6 +35,10 @@ export function resolveScopesToSql({ metadata, scopedEntity }: { metadata: Entit
 
     if (scopedEntity) {
         if (!isEntityScopeMapping(scopedEntity)) {
+            if (onUnsupported === "null") {
+                return NO_SCOPES_SQL;
+            }
+
             throw new Error(
                 `Entity "${metadata.className}" uses a @ScopedEntity callback or service that cannot be converted to SQL, which the FullTextSearchModule requires. ` +
                     `Use the field-path string (e.g. @ScopedEntity("company.scope")) or the object mapping (e.g. @ScopedEntity({ companyId: "company.id" })) variant instead.`,
@@ -30,7 +49,7 @@ export function resolveScopesToSql({ metadata, scopedEntity }: { metadata: Entit
         return `jsonb_build_array(${scopeSqls.join(", ")})`;
     }
 
-    return "NULL::jsonb";
+    return NO_SCOPES_SQL;
 }
 
 function resolveScopeMappingToSql(mapping: SingleEntityScopeMapping, metadata: EntityMetadata, tableName: string): string {


### PR DESCRIPTION
## Problem

Entities can be used across scopes. The common case is a DAM that is shared between several sites, so one file is used by pages living in different content scopes.

The "Dependents" and "Dependencies" lists built their links from the **currently active** scope: `resolvePath()` deliberately returns a scope-less path, and the lists prefixed it with `contentScope.match.url`. Opening an entry that belongs to another scope therefore led to a wrong or non-existent page.

## Solution

The API delivers the scope of each entry, and the lists use it to build the link. The `EntityInfo` view gets a `scopes` column, resolved with the existing `resolveScopesToSql()` (from the entity's `scope` property or its `@ScopedEntity()` decorator). `block_index_dependencies` picks the scope up from the joins it already has (`ei_root`/`ei_target`), and `Dependency` exposes it as a nullable `scope` field.

In the Admin, `resolveDependencyScope()` determines which scope to open: the entry's scope merged into the active one — merging rather than replacing is what makes incomplete scopes work, so a DAM file scoped by `domain` only keeps the active `language` — or, when the user has no access to that combination, the first of their scopes containing the entry's scope. An entry whose scope matches none of the user's scopes is not linked at all. A "Scope" column is shown when the project has more than one scope.

Both lists take their query from the outside, so projects have to request the new field. Without it, the links keep today's behavior instead of breaking:

```diff
  dependents(offset: $offset, limit: $limit, forceRefresh: $forceRefresh, filter: $filter, sort: $sort) {
      nodes {
          rootGraphqlObjectType
          rootId
          rootColumnName
          jsonPath
          name
          secondaryInformation
          visible
+         scope
      }
      totalCount
  }
```

## Screencasts

Same setup: a DAM asset is used both on the English and the German homepage.

**Before:** the link to the German homepage doesn't resolve.

https://github.com/user-attachments/assets/3fc50b6b-5347-4427-9e36-4398765e11bb

**After:** the link to the German homepage resolves.

https://github.com/user-attachments/assets/2692325b-36a1-4cb5-af2b-601418d0cd60

## Performance

I let Claude analyze the performance impact of adding the scope to the views:

- Refresh of `block_index_dependencies` takes about **22%** longer
- Size of the views increases by **28%**
- Reading the view remains unchanged

IMO we can accept the increases since they only affect the write path.

<details>
<summary>Performance analysis</summary>

The change touches a materialized view, so here are numbers. Both view definitions were run interleaved in one session on the same data (Demo: 8,757 dependency rows, 9,243 `EntityInfo` rows).

**Refresh of `block_index_dependencies`** — the recurring cost, at most every 5 minutes and in the background:

| | runs | mean |
| --- | --- | --- |
| before | 3.50 / 3.64 / 3.74 s | 3.63 s |
| after | 4.42 / 4.49 / 4.51 s | 4.47 s |

**+0.85 s (≈ +22%).** A third variant (new `EntityInfo`, old column list in the materialized view) splits it up: **+0.18 s (≈5%)** for the two extra `LEFT JOIN`s in `EntityInfo` (`DamFile`, `PageTreeNode`, both on primary keys), **+0.66 s (≈17%)** for materializing the two `jsonb` columns. The cost is in writing the columns, not in resolving the scopes.

**Size**: matview heap 2184 kB → 2792 kB (**+608 kB, +28%**; +23% counting the two indexes, which are unchanged). That is **~70 bytes per dependency row** — `pg_column_size` averages 31 B for `rootScope` and 41 B for `targetScope`, plus row overhead.

**Read path: unchanged.** The query the lists actually run (filter on `targetEntityName`/`targetId`, order, `LIMIT 25`) measured 2.56 ms before and 2.60 ms after. The extra bytes live on disk and in the page cache, not in the API process — a request still materializes only its page of 25 rows.

Both numbers scale linearly with the number of dependency rows: a project whose refresh takes 60 s today would land at roughly 73 s, a 100 MB matview at roughly 123 MB. The alternative — resolving the scope per request instead of materializing it — would trade a background cost for a foreground one, and `EntityInfo` is expensive to evaluate ad hoc (a UNION over every entity, including the recursive DAM folder-path CTE), which is exactly why it is pre-joined into this view in the first place. If the refresh cost ever becomes a problem, the lever is the refresh cadence rather than this column.

</details>

## Design decisions

- Entities using a `@ScopedEntity()` **callback or service** report no scope, as it cannot be resolved in SQL. Those entries keep linking into the active scope. Switching such an entity to the field-path (`@ScopedEntity("company.scope")`) or object-mapping (`@ScopedEntity({ companyId: "company.id" })`) variant makes its scope available.
- Entities with multiple scopes (an array `@ScopedEntity`) report their first scope.

## Related PRs

An Admin-only solution was tried in https://github.com/vivid-planet/dextinity/pull/2493 but never completed.

## Further information

Task: https://vivid-planet.atlassian.net/browse/DEX-3135

https://claude.ai/code/session_01UPHi52TAjb3P9aM5DX8ReX