### PR TITLE
mail-react: Fix the size of rounded images in classic Outlook

### DIFF
--- a/.changeset/outlook-vml-shape-reserved-pixel.md
+++ b/.changeset/outlook-vml-shape-reserved-pixel.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/mail-react": patch
+---
+
+Fix rounded images rendering a pixel too large in classic Outlook
+
+Two images side by side made their section wider than the body width. Affects `MjmlImage`, `HtmlImage`, `MjmlPixelImageBlock` and `HtmlPixelImageBlock`.

--- a/packages/mail-react/src/blocks/pixelImage/__tests__/MjmlPixelImageBlock.test.tsx
+++ b/packages/mail-react/src/blocks/pixelImage/__tests__/MjmlPixelImageBlock.test.tsx
@@ -33,6 +33,6 @@ describe("MjmlPixelImageBlock", () => {
             </MjmlMailRoot>,
         );
 
-        expect(html).toMatch(/<v:roundrect[^>]*style="width:300px;height:200px;"/);
+        expect(html).toMatch(/<v:roundrect[^>]*style="width:299px;height:199px;"/);
     });
 });

--- a/packages/mail-react/src/components/image/__tests__/outlookVml.test.ts
+++ b/packages/mail-react/src/components/image/__tests__/outlookVml.test.ts
@@ -5,6 +5,12 @@ import { generateOutlookImageVml } from "../outlookVml.js";
 const image = { src: "image.jpg", width: 400, height: 200 };
 
 describe("generateOutlookImageVml", () => {
+    it("declares the shape a pixel smaller than the image, to leave room for the stroke Outlook reserves", () => {
+        const vml = generateOutlookImageVml({ ...image, borderRadius: 20 });
+
+        expect(vml).toContain(`style="width:399px;height:199px;"`);
+    });
+
     it("measures arcsize against the whole shorter side", () => {
         const vml = generateOutlookImageVml({ ...image, borderRadius: 20 });
 

--- a/packages/mail-react/src/components/image/outlookVml.ts
+++ b/packages/mail-react/src/components/image/outlookVml.ts
@@ -28,11 +28,14 @@ export function generateOutlookImageVml({ src, width, height, borderRadius, alt,
         return null;
     }
 
+    const declaredWidth = subtractReservedStroke(widthInPixels);
+    const declaredHeight = subtractReservedStroke(heightInPixels);
+
     const attributes = formatAttributes({
         "xmlns:v": "urn:schemas-microsoft-com:vml",
-        arcsize: shape.name === "v:roundrect" ? calculateArcsize(shape.radius, widthInPixels, heightInPixels) : undefined,
+        arcsize: shape.name === "v:roundrect" ? calculateArcsize(shape.radius, declaredWidth, declaredHeight) : undefined,
         stroked: "f",
-        style: `width:${widthInPixels}px;height:${heightInPixels}px;`,
+        style: `width:${declaredWidth}px;height:${declaredHeight}px;`,
         href,
         alt,
     });
@@ -63,6 +66,11 @@ function parsePixelLength(value: string | number | undefined): number | null {
     }
 
     return pixels !== null && Number.isFinite(pixels) && pixels > 0 ? pixels : null;
+}
+
+/** Classic Outlook lays a shape out one pixel wider and taller than the size it declares. */
+function subtractReservedStroke(lengthInPixels: number): number {
+    return Math.max(lengthInPixels - 1, 1);
 }
 
 /**


### PR DESCRIPTION
Outlook renders the shape one pixel wider and taller than the size it is given, so it is given one pixel less. The extra pixel appears to be the shape's stroke, which defaults to one pixel and sits outside the declared size; switching the stroke off does not release it.

| Before (Outlook Office 365 Windows 10) | Now (Outlook Office 365 Windows 10) |
|--------|--------|
| <img width="630" height="1265" alt="1px bug before" src="https://github.com/user-attachments/assets/22613da7-8a09-495c-a486-af9495db785e" /> | <img width="630" height="1265" alt="1px bug after" src="https://github.com/user-attachments/assets/f535e259-f538-4062-804c-4d5d8e20fa1e" /> | 

---

Task: https://vivid-planet.atlassian.net/browse/PHSB2C-13931