### PR TITLE
Fix beta release tags pointing at the wrong commit

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -41,6 +41,21 @@ jobs:
                   cd packages/admin/admin
                   echo "PUBLISHED_VERSION=$(pnpm pkg get version | sed -r 's/"//g')" >> $GITHUB_ENV
 
+            # dotansimha/changesets-action creates the GitHub release without passing
+            # target_commitish, so GitHub places the tag on the default branch (main) instead of
+            # the released commit. That's wrong for every release that doesn't run on main.
+            # Creating the tag upfront fixes it: GitHub ignores target_commitish when the tag
+            # already exists.
+            - name: Create tag on released commit
+              if: ${{ contains(github.event.head_commit.message, 'Version Packages') }}
+              run: |
+                  if git ls-remote --exit-code --tags origin "v$PUBLISHED_VERSION" > /dev/null; then
+                      echo "Tag v$PUBLISHED_VERSION already exists"
+                  else
+                      git tag "v$PUBLISHED_VERSION" "$GITHUB_SHA"
+                      git push origin "v$PUBLISHED_VERSION"
+                  fi
+
             - name: Create Release Pull Request or Publish to npm
               id: changesets
               uses: dotansimha/changesets-action@v1.5.2
@@ -54,3 +69,15 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   HUSKY: 0 # https://typicode.github.io/husky/#/?id=with-env-variables
+
+            # Catches a silently broken guard on the tag step above: without this, a wrong tag
+            # would go unnoticed again.
+            - name: Verify the release tag
+              if: ${{ steps.changesets.outputs.published == 'true' }}
+              run: |
+                  git fetch --force origin "refs/tags/v$PUBLISHED_VERSION:refs/tags/v$PUBLISHED_VERSION"
+                  TAGGED_SHA=$(git rev-parse "v$PUBLISHED_VERSION^{commit}")
+                  if [ "$TAGGED_SHA" != "$GITHUB_SHA" ]; then
+                      echo "::error::Publishing succeeded, but tag v$PUBLISHED_VERSION points at $TAGGED_SHA instead of the released commit $GITHUB_SHA. Move the tag, then check the condition of the \"Create tag on released commit\" step."
+                      exit 1
+                  fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,21 @@ jobs:
                   cd packages/admin/admin
                   echo "PUBLISHED_VERSION=$(pnpm pkg get version | sed -r 's/"//g')" >> $GITHUB_ENV
 
+            # dotansimha/changesets-action creates the GitHub release without passing
+            # target_commitish, so GitHub places the tag on the default branch (main) instead of
+            # the released commit. That's wrong for every release that doesn't run on main.
+            # Creating the tag upfront fixes it: GitHub ignores target_commitish when the tag
+            # already exists.
+            - name: Create tag on released commit
+              if: ${{ contains(github.event.head_commit.message, 'Version Packages') }}
+              run: |
+                  if git ls-remote --exit-code --tags origin "v$PUBLISHED_VERSION" > /dev/null; then
+                      echo "Tag v$PUBLISHED_VERSION already exists"
+                  else
+                      git tag "v$PUBLISHED_VERSION" "$GITHUB_SHA"
+                      git push origin "v$PUBLISHED_VERSION"
+                  fi
+
             - name: Create Release Pull Request or Publish to npm
               id: changesets
               uses: dotansimha/changesets-action@v1.5.2
@@ -38,3 +53,15 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   HUSKY: 0 # https://typicode.github.io/husky/#/?id=with-env-variables
+
+            # Catches a silently broken guard on the tag step above: without this, a wrong tag
+            # would go unnoticed again.
+            - name: Verify the release tag
+              if: ${{ steps.changesets.outputs.published == 'true' }}
+              run: |
+                  git fetch --force origin "refs/tags/v$PUBLISHED_VERSION:refs/tags/v$PUBLISHED_VERSION"
+                  TAGGED_SHA=$(git rev-parse "v$PUBLISHED_VERSION^{commit}")
+                  if [ "$TAGGED_SHA" != "$GITHUB_SHA" ]; then
+                      echo "::error::Publishing succeeded, but tag v$PUBLISHED_VERSION points at $TAGGED_SHA instead of the released commit $GITHUB_SHA. Move the tag, then check the condition of the \"Create tag on released commit\" step."
+                      exit 1
+                  fi


### PR DESCRIPTION
https://github.com/vivid-planet/dextinity/pull/6319 for main

## Problem

Beta releases on `next` tag the wrong commit: the tag lands on the newest `main` commit instead of the commit that was released.

`v10.0.0-beta.0` points at `0e9bb5fc4` ("Remove leftover .cspellignore (#6158)"), a `main` commit.

## Cause

`dotansimha/changesets-action` calls the create-release API without `target_commitish`, so GitHub creates the tag on the repository's default branch.

## Fix

The release workflows create the `vX.Y.Z` tag themselves before the action runs. GitHub ignores `target_commitish` when the tag already exists, so the release attaches to the correct commit. A second step then asserts the tag ended up on the released commit and fails the job otherwise.

`release-beta.yml` is the one that is actually broken here, since it runs on `next`. `release.yml` gets the same steps even though `main` is the default branch and therefore unaffected today: it is the template the `vN.x.x` branches are cut from, and it should not start tagging wrongly if the default branch ever changes.

## Verification

- **Confirmed working on `v8.x.x`.** The first release after [#6319](https://github.com/vivid-planet/dextinity/pull/6319) merged, [`v8.32.0`](https://github.com/vivid-planet/dextinity/releases/tag/v8.32.0), is tagged on `cf9fc0cf2` — the release commit on `v8.x.x`, no longer a `main` commit.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/DEX-2597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgLEUzTiJX7Jn3WQJBWhok

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgLEUzTiJX7Jn3WQJBWhok)_