### PR TITLE
Preserve DAM video block playback settings when no file is selected

### DIFF
--- a/.changeset/dam-video-block-keep-playback-settings-without-file.md
+++ b/.changeset/dam-video-block-keep-playback-settings-without-file.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/cms-admin": patch
+---
+
+Fix the DAM video block losing its playback settings when no video file is selected
+
+`output2State` dropped `autoplay`, `loop` and `showControls` when the block had no `damFileId`, so the stored playback settings were reset as soon as the video file was removed.

--- a/packages/admin/cms-admin/src/blocks/createDamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createDamVideoBlock.tsx
@@ -77,7 +77,12 @@ export const createDamVideoBlock = (
 
         output2State: async (output, context) => {
             if (!output.damFileId) {
-                return { previewImage: await PixelImageBlock.output2State(output.previewImage, context) };
+                return {
+                    autoplay: output.autoplay,
+                    loop: output.loop,
+                    showControls: output.showControls,
+                    previewImage: await PixelImageBlock.output2State(output.previewImage, context),
+                };
             }
 
             const { data } = await context.apolloClient.query<GQLVideoBlockDamFileQuery, GQLVideoBlockDamFileQueryVariables>({


### PR DESCRIPTION
Found as side-effect in a [CodeRabbit review](https://github.com/vivid-planet/dextinity/pull/6224#pullrequestreview-5008098422): the DAM video block doesn't set `autoplay`, `loop`, and `showControls` in `output2State` when no file is selected.

https://claude.ai/code/session_01TH95t96kpJTd7rPjqddWs4