### PR TITLE
[greptile] Exclude bot authors from auto-approval

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -2,5 +2,6 @@
     "skipReview": "AUTOMATIC",
     "autoApprove": {
         "enabled": true
-    }
+    },
+    "excludeAuthors": ["vivid-planet-bot", "github-actions[bot]", "renovate[bot]"]
 }

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -3,7 +3,7 @@
     "autoApprove": {
         "enabled": true
     },
-    "excludeAuthors": ["vivid-planet-bot", "github-actions[bot]", "renovate[bot]"]
+    "excludeAuthors": ["vivid-planet-bot", "github-actions[bot]", "renovate[bot]"],
     "ignorePatterns": [
         "pnpm-lock.yaml",
         "**/CHANGELOG.md",


### PR DESCRIPTION
Updated the Greptile configuration to exclude automated bot accounts from the auto-approval process.

this is not really needed as long as we have skipReview=AUTOMATIC, but we might change that in future


https://claude.ai/code/session_01AHhH2ZCXZRyULnL8EFNVqL