### PR TITLE
Fix scope validation for @InputType decorated classes

### DIFF
--- a/.changeset/eight-cows-repeat.md
+++ b/.changeset/eight-cows-repeat.md
@@ -1,0 +1,14 @@
+---
+"@dextinity/cms-api": patch
+---
+
+Fix scope validation in `PageTreeModule.forRoot` and `DamModule.register` rejecting correctly decorated scope classes
+
+`@InputType()` doesn't register its metadata immediately, it only queues the registration until a GraphQL schema is built. Since the scope is validated while the module is being defined, the queued registration hadn't run yet and a scope class decorated with `@InputType("PageTreeNodeScopeInput")` could be rejected with:
+
+```
+Error: Invalid input type name for provided page tree scope class.
+Make sure to decorate the class with @InputType("PageTreeNodeScopeInput")
+```
+
+The queued registrations are now executed before the scope is validated.

--- a/packages/api/cms-api/src/common/helper/scope-type-names.helper.ts
+++ b/packages/api/cms-api/src/common/helper/scope-type-names.helper.ts
@@ -1,0 +1,38 @@
+import type { Type } from "@nestjs/common";
+import { TypeMetadataStorage } from "@nestjs/graphql";
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage.js";
+
+interface ValidateScopeTypeNamesOptions {
+    label: string;
+    objectTypeName: string;
+    inputTypeName: string;
+}
+
+/**
+ * Validates that a scope class is decorated with the GraphQL type names Dextinity expects.
+ *
+ * `@ObjectType()` registers its metadata immediately, `@InputType()` only queues the registration in
+ * `LazyMetadataStorage` and it is executed once a GraphQL schema is built. Modules validate their scope while they are
+ * being defined, so the queued registrations have to be executed upfront. Only the registrations without a target are
+ * executed (they contain the input type metadata), because executing field metadata this early can fail for types that
+ * aren't fully defined yet.
+ */
+export function validateScopeTypeNames(Scope: Type<unknown>, { label, objectTypeName, inputTypeName }: ValidateScopeTypeNamesOptions): void {
+    LazyMetadataStorage.load([], { skipFieldLazyMetadata: true });
+
+    const scopeObjectType = TypeMetadataStorage.getObjectTypeMetadataByTarget(Scope);
+
+    if (scopeObjectType?.name !== objectTypeName) {
+        throw new Error(
+            `Invalid object type name for provided ${label} scope class. Make sure to decorate the class with @ObjectType("${objectTypeName}")`,
+        );
+    }
+
+    const scopeInputType = TypeMetadataStorage.getInputTypeMetadataByTarget(Scope);
+
+    if (scopeInputType?.name !== inputTypeName) {
+        throw new Error(
+            `Invalid input type name for provided ${label} scope class. Make sure to decorate the class with @InputType("${inputTypeName}")`,
+        );
+    }
+}

--- a/packages/api/cms-api/src/dam/dam-files.module.ts
+++ b/packages/api/cms-api/src/dam/dam-files.module.ts
@@ -1,7 +1,7 @@
 import { MikroOrmModule } from "@mikro-orm/nestjs";
 import { DynamicModule, Global, Module, Type, ValueProvider } from "@nestjs/common";
-import { TypeMetadataStorage } from "@nestjs/graphql";
 
+import { validateScopeTypeNames } from "../common/helper/scope-type-names.helper";
 import { FileValidationService } from "../file-utils/file-validation.service";
 import { HasValidFilenameConstraint } from "./common/decorators/has-valid-filename.decorator";
 import { damDefaultAcceptedMimetypes } from "./common/mimeTypes/dam-default-accepted-mimetypes";
@@ -89,22 +89,7 @@ export class DamFilesModule {
         const DamMediaAlternativeResolver = createDamMediaAlternativeResolver({ File, Scope });
 
         if (Scope) {
-            // Scope validation needs to happen after resolver generation. Otherwise the input type metadata has not been defined yet.
-            const scopeObjectType = TypeMetadataStorage.getObjectTypeMetadataByTarget(Scope);
-
-            if (scopeObjectType?.name !== "DamScope") {
-                throw new Error(
-                    `Invalid object type name for provided DAM scope class. Make sure to decorate the class with @ObjectType("DamScope")`,
-                );
-            }
-
-            const scopeInputType = TypeMetadataStorage.getInputTypeMetadataByTarget(Scope);
-
-            if (scopeInputType?.name !== "DamScopeInput") {
-                throw new Error(
-                    `Invalid input type name for provided DAM scope class. Make sure to decorate the class with @InputType("DamScopeInput")`,
-                );
-            }
+            validateScopeTypeNames(Scope, { label: "DAM", objectTypeName: "DamScope", inputTypeName: "DamScopeInput" });
         }
 
         return {

--- a/packages/api/cms-api/src/page-tree/page-tree.module.test.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.module.test.ts
@@ -1,5 +1,5 @@
 import { Entity } from "@mikro-orm/postgresql";
-import { Field, ObjectType, TypeMetadataStorage } from "@nestjs/graphql";
+import { Field, InputType, ObjectType } from "@nestjs/graphql";
 import { describe, expect, it } from "vitest";
 
 import { DocumentInterface } from "../document/dto/document-interface";
@@ -21,41 +21,53 @@ function registerPageTreeModule(Scope?: unknown) {
     return PageTreeModule.forRoot({ PageTreeNode, Documents: [Page], Scope: Scope as any, sitePreviewSecret: "secret" });
 }
 
-// @InputType() only queues its metadata for the schema builder to pick up once a GraphQL schema is actually built, so it
-// isn't visible via TypeMetadataStorage.getInputTypeMetadataByTarget() otherwise. Registering it directly keeps these
-// tests synchronous and independent of whether a schema gets built.
-function createScope(objectTypeName: string, inputTypeName: string) {
-    @ObjectType(objectTypeName)
-    class Scope {
-        @Field()
-        domain: string;
-    }
-
-    TypeMetadataStorage.addInputTypeMetadata({ target: Scope, name: inputTypeName });
-
-    return Scope;
-}
-
 describe("PageTreeModule", () => {
     describe("forRoot", () => {
         it("accepts a scope decorated with the required GraphQL type names", () => {
-            const ValidScope = createScope("PageTreeNodeScope", "PageTreeNodeScopeInput");
+            @ObjectType("PageTreeNodeScope")
+            @InputType("PageTreeNodeScopeInput")
+            class Scope {
+                @Field()
+                domain: string;
+            }
 
-            expect(() => registerPageTreeModule(ValidScope)).not.toThrow();
+            expect(() => registerPageTreeModule(Scope)).not.toThrow();
         });
 
         it("throws if the scope's object type isn't named PageTreeNodeScope", () => {
-            const InvalidScope = createScope("WrongScope", "PageTreeNodeScopeInput");
+            @ObjectType("WrongScope")
+            @InputType("PageTreeNodeScopeInput")
+            class Scope {
+                @Field()
+                domain: string;
+            }
 
-            expect(() => registerPageTreeModule(InvalidScope)).toThrow(
+            expect(() => registerPageTreeModule(Scope)).toThrow(
                 `Invalid object type name for provided page tree scope class. Make sure to decorate the class with @ObjectType("PageTreeNodeScope")`,
             );
         });
 
         it("throws if the scope's input type isn't named PageTreeNodeScopeInput", () => {
-            const InvalidScope = createScope("PageTreeNodeScope", "WrongScopeInput");
+            @ObjectType("PageTreeNodeScope")
+            @InputType("WrongScopeInput")
+            class Scope {
+                @Field()
+                domain: string;
+            }
 
-            expect(() => registerPageTreeModule(InvalidScope)).toThrow(
+            expect(() => registerPageTreeModule(Scope)).toThrow(
+                `Invalid input type name for provided page tree scope class. Make sure to decorate the class with @InputType("PageTreeNodeScopeInput")`,
+            );
+        });
+
+        it("throws if the scope isn't decorated with @InputType at all", () => {
+            @ObjectType("PageTreeNodeScope")
+            class Scope {
+                @Field()
+                domain: string;
+            }
+
+            expect(() => registerPageTreeModule(Scope)).toThrow(
                 `Invalid input type name for provided page tree scope class. Make sure to decorate the class with @InputType("PageTreeNodeScopeInput")`,
             );
         });

--- a/packages/api/cms-api/src/page-tree/page-tree.module.ts
+++ b/packages/api/cms-api/src/page-tree/page-tree.module.ts
@@ -1,8 +1,8 @@
 import { MikroOrmModule } from "@mikro-orm/nestjs";
 import { EntityManager, EntityRepository } from "@mikro-orm/postgresql";
 import { DynamicModule, Global, Module, Type, ValueProvider } from "@nestjs/common";
-import { TypeMetadataStorage } from "@nestjs/graphql";
 
+import { validateScopeTypeNames } from "../common/helper/scope-type-names.helper";
 import { DependenciesResolverFactory } from "../dependencies/dependencies.resolver.factory";
 import { DependentsResolverFactory } from "../dependencies/dependents.resolver.factory";
 import { DocumentInterface } from "../document/dto/document-interface";
@@ -90,22 +90,7 @@ export class PageTreeModule {
             : null;
 
         if (Scope) {
-            // Scope validation needs to happen after resolver generation. Otherwise the input type metadata has not been defined yet.
-            const scopeObjectType = TypeMetadataStorage.getObjectTypeMetadataByTarget(Scope);
-
-            if (scopeObjectType?.name !== "PageTreeNodeScope") {
-                throw new Error(
-                    `Invalid object type name for provided page tree scope class. Make sure to decorate the class with @ObjectType("PageTreeNodeScope")`,
-                );
-            }
-
-            const scopeInputType = TypeMetadataStorage.getInputTypeMetadataByTarget(Scope);
-
-            if (scopeInputType?.name !== "PageTreeNodeScopeInput") {
-                throw new Error(
-                    `Invalid input type name for provided page tree scope class. Make sure to decorate the class with @InputType("PageTreeNodeScopeInput")`,
-                );
-            }
+            validateScopeTypeNames(Scope, { label: "page tree", objectTypeName: "PageTreeNodeScope", inputTypeName: "PageTreeNodeScopeInput" });
         }
 
         const repositoryProvider = {


### PR DESCRIPTION
Regression introduced with https://github.com/vivid-planet/dextinity/pull/6173: `@InputType()` doesn't register its metadata immediately, it only queues the registration until a GraphQL schema is built. Since the scope is validated while the module is being defined, the queued registration hadn't run yet and a scope class decorated with `@InputType("PageTreeNodeScopeInput")` could be rejected with:

```
Error: Invalid input type name for provided page tree scope class.
Make sure to decorate the class with @InputType("PageTreeNodeScopeInput")
```

The queued registrations are now executed before the scope is validated.

https://claude.ai/code/session_01Qe7bCBD3eZmRhv4a8qJ77h