### PR TITLE
Make `TipTapNode` compatible with TipTap's `JSONContent`

### DIFF
--- a/.changeset/tiptap-node-json-content-compat.md
+++ b/.changeset/tiptap-node-json-content-compat.md
@@ -6,7 +6,7 @@
 
 Make the generated `TipTapNode` type compatible with TipTap's `JSONContent`
 
-`TipTapNode["type"]` is optional now, matching `JSONContent["type"]`. Both types can be used interchangeably, so no cast is needed when passing a rich text block's content to a TipTap utility or when rendering a `JSONContent` value with `renderTipTapRichText`.
+`TipTapNode["type"]` is optional now, matching `JSONContent["type"]`. Both types can be used interchangeably, so no cast is needed when passing a rich text block's content to a TipTap utility or when rendering a `JSONContent` value with `renderTipTapRichText`. `renderTipTapRichText` renders a node without a `type` as a text node.
 
 **Example**
 

--- a/.changeset/tiptap-node-json-content-compat.md
+++ b/.changeset/tiptap-node-json-content-compat.md
@@ -1,0 +1,20 @@
+---
+"@dextinity/cli": patch
+"@dextinity/site-react": patch
+"@dextinity/site-nextjs": patch
+---
+
+Make the generated `TipTapNode` type compatible with TipTap's `JSONContent`
+
+`TipTapNode["type"]` is optional now, matching `JSONContent["type"]`. Both types can be used interchangeably, so no cast is needed when passing a rich text block's content to a TipTap utility or when rendering a `JSONContent` value with `renderTipTapRichText`.
+
+**Example**
+
+```ts
+import { generateHTML } from "@tiptap/core";
+import type { TipTapRichTextBlockData } from "@src/blocks.generated";
+
+function renderToHtml(data: TipTapRichTextBlockData) {
+    return generateHTML(data.tipTapContent, extensions);
+}
+```

--- a/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
+++ b/docs/docs/2-core-concepts/2-blocks/tiptap-rich-text-block.mdx
@@ -111,7 +111,6 @@ import {
     type PropsWithData,
     renderTipTapRichText,
     type TipTapMarkHandler,
-    type TipTapNode,
     type TipTapNodeHandler,
 } from "@dextinity/site-nextjs";
 import { LinkBlockData, TipTapRichTextBlockData } from "@src/blocks.generated";
@@ -131,7 +130,7 @@ const markMapping: Record<string, TipTapMarkHandler> = {
 };
 
 export function TipTapRichTextBlock({ data }: PropsWithData<TipTapRichTextBlockData>) {
-    const content = data.tipTapContent as TipTapNode;
+    const content = data.tipTapContent;
     return (
         <PreviewSkeleton
             title="RichText"
@@ -148,7 +147,8 @@ export function TipTapRichTextBlock({ data }: PropsWithData<TipTapRichTextBlockD
 
 :::note
 
-The generated type `TipTapRichTextBlockData.tipTapContent` is `unknown` on the site. Cast it to `TipTapNode` before passing it to `renderTipTapRichText`.
+`TipTapNode` is structurally compatible with TipTap's own `JSONContent` type.
+A `JSONContent` value can be rendered with `renderTipTapRichText`, and the block data can be passed to TipTap utilities such as `generateHTML()` — no cast needed in either direction.
 
 :::
 

--- a/packages/cli/src/commands/generate-block-types.ts
+++ b/packages/cli/src/commands/generate-block-types.ts
@@ -12,8 +12,11 @@ const tipTapNodeType = `export interface TipTapMark {
     attrs?: Record<string, unknown>;
 }
 
+/**
+ * Structurally compatible with TipTap's \`JSONContent\` type, meaning \`TipTapNode\` and \`JSONContent\` values can be used interchangeably.
+ */
 export interface TipTapNode {
-    type: string;
+    type?: string;
     attrs?: Record<string, unknown>;
     content?: TipTapNode[];
     marks?: TipTapMark[];

--- a/packages/site/site-react/src/blocks/helpers/TipTapRichTextRenderer.tsx
+++ b/packages/site/site-react/src/blocks/helpers/TipTapRichTextRenderer.tsx
@@ -86,7 +86,7 @@ export function renderTipTapRichText({ content, nodeMapping, markMapping }: Rend
             return <>{renderedChildren}</>;
         }
 
-        const handler = mergedNodeMapping[node.type];
+        const handler = node.type ? mergedNodeMapping[node.type] : undefined;
         const rendered = handler ? handler({ node, parent, children: renderedChildren }) : <>{renderedChildren}</>;
         return applyMarks(rendered, node);
     };

--- a/packages/site/site-react/src/blocks/helpers/TipTapRichTextRenderer.tsx
+++ b/packages/site/site-react/src/blocks/helpers/TipTapRichTextRenderer.tsx
@@ -73,7 +73,7 @@ export function renderTipTapRichText({ content, nodeMapping, markMapping }: Rend
     };
 
     const renderNode = (node: TipTapNode, parent: TipTapNode | undefined): ReactNode => {
-        if (node.type === "text") {
+        if (!node.type || node.type === "text") {
             return applyMarks(node.text ?? "", node);
         }
 
@@ -86,7 +86,7 @@ export function renderTipTapRichText({ content, nodeMapping, markMapping }: Rend
             return <>{renderedChildren}</>;
         }
 
-        const handler = node.type ? mergedNodeMapping[node.type] : undefined;
+        const handler = mergedNodeMapping[node.type];
         const rendered = handler ? handler({ node, parent, children: renderedChildren }) : <>{renderedChildren}</>;
         return applyMarks(rendered, node);
     };


### PR DESCRIPTION
Alternative to https://github.com/vivid-planet/dextinity/pull/6328: align our `TipTapNode` type with TipTap's `JSONContent` so they can be used interchangeably, thereby removing the need for casts. The only change necessary is to make `TipTapNode["type"]` optional. Nodes without a `type` a rendered as text nodes.

https://claude.ai/code/session_019bBn1E2QvimLePQuVg39Uf