### PR TITLE
[greptile] Fix ignorePatterns type in Greptile config

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -3,13 +3,5 @@
     "autoApprove": {
         "enabled": true
     },
-    "ignorePatterns": [
-        "pnpm-lock.yaml",
-        "**/CHANGELOG.md",
-        "CHANGELOG.old.md",
-        "**/__snapshots__/**",
-        "**/generated/**",
-        "**/schema.gql",
-        "**/block-meta.json"
-    ]
+    "ignorePatterns": "pnpm-lock.yaml\n**/CHANGELOG.md\nCHANGELOG.old.md\n**/__snapshots__/**\n**/generated/**\n**/schema.gql\n**/block-meta.json"
 }


### PR DESCRIPTION
fix ignorePattern, this must be a string (.gitignore style)

see example https://www.greptile.com/docs/code-review/greptile-config-reference#complete-example


---
_Generated by [Claude Code](https://claude.ai/code/session_01KspKCWSZbtLGE7mKtvqQx8)_