### PR TITLE
Fix package scope in backported changeset

### DIFF
--- a/.changeset/user-permissions-wildcard-content-scope.md
+++ b/.changeset/user-permissions-wildcard-content-scope.md
@@ -1,6 +1,6 @@
 ---
-"@dextinity/cms-api": minor
-"@dextinity/cms-admin": minor
+"@comet/cms-api": minor
+"@comet/cms-admin": minor
 ---
 
 Support wildcard values for content scope dimensions in `getContentScopesForUser`


### PR DESCRIPTION
## Problem

The release workflow on `v8.x.x` fails when assembling the release plan:

> 🦋 error Error: Found changeset user-permissions-wildcard-content-scope for package @dextinity/cms-api which is not in the workspace

No release can be published from `v8.x.x` until this is resolved.

## Cause

`.changeset/user-permissions-wildcard-content-scope.md` was backported from a branch where the packages are already published under the `@dextinity/*` scope. On `v8.x.x` they still use `@comet/*`, so `@dextinity/cms-api` does not exist in the workspace and Changesets aborts.

**This is the second time the same mistake blocks the v8 release, and it happened despite the backport routine explicitly warning about it.** #6293 fixed the identical break for `olive-pears-invent` less than a week ago. The routine carries a caveat about adjusting the changeset scope when backporting to `v8.x.x` — #6318 followed it and renamed its changeset, but #6292, which added this one, did not. A caveat in the prompt is evidently not enough: the routine needs a check that fails the backport when a changeset names a package that isn't in the target branch's workspace.

## Fix

Rename the packages in the changeset's frontmatter to `@comet/cms-api` and `@comet/cms-admin`, matching the names in `packages/api/cms-api/package.json` and `packages/admin/cms-admin/package.json` on this branch. The changeset text is unchanged, so the released changelog entry stays the same.

## Verification

`changeset status` cannot run on this branch (it resolves changed packages against a `main` base ref that doesn't apply here), so the release plan was assembled directly via `@changesets/get-release-plan`. It now succeeds and versions 19 packages from `8.31.0` to `8.32.0`, consuming both pending changesets.

## Further information

- Failing run: https://github.com/vivid-planet/dextinity/actions/runs/34201879258
- Previous occurrence and fix: #6293
- Backport that added this changeset: #6292 (the sibling backport #6318 did rename its changeset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017d1A8MxYTpS29HTXgKJpJA

---
_Generated by [Claude Code](https://claude.ai/code/session_017d1A8MxYTpS29HTXgKJpJA)_