### PR TITLE
Configure Greptile to ignore generated and lock files

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -2,5 +2,14 @@
     "skipReview": "AUTOMATIC",
     "autoApprove": {
         "enabled": true
-    }
+    },
+    "ignorePatterns": [
+        "pnpm-lock.yaml",
+        "**/CHANGELOG.md",
+        "CHANGELOG.old.md",
+        "**/__snapshots__/**",
+        "**/generated/**",
+        "**/schema.gql",
+        "**/block-meta.json"
+    ]
 }


### PR DESCRIPTION
Updated the Greptile configuration to exclude generated files, lock files, and other non-source artifacts from code review analysis.


https://claude.ai/code/session_01Rx8jBFVqSSjR1xQsrRoNXE