### PR TITLE
Track video block preview images as block dependencies

### DIFF
--- a/.changeset/dam-video-block-preview-image-dependencies.md
+++ b/.changeset/dam-video-block-preview-image-dependencies.md
@@ -1,0 +1,8 @@
+---
+"@dextinity/cms-admin": patch
+---
+
+Track the preview image of the video blocks as a block dependency
+
+`createDamVideoBlock`, `YouTubeVideoBlock` and `VimeoVideoBlock` didn't report the DAM file used as preview image as a dependency, so it showed no usages and its ID wasn't remapped when copying pages between scopes, leaving a dangling reference.
+The blocks now delegate to `PixelImageBlock` for the preview image. `createDamVideoBlock` merges the result with the dependency of its own video file.

--- a/packages/admin/cms-admin/src/blocks/VimeoVideoBlock.test.tsx
+++ b/packages/admin/cms-admin/src/blocks/VimeoVideoBlock.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { VimeoVideoBlock } from "./VimeoVideoBlock";
+
+const previewImageDamFile = {
+    id: "image-1",
+    name: "preview.png",
+    size: 100,
+    mimetype: "image/png",
+    contentHash: "image-hash",
+    archived: false,
+    fileUrl: "https://example.com/preview.png",
+};
+
+describe("VimeoVideoBlock", () => {
+    describe("dependencies", () => {
+        it("should return the preview image", () => {
+            expect(VimeoVideoBlock.dependencies?.({ previewImage: { damFile: previewImageDamFile } })).toEqual([
+                { targetGraphqlObjectType: "DamFile", id: "image-1", data: { damFile: previewImageDamFile } },
+            ]);
+        });
+
+        it("should return no dependencies without a preview image", () => {
+            expect(VimeoVideoBlock.dependencies?.({ previewImage: {} })).toEqual([]);
+        });
+    });
+
+    describe("replaceDependenciesInOutput", () => {
+        it("should replace the preview image file", () => {
+            expect(
+                VimeoVideoBlock.replaceDependenciesInOutput({ vimeoIdentifier: "76979871", previewImage: { damFileId: "image-1" } }, [
+                    { type: "DamFile", originalId: "image-1", replaceWithId: "image-2" },
+                ]),
+            ).toEqual({ vimeoIdentifier: "76979871", previewImage: { damFileId: "image-2" } });
+        });
+
+        it("should keep the id without a replacement", () => {
+            expect(VimeoVideoBlock.replaceDependenciesInOutput({ vimeoIdentifier: "76979871", previewImage: { damFileId: "image-1" } }, [])).toEqual({
+                vimeoIdentifier: "76979871",
+                previewImage: { damFileId: "image-1" },
+            });
+        });
+    });
+});

--- a/packages/admin/cms-admin/src/blocks/VimeoVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/VimeoVideoBlock.tsx
@@ -61,6 +61,13 @@ export const VimeoVideoBlock: BlockInterface<VimeoVideoBlockData, State, VimeoVi
         };
     },
 
+    dependencies: (state) => PixelImageBlock.dependencies?.(state.previewImage) ?? [],
+
+    replaceDependenciesInOutput: (output, replacements) => ({
+        ...output,
+        previewImage: PixelImageBlock.replaceDependenciesInOutput(output.previewImage, replacements),
+    }),
+
     definesOwnPadding: true,
 
     isValid: ({ vimeoIdentifier }) => !vimeoIdentifier || isValidVimeoIdentifier(vimeoIdentifier),

--- a/packages/admin/cms-admin/src/blocks/YouTubeVideoBlock.test.tsx
+++ b/packages/admin/cms-admin/src/blocks/YouTubeVideoBlock.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { YouTubeVideoBlock } from "./YouTubeVideoBlock";
+
+const previewImageDamFile = {
+    id: "image-1",
+    name: "preview.png",
+    size: 100,
+    mimetype: "image/png",
+    contentHash: "image-hash",
+    archived: false,
+    fileUrl: "https://example.com/preview.png",
+};
+
+describe("YouTubeVideoBlock", () => {
+    describe("dependencies", () => {
+        it("should return the preview image", () => {
+            expect(YouTubeVideoBlock.dependencies?.({ previewImage: { damFile: previewImageDamFile } })).toEqual([
+                { targetGraphqlObjectType: "DamFile", id: "image-1", data: { damFile: previewImageDamFile } },
+            ]);
+        });
+
+        it("should return no dependencies without a preview image", () => {
+            expect(YouTubeVideoBlock.dependencies?.({ previewImage: {} })).toEqual([]);
+        });
+    });
+
+    describe("replaceDependenciesInOutput", () => {
+        it("should replace the preview image file", () => {
+            expect(
+                YouTubeVideoBlock.replaceDependenciesInOutput({ youtubeIdentifier: "dQw4w9WgXcQ", previewImage: { damFileId: "image-1" } }, [
+                    { type: "DamFile", originalId: "image-1", replaceWithId: "image-2" },
+                ]),
+            ).toEqual({ youtubeIdentifier: "dQw4w9WgXcQ", previewImage: { damFileId: "image-2" } });
+        });
+
+        it("should keep the id without a replacement", () => {
+            expect(
+                YouTubeVideoBlock.replaceDependenciesInOutput({ youtubeIdentifier: "dQw4w9WgXcQ", previewImage: { damFileId: "image-1" } }, []),
+            ).toEqual({ youtubeIdentifier: "dQw4w9WgXcQ", previewImage: { damFileId: "image-1" } });
+        });
+    });
+});

--- a/packages/admin/cms-admin/src/blocks/YouTubeVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/YouTubeVideoBlock.tsx
@@ -61,6 +61,13 @@ export const YouTubeVideoBlock: BlockInterface<YouTubeVideoBlockData, State, You
         };
     },
 
+    dependencies: (state) => PixelImageBlock.dependencies?.(state.previewImage) ?? [],
+
+    replaceDependenciesInOutput: (output, replacements) => ({
+        ...output,
+        previewImage: PixelImageBlock.replaceDependenciesInOutput(output.previewImage, replacements),
+    }),
+
     definesOwnPadding: true,
 
     isValid: ({ youtubeIdentifier }) => !youtubeIdentifier || isValidYouTubeIdentifier(youtubeIdentifier),

--- a/packages/admin/cms-admin/src/blocks/createDamVideoBlock.test.tsx
+++ b/packages/admin/cms-admin/src/blocks/createDamVideoBlock.test.tsx
@@ -1,6 +1,31 @@
 import { describe, expect, it } from "vitest";
 
-import { createDamVideoBlock } from "./createDamVideoBlock";
+import { createDamVideoBlock, type DamVideoBlockState } from "./createDamVideoBlock";
+
+const videoDamFile = {
+    id: "video-1",
+    name: "video.mp4",
+    size: 1000,
+    mimetype: "video/mp4",
+    contentHash: "video-hash",
+    archived: false,
+    fileUrl: "https://example.com/video.mp4",
+};
+
+const previewImageDamFile = {
+    id: "image-1",
+    name: "preview.png",
+    size: 100,
+    mimetype: "image/png",
+    contentHash: "image-hash",
+    archived: false,
+    fileUrl: "https://example.com/preview.png",
+};
+
+const createState = (state: Partial<DamVideoBlockState> = {}): DamVideoBlockState => ({
+    previewImage: {},
+    ...state,
+});
 
 describe("createDamVideoBlock", () => {
     it("should create a block named DamVideo", () => {
@@ -15,5 +40,53 @@ describe("createDamVideoBlock", () => {
         const block = createDamVideoBlock({}, (block) => ({ ...block, name: "MyCustomDamVideo" }));
 
         expect(block.name).toBe("MyCustomDamVideo");
+    });
+
+    describe("dependencies", () => {
+        it("should return the video file and the preview image", () => {
+            const block = createDamVideoBlock();
+
+            expect(block.dependencies?.(createState({ damFile: videoDamFile, previewImage: { damFile: previewImageDamFile } }))).toEqual([
+                { targetGraphqlObjectType: "DamFile", id: "video-1", data: { damFile: videoDamFile } },
+                { targetGraphqlObjectType: "DamFile", id: "image-1", data: { damFile: previewImageDamFile } },
+            ]);
+        });
+
+        it("should return the preview image even when no video file is set", () => {
+            const block = createDamVideoBlock();
+
+            expect(block.dependencies?.(createState({ previewImage: { damFile: previewImageDamFile } }))).toEqual([
+                { targetGraphqlObjectType: "DamFile", id: "image-1", data: { damFile: previewImageDamFile } },
+            ]);
+        });
+
+        it("should return no dependencies for an empty block", () => {
+            const block = createDamVideoBlock();
+
+            expect(block.dependencies?.(createState())).toEqual([]);
+        });
+    });
+
+    describe("replaceDependenciesInOutput", () => {
+        it("should replace the video file and the preview image file", () => {
+            const block = createDamVideoBlock();
+
+            expect(
+                block.replaceDependenciesInOutput({ damFileId: "video-1", previewImage: { damFileId: "image-1" } }, [
+                    { type: "DamFile", originalId: "video-1", replaceWithId: "video-2" },
+                    { type: "DamFile", originalId: "image-1", replaceWithId: "image-2" },
+                ]),
+            ).toEqual({ damFileId: "video-2", previewImage: { damFileId: "image-2" } });
+        });
+
+        it("should keep ids without a replacement", () => {
+            const block = createDamVideoBlock();
+
+            expect(
+                block.replaceDependenciesInOutput({ damFileId: "video-1", previewImage: { damFileId: "image-1" } }, [
+                    { type: "DamFile", originalId: "image-1", replaceWithId: "image-2" },
+                ]),
+            ).toEqual({ damFileId: "video-1", previewImage: { damFileId: "image-2" } });
+        });
     });
 });

--- a/packages/admin/cms-admin/src/blocks/createDamVideoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createDamVideoBlock.tsx
@@ -133,6 +133,8 @@ export const createDamVideoBlock = (
                 });
             }
 
+            dependencies.push(...(PixelImageBlock.dependencies?.(state.previewImage) ?? []));
+
             return dependencies;
         },
 
@@ -143,6 +145,8 @@ export const createDamVideoBlock = (
             if (replacement) {
                 clonedOutput.damFileId = replacement.replaceWithId;
             }
+
+            clonedOutput.previewImage = PixelImageBlock.replaceDependenciesInOutput(output.previewImage, replacements);
 
             return clonedOutput;
         },


### PR DESCRIPTION
Found as side-effect in a [CodeRabbit review](https://github.com/vivid-planet/dextinity/pull/6224#pullrequestreview-5008098422): the video blocks don't consider preview images for dependencies. Add `previewImage`-handling to `dependencies` and `replaceDependenciesInOutput` in all three blocks.

https://claude.ai/code/session_01WyDHe3xZfqePJotRS5RSLc