### PR TITLE
[greptile] Restrict auto-approval to trusted authors

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,7 +1,10 @@
 {
     "skipReview": "AUTOMATIC",
     "autoApprove": {
-        "enabled": true
+        "enabled": true,
+        "filters": {
+            "includeAuthors": ["VPS-Obi", "VPS-thodax", "nsams", "fraxachun"]
+        }
     },
     "ignorePatterns": [
         "pnpm-lock.yaml",


### PR DESCRIPTION
Updated the auto-approval configuration to only apply to pull requests from a curated list of trusted authors, adding an additional layer of control over which PRs are automatically approved.


https://claude.ai/code/session_01WRfAGP3iUosJeV83CdNTiz