### PR TITLE
Implement extractTextContents in SEO block

### DIFF
--- a/.changeset/seo-block-extract-text-contents.md
+++ b/.changeset/seo-block-extract-text-contents.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/cms-admin": patch
+---
+
+Implement `extractTextContents` in the SEO block
+
+The SEO block only extracted the text contents of the Open Graph image, so its own texts (HTML title, meta description, Open Graph title and description) were missing wherever block text contents are used, e.g., for SEO text generation.

--- a/packages/admin/cms-admin/src/blocks/createSeoBlock.test.tsx
+++ b/packages/admin/cms-admin/src/blocks/createSeoBlock.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { createSeoBlock } from "./createSeoBlock";
+import { createBlockSkeleton } from "./helpers/createBlockSkeleton";
+import type { BlockInterface } from "./types";
+
+interface ImageBlockState {
+    altText?: string;
+}
+
+const ImageBlock: BlockInterface<ImageBlockState, ImageBlockState, ImageBlockState> = {
+    ...createBlockSkeleton(),
+    name: "Image",
+    displayName: "Image",
+    defaultValues: () => ({ altText: undefined }),
+    extractTextContents: (state) => (state.altText ? [state.altText] : []),
+};
+
+const SeoBlock = createSeoBlock({ image: ImageBlock });
+
+describe("createSeoBlock", () => {
+    it("should extract the text contents of the SEO fields and the open graph image", () => {
+        const state = {
+            ...SeoBlock.defaultValues(),
+            htmlTitle: "HTML Title",
+            metaDescription: "Meta Description",
+            openGraphTitle: "Open Graph Title",
+            openGraphDescription: "Open Graph Description",
+            openGraphImage: { visible: true, block: { altText: "Open Graph Image Alt Text" } },
+        };
+
+        expect(SeoBlock.extractTextContents?.(state, { includeInvisibleContent: false })).toEqual([
+            "HTML Title",
+            "Meta Description",
+            "Open Graph Title",
+            "Open Graph Description",
+            "Open Graph Image Alt Text",
+        ]);
+    });
+
+    it("should not extract text contents for empty SEO fields", () => {
+        expect(SeoBlock.extractTextContents?.(SeoBlock.defaultValues(), { includeInvisibleContent: false })).toEqual([]);
+    });
+});

--- a/packages/admin/cms-admin/src/blocks/createSeoBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/createSeoBlock.tsx
@@ -67,6 +67,27 @@ export function createSeoBlock(
 
         displayName: <FormattedMessage id="dextinity.blocks.seo" defaultMessage="SEO" />,
 
+        extractTextContents: (state, options) => {
+            const contents: string[] = [];
+
+            if (state.htmlTitle) {
+                contents.push(state.htmlTitle);
+            }
+            if (state.metaDescription) {
+                contents.push(state.metaDescription);
+            }
+            if (state.openGraphTitle) {
+                contents.push(state.openGraphTitle);
+            }
+            if (state.openGraphDescription) {
+                contents.push(state.openGraphDescription);
+            }
+
+            contents.push(...(block.extractTextContents?.(state, options) ?? []));
+
+            return contents;
+        },
+
         AdminComponent: ({ state, updateState }) => {
             const intl = useIntl();
             const { openGraphImage } = composedApi.adminComponents({


### PR DESCRIPTION
This is needed for the upcoming Admin AI Mode: the agent currently doesn't know the SEO block's contents, so a prompt like "Reword the existing SEO description" might not work as expected.

Note: the extracted texts aren't used for the existing SEO-related content generation features. It only uses the actual page content: https://github.com/vivid-planet/dextinity/blob/c92ad6a54bf840b65f08928b6dfab44dab7077be/demo/admin/src/documents/pages/EditPage.tsx#L183-L193

https://claude.ai/code/session_0129cQS51cCvby1nBQg4hNGx