### PR TITLE
Add Content-Disposition inline header to DAM file endpoints

### DIFF
--- a/.changeset/dam-inline-content-disposition.md
+++ b/.changeset/dam-inline-content-disposition.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/cms-api": patch
+---
+
+Add a `Content-Disposition: inline` header with the file name to DAM file endpoints
+
+The endpoints serving a file for display previously sent no `Content-Disposition` header at all, so browsers derived the name from the URL when saving the file. They now send `inline` together with the file name, which keeps the file being displayed instead of downloaded.

--- a/packages/api/cms-api/src/dam/files/files.controller.ts
+++ b/packages/api/cms-api/src/dam/files/files.controller.ts
@@ -216,6 +216,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
                 throw new ForbiddenException();
             }
 
+            res.setHeader("Content-Disposition", createContentDisposition(file.name, { type: "inline" }));
             return this.streamFile(file, res, { range, overrideHeaders: { "cache-control": "max-age=31536000, private" } }); // Local caches only (1 year)
         }
 
@@ -290,6 +291,7 @@ export function createFilesController({ Scope: PassedScope, damBasePath }: { Sco
                 throw new BadRequestException("Content Hash mismatch!");
             }
 
+            res.setHeader("Content-Disposition", createContentDisposition(file.name, { type: "inline" }));
             return this.streamFile(file, res, {
                 range,
                 overrideHeaders: {


### PR DESCRIPTION
The DAM endpoints that serve a file for display sent no `Content-Disposition` header at all. Browsers therefore derived the name from the URL when the user saved such a file, and the URL carries the file name without its extension — so the file was saved without one.

These endpoints now send `inline` together with the file name. `inline` keeps the existing behavior of displaying the file instead of downloading it, while the file name is what the browser uses once the file is saved.

This is the follow-up to [#6338](https://github.com/vivid-planet/dextinity/pull/6338), which did the same for the download endpoints. It uses the same `create` from the [content-disposition](https://www.npmjs.com/package/content-disposition) package that [#6338](https://github.com/vivid-planet/dextinity/pull/6338) introduced, so escaping and RFC 5987 encoding are handled by the package; the only difference is passing `{ type: "inline" }` instead of relying on the default `attachment`.

## Tests

### cURL

The command

```sh
curl -X HEAD -i http://localhost:3000/dam/files/54f58ee706e25f6e3b72f4ccbebe90783137b128/a7cbfdb5d46f24300eb4fd122c047a38/afccae74-d443-4ed4-b8ff-b55313328ab3/test
``` 

returns `content-disposition: inline; filename=test.pdf`.

### Browser download

Tested the following files in Chrome, Firefox, and Safari:

- Bär.pdf: is converted to Bar.pdf on upload, is downloaded as Bar.pdf in all browsers
- test.pdf: is downloaded as test.pdf in all browsers
- test.2026.pdf is downloaded as test.2026.pdf (not test.2026) in all browsers

### Other usages

The `fileUrl` is also used for the DamVideoBlock and SvgImageBlock, tested both in all three browsers, works as expected.

https://claude.ai/code/session_01Am8ymPRJVXHnLnwXNBE1E3