### PR TITLE
Disable CodeRabbit review status

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
+    review_status: false
     auto_review:
         enabled: false
     high_level_summary_in_walkthrough: true


### PR DESCRIPTION
Disable the review status to reduce noise when creating a PR. Without it, CodeRabbit would post a "Review skipped"-comment on every PR. Reviews can still be invoked using `@coderabbitai review`.