### PR TITLE
[greptile] Point Greptile at the repository's coding guidelines

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -3,6 +3,7 @@
     "autoApprove": {
         "enabled": true
     },
+    "instructions": "The files referenced in .greptile/files.json are this repository's coding guidelines. Treat them as binding and flag violations in review comments. The frontmatter of those files (description, applyTo, paths, globs, alwaysApply) is metadata for other tools, not a rule to review against.",
     "ignorePatterns": [
         "pnpm-lock.yaml",
         "**/CHANGELOG.md",

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,69 @@
+{
+    "files": [
+        {
+            "path": "rules/coding-guidelines/api-nestjs.instructions.md",
+            "description": "NestJS service/controller layering, MikroORM, GraphQL, ACL",
+            "scope": ["**/api/**/*.ts"]
+        },
+        {
+            "path": "rules/coding-guidelines/cdn.instructions.md",
+            "description": "Cache-Control header policy for GET routes (Site and API)",
+            "scope": [
+                "**/api/**/*.controller.ts",
+                "**/api/**/*.resolver.ts",
+                "**/site/**/route.ts",
+                "**/site/**/next.config.js",
+                "**/site/**/next.config.ts",
+                "**/site/**/next.config.mjs"
+            ]
+        },
+        {
+            "path": "rules/coding-guidelines/general.instructions.md",
+            "description": "Language-agnostic naming, control-flow, and comment rules",
+            "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs"]
+        },
+        {
+            "path": "rules/coding-guidelines/git.instructions.md",
+            "description": "Git, commit, PR, and changeset conventions for this repo"
+        },
+        {
+            "path": "rules/coding-guidelines/kubernetes.instructions.md",
+            "description": "CronJob intervals, environments, replicas, resource requests/limits",
+            "scope": ["**/*.yaml", "**/*.yml", "**/helm/**", "**/k8s/**"]
+        },
+        {
+            "path": "rules/coding-guidelines/libraries.instructions.md",
+            "description": "Criteria for adding or replacing npm packages",
+            "scope": ["**/package.json"]
+        },
+        {
+            "path": "rules/coding-guidelines/naming.instructions.md",
+            "description": "File, folder, DB, and branch naming conventions across api/admin/site",
+            "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.sql"]
+        },
+        {
+            "path": "rules/coding-guidelines/postgresql.instructions.md",
+            "description": "UUID IDs, column types, forward-only migrations, DB defaults",
+            "scope": ["**/*.entity.ts", "**/entities/**/*.ts", "**/migrations/**/*.ts", "**/*.sql"]
+        },
+        {
+            "path": "rules/coding-guidelines/react.instructions.md",
+            "description": "React component, prop, state, fragment, and anti-pattern rules",
+            "scope": ["**/*.ts", "**/*.tsx"]
+        },
+        {
+            "path": "rules/coding-guidelines/security.instructions.md",
+            "description": "Security-by-design, privacy, authorization, defense-in-depth principles"
+        },
+        {
+            "path": "rules/coding-guidelines/styling.instructions.md",
+            "description": "Theme usage, Emotion/styled-components, responsive, SVG handling",
+            "scope": ["**/*.tsx", "**/*.sc.ts", "**/*.css", "**/*.scss"]
+        },
+        {
+            "path": "rules/coding-guidelines/typescript.instructions.md",
+            "description": "TypeScript style — options objects, named exports, async/await, enums",
+            "scope": ["**/*.ts", "**/*.tsx"]
+        }
+    ]
+}


### PR DESCRIPTION
Try to use our coding guidelines rules for Greptile code review.

<details>
<summary>AI-generated description</summary>

## Problem

`.greptile/config.json` only configured *how* Greptile reviews (skip automatic reviews, auto-approve, ignore patterns). It never told Greptile *what* our conventions are, so Greptile reviewed PRs without the coding guidelines in `rules/` — the same guidelines every other agent in this repo already gets wired up for it:

- Copilot → `.github/copilot-review-instructions.md` + `.github/instructions/` (symlinked from `rules/`)
- Cursor → `.cursor/rules/` (symlinked from `rules/`)
- Claude / generic agents → `.agents/rules/`, `.claude/rules/` (symlinked from `rules/`)

Result: Greptile could not flag violations of rules we enforce everywhere else (e.g. "always use `columnType: text` for strings", "use named exports only", "ACL logic must not live in shared services").

## Solution

Add `.greptile/files.json`, which is Greptile's native mechanism for pointing the reviewer at existing files in the repository, and reference all 12 `rules/coding-guidelines/*.instructions.md` files. The rule files stay the single source of truth — nothing is duplicated into the Greptile config.

Each entry's `scope` mirrors the rule's own `applyTo` frontmatter, so a guideline is only loaded when a file it covers is under review (`postgresql` only for entities/migrations/SQL, `styling` only for `.tsx`/`.sc.ts`/CSS, …). `git.instructions.md` and `security.instructions.md` have `applyTo: "**"` and therefore carry no `scope`, which per the docs means they apply to every review.

`config.json` additionally gains an `instructions` field stating that the referenced files are binding, so violations get reported instead of merely informing the review summary. It also tells the reviewer to ignore the rule files' frontmatter (`description`, `applyTo`, `paths`, `globs`, `alwaysApply`), which is metadata for the other tools and not something to review against.

### Example

`.greptile/files.json` (excerpt):

```json
{
    "files": [
        {
            "path": "rules/coding-guidelines/api-nestjs.instructions.md",
            "description": "NestJS service/controller layering, MikroORM, GraphQL, ACL",
            "scope": ["**/api/**/*.ts"]
        },
        {
            "path": "rules/coding-guidelines/security.instructions.md",
            "description": "Security-by-design, privacy, authorization, defense-in-depth principles"
        }
    ]
}
```

A PR touching `packages/api/cms-api/src/**/*.ts` now gets `api-nestjs`, `general`, `naming`, `typescript`, `react`, `git` and `security` as review context; a PR touching only `demo/site/**/*.tsx` gets `styling`, `react`, `general`, `naming`, `typescript`, `git` and `security` — but not `api-nestjs` or `postgresql`.

## Verification against the docs

Everything here was checked against the current Greptile documentation:

- [`.greptile/` Configuration](https://www.greptile.com/docs/code-review/greptile-config) — the `.greptile/` folder is the recommended format and supports exactly three optional files (`config.json`, `rules.md`, `files.json`); adding `files.json` next to the existing `config.json` is the supported layout, and it takes effect on the next PR with no reindexing.
- [`.greptile/` File Reference → `files.json`](https://www.greptile.com/docs/code-review/greptile-config-reference#files-json) — schema is `{ "files": [{ path, description?, scope? }] }`. `path` is **required** and **relative to the directory containing the `.greptile/` folder**, which is the repo root here, hence `rules/coding-guidelines/…`. "Files without a `scope` are included in every review within the directory tree" — which is why the two `applyTo: "**"` rules deliberately omit `scope`.
- [`.greptile/` File Reference → `config.json` → Instructions](https://www.greptile.com/docs/code-review/greptile-config-reference#instructions) — `instructions` is a free-form string; existing settings in the file (`skipReview`, `autoApprove`, `ignorePatterns`) are unchanged.
- [Custom Standards & Rules → Context Files](https://www.greptile.com/docs/code-review/custom-standards#context-files-files-json) — referencing existing documentation in the repo (rather than pasting rules into the config) is the documented way to hand Greptile an existing style guide; Markdown is a supported format.
- [Custom Standards & Rules → Pattern syntax errors](https://www.greptile.com/docs/code-review/custom-standards#troubleshooting-custom-rules) — `scope` must be an **array** of glob patterns, never a comma-separated string. The rule files' `applyTo` values are comma-separated strings, so each one was expanded into an array here.
- Brace patterns were deliberately avoided: the docs only document `{a,b}` support for [label/author/branch filter globs](https://www.greptile.com/docs/code-review/greptile-config-reference#glob-patterns-in-filters), not for `scope`. The rule files' `paths`/`globs` frontmatter uses braces (`**/*.{ts,tsx}`), so this PR derives `scope` from the already-expanded `applyTo` instead, where a wrong assumption would silently mean "rule never applies".

Locally verified: both files are valid JSON, prettier-clean (`pnpm lint:root` passes via the lint-staged pre-commit hook), and every referenced path exists and is tracked in git — all 12 files in `rules/coding-guidelines/` are covered, none missing.

Not verified: whether Greptile actually picks the files up on a real review — that needs a PR against this repo. The docs' suggested check is `@greptileai review this` on a PR with a deliberate violation.

## Open TODOs/questions

- **No changeset.** This is repo tooling config, which per [CONTRIBUTING.md](https://github.com/vivid-planet/dextinity/blob/main/CONTRIBUTING.md#when-to-add-a-changeset) ("changing the dev setup or workflows") does not get one.
- **`files.json` needs a manual update when a rule file is added.** `path` takes a single file, not a glob, so new `rules/coding-guidelines/*.instructions.md` files must be added here too. There is currently no central doc listing the consumers of `rules/` (`.github/copilot-review-instructions.md` is hand-maintained the same way), so nothing was updated for it — happy to add a note somewhere if you want a reminder.
- **`main` merged in** to pick up #6352 (the `ignorePatterns` type fix that an earlier revision of this description flagged as a follow-up) and #6350 (`autoApprove.filters`). The single conflict in `config.json` was resolved by keeping both sides: main's newline-separated `ignorePatterns` string and author filters, plus this PR's `instructions` field. The diff against `main` is now exactly the new `files.json` plus that one added line.

</details>

https://claude.ai/code/session_01GMQHMxZRQWaQn43a3eukQD