### PR TITLE
Add `@RootBlockEntity` and `@EntityInfo` decorators to Brevo email campaign entity

### DIFF
--- a/.changeset/brevo-email-campaign-root-block-entity-and-entity-info.md
+++ b/.changeset/brevo-email-campaign-root-block-entity-and-entity-info.md
@@ -1,0 +1,11 @@
+---
+"@dextinity/brevo-api": patch
+---
+
+Add `@RootBlockEntity()` and `@EntityInfo()` to the email campaign entity
+
+The entity created by `createEmailCampaignEntity` has a root block (`content`), but was missing `@RootBlockEntity()`, so it wasn't picked up by the root block discovery. Blocks used inside an email campaign therefore never appeared in the block index: dependencies of the campaign's content weren't tracked, DAM files used in a campaign showed no usages, and their IDs weren't remapped when copying between scopes.
+
+`@EntityInfo()` was missing as well, so the campaign had no entry in the `EntityInfo` view. Anything referencing a campaign (dependencies and warnings) couldn't resolve a name for it and logged a warning about the missing decorator instead.
+
+The entity now uses `title` as name and `subject` as secondary information.

--- a/packages/api/brevo-api/src/email-campaign/entities/email-campaign-entity.factory.ts
+++ b/packages/api/brevo-api/src/email-campaign/entities/email-campaign-entity.factory.ts
@@ -1,4 +1,13 @@
-import { Block, BlockDataInterface, DocumentInterface, RootBlock, RootBlockDataScalar, RootBlockType } from "@dextinity/cms-api";
+import {
+    Block,
+    BlockDataInterface,
+    DocumentInterface,
+    EntityInfo,
+    RootBlock,
+    RootBlockDataScalar,
+    RootBlockEntity,
+    RootBlockType,
+} from "@dextinity/cms-api";
 import { Collection, Embedded, Entity, Enum, ManyToMany, OptionalProps, PrimaryKey, Property } from "@mikro-orm/postgresql";
 import { Type } from "@nestjs/common";
 import { Field, ID, Int, ObjectType } from "@nestjs/graphql";
@@ -33,6 +42,8 @@ export function createEmailCampaignEntity({
     Scope: Type<EmailCampaignScopeInterface>;
     TargetGroup: Type<TargetGroupInterface>;
 }): Type<EmailCampaignInterface> {
+    @EntityInfo<EmailCampaignInterface>({ name: "title", secondaryInformation: "subject" })
+    @RootBlockEntity()
     @Entity()
     @ObjectType({
         implements: () => [DocumentInterface],


### PR DESCRIPTION
The entity created by `createEmailCampaignEntity` has a root block (`content`), but was missing `@RootBlockEntity()`, so it wasn't picked up by the root block discovery. Blocks used inside an email campaign therefore never appeared in the block index: dependencies of the campaign's content weren't tracked, DAM files used in a campaign showed no usages, and their IDs weren't remapped when copying between scopes.

`@EntityInfo()` was missing as well, so the campaign had no entry in the `EntityInfo` view. Anything referencing a campaign (dependencies and warnings) couldn't resolve a name for it and logged a warning about the missing decorator instead.

The entity now uses `title` as name and `subject` as secondary information.

https://claude.ai/code/session_01FGo1u63xMfdYJJmFWccaT6