### PR TITLE
Include attachedBlocks in one-of block input meta

### DIFF
--- a/.changeset/oneof-block-input-meta-attached-blocks.md
+++ b/.changeset/oneof-block-input-meta-attached-blocks.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/cms-api": patch
+---
+
+Include `attachedBlocks` in the input fields of the block meta of one-of blocks
+
+The block meta of blocks created with `createOneOfBlock` (and `createLinkBlock`) was missing the `attachedBlocks` field in `inputFields`, causing the generated block input types to only contain `activeType`.

--- a/demo/api/block-meta.json
+++ b/demo/api/block-meta.json
@@ -890,6 +890,29 @@
         ],
         "inputFields": [
             {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": {
+                                "pixelImage": "PixelImage",
+                                "svgImage": "SvgImage"
+                            },
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
+            {
                 "name": "activeType",
                 "kind": "String",
                 "nullable": false
@@ -1652,6 +1675,33 @@
         ],
         "inputFields": [
             {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": {
+                                "internal": "InternalLink",
+                                "external": "ExternalLink",
+                                "damFileDownload": "DamFileDownloadLink",
+                                "email": "EmailLink",
+                                "phone": "PhoneLink",
+                                "news": "NewsLink"
+                            },
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
+            {
                 "name": "activeType",
                 "kind": "String",
                 "nullable": false
@@ -1903,6 +1953,29 @@
         ],
         "inputFields": [
             {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": {
+                                "external": "ExternalLink",
+                                "phone": "PhoneLink"
+                            },
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
+            {
                 "name": "activeType",
                 "kind": "String",
                 "nullable": false
@@ -2018,6 +2091,31 @@
             }
         ],
         "inputFields": [
+            {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": {
+                                "image": "DamImage",
+                                "damVideo": "DamVideo",
+                                "youTubeVideo": "YouTubeVideo",
+                                "vimeoVideo": "VimeoVideo"
+                            },
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
             {
                 "name": "activeType",
                 "kind": "String",
@@ -2978,6 +3076,30 @@
             }
         ],
         "inputFields": [
+            {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": {
+                                "internal": "InternalLink",
+                                "external": "ExternalLink",
+                                "news": "NewsLink"
+                            },
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
             {
                 "name": "activeType",
                 "kind": "String",

--- a/packages/api/brevo-api/block-meta.json
+++ b/packages/api/brevo-api/block-meta.json
@@ -152,6 +152,29 @@
         ],
         "inputFields": [
             {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": {
+                                "pixelImage": "PixelImage",
+                                "svgImage": "SvgImage"
+                            },
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
+            {
                 "name": "activeType",
                 "kind": "String",
                 "nullable": false
@@ -220,6 +243,15 @@
                         {
                             "name": "altText",
                             "kind": "String",
+                            "nullable": true
+                        },
+                        {
+                            "name": "aiContentType",
+                            "kind": "Enum",
+                            "enum": [
+                                "Generated",
+                                "Modified"
+                            ],
                             "nullable": true
                         },
                         {
@@ -482,6 +514,15 @@
                         {
                             "name": "altText",
                             "kind": "String",
+                            "nullable": true
+                        },
+                        {
+                            "name": "aiContentType",
+                            "kind": "Enum",
+                            "enum": [
+                                "Generated",
+                                "Modified"
+                            ],
                             "nullable": true
                         },
                         {

--- a/packages/api/cms-api/block-meta.json
+++ b/packages/api/cms-api/block-meta.json
@@ -152,6 +152,29 @@
         ],
         "inputFields": [
             {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": {
+                                "pixelImage": "PixelImage",
+                                "svgImage": "SvgImage"
+                            },
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
+            {
                 "name": "activeType",
                 "kind": "String",
                 "nullable": false
@@ -479,6 +502,31 @@
             }
         ],
         "inputFields": [
+            {
+                "name": "attachedBlocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "type",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "OneOfBlocks",
+                            "blocks": {
+                                "internal": "InternalLink",
+                                "external": "ExternalLink",
+                                "email": "EmailLink",
+                                "phone": "PhoneLink"
+                            },
+                            "nullable": false
+                        }
+                    ]
+                },
+                "nullable": false
+            },
             {
                 "name": "activeType",
                 "kind": "String",

--- a/packages/api/cms-api/src/blocks/factories/createOneOfBlock.test.ts
+++ b/packages/api/cms-api/src/blocks/factories/createOneOfBlock.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { InternalLinkBlock } from "../../page-tree/blocks/internal-link.block";
+import { BlockMetaFieldKind } from "../block";
+import { ExternalLinkBlock } from "../externalLink/external-link.block";
+import { createOneOfBlock } from "./createOneOfBlock";
+
+describe("createOneOfBlock", () => {
+    it("should include attachedBlocks in the block input meta", () => {
+        const supportedBlocks = { internal: InternalLinkBlock, external: ExternalLinkBlock };
+        const OneOfBlock = createOneOfBlock({ supportedBlocks }, "OneOfBlockInputMetaTest");
+
+        expect(OneOfBlock.blockInputMeta.fields).toEqual([
+            {
+                name: "attachedBlocks",
+                kind: BlockMetaFieldKind.NestedObjectList,
+                object: {
+                    fields: [
+                        { name: "type", kind: BlockMetaFieldKind.String, nullable: false },
+                        { name: "props", kind: BlockMetaFieldKind.OneOfBlocks, blocks: supportedBlocks, nullable: false },
+                    ],
+                },
+                nullable: false,
+            },
+            { name: "activeType", kind: BlockMetaFieldKind.String, nullable: true },
+        ]);
+    });
+});

--- a/packages/api/cms-api/src/blocks/factories/createOneOfBlock.ts
+++ b/packages/api/cms-api/src/blocks/factories/createOneOfBlock.ts
@@ -11,6 +11,7 @@ import {
     BlockInputInterface,
     BlockMetaField,
     BlockMetaFieldKind,
+    BlockMetaInterface,
     ChildBlockInfo,
     createBlock,
     ExtractBlockData,
@@ -294,25 +295,27 @@ export function createOneOfBlock<
     }: CreateOneOfBlockOptions<BlockMap, Data, Input>,
     nameOrOptions: BlockFactoryNameOrOptions,
 ): OneOfBlock<BlockMap, Data, Input> {
+    const attachedBlockObject: BlockMetaInterface = {
+        fields: [
+            { name: "type", kind: BlockMetaFieldKind.String, nullable: false },
+            {
+                name: "props",
+                kind: BlockMetaFieldKind.OneOfBlocks,
+                blocks: supportedBlocks,
+                nullable: false,
+            },
+        ],
+    };
+
+    const attachedBlocksField: BlockMetaField = {
+        name: "attachedBlocks",
+        kind: BlockMetaFieldKind.NestedObjectList,
+        object: attachedBlockObject,
+        nullable: false,
+    };
+
     class Meta extends AnnotationBlockMeta {
         get fields(): BlockMetaField[] {
-            const attachedBlocksField: BlockMetaField = {
-                name: "attachedBlocks",
-                kind: BlockMetaFieldKind.NestedObjectList,
-                object: {
-                    fields: [
-                        { name: "type", kind: BlockMetaFieldKind.String, nullable: false },
-                        {
-                            name: "props",
-                            kind: BlockMetaFieldKind.OneOfBlocks,
-                            blocks: supportedBlocks,
-                            nullable: false,
-                        },
-                    ],
-                },
-                nullable: false,
-            };
-
             return [
                 ...super.fields,
                 attachedBlocksField,
@@ -325,9 +328,15 @@ export function createOneOfBlock<
                     name: "block",
                     kind: BlockMetaFieldKind.NestedObject,
                     nullable: true,
-                    object: attachedBlocksField.object,
+                    object: attachedBlockObject,
                 },
             ];
+        }
+    }
+
+    class InputMeta extends AnnotationBlockMeta {
+        get fields(): BlockMetaField[] {
+            return [attachedBlocksField, ...super.fields];
         }
     }
 
@@ -341,5 +350,10 @@ export function createOneOfBlock<
         migrate = nameOrOptions.migrate;
     }
 
-    return createBlock(OneOfBlockData, OneOfBlockInput, { name, blockMeta: new Meta(OneOfBlockData), migrate });
+    return createBlock(OneOfBlockData, OneOfBlockInput, {
+        name,
+        blockMeta: new Meta(OneOfBlockData),
+        blockInputMeta: new InputMeta(OneOfBlockInput),
+        migrate,
+    });
 }


### PR DESCRIPTION
This came up when creating a MCP tool that returns a block's schema: the input meta for one-of block's was missing the attachedBlocks, which are necessary for block creation. The agent could fallback to the block's data meta for this, but the proper fix is to include it in the input meta.

https://claude.ai/code/session_01TYmYM9YE7bL9BjCDyN9dUv