### PR TITLE
[Dont merge] docs: Add ode to Dextinity poem to overview page

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -44,3 +44,20 @@ You can build two types of applications with Dextinity:
 :::note
 This terms are used throughout the documentation as some concepts heavily differ between this two types.
 :::
+
+## An Ode to Dextinity
+
+> Headless by design, yet never headstrong,<br />
+> a page tree that grows where the blocks belong.<br />
+> Twelve factors deep and cloud-native at heart,<br />
+> each microservice a replaceable part.<br />
+>
+> TypeScript everywhere, from schema to view,<br />
+> so the compiler catches the bugs before you.<br />
+> Mobile first, on-premise, and free to extend —<br />
+> infrastructure as code from beginning to end.<br />
+>
+> Content or data, whichever you need,<br />
+> Dextinity bends to the shape of the deed.<br />
+> Not off-the-shelf, but crafted with care:<br />
+> the DX you dreamed of is finally there.


### PR DESCRIPTION
Give the documentation overview a lighthearted closing section that
restates Dextinity's design principles in verse, so the page ends on
something memorable rather than trailing off after the terminology note.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0155q5wUncvvgBHV9MGvsmFa