### PR TITLE
Skip automatic Greptile reviews

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,4 +1,5 @@
 {
+    "skipReview": "AUTOMATIC",
     "autoApprove": {
         "enabled": true
     }


### PR DESCRIPTION
AI reviews should be opt-in to keep the review count at a minimum.