### PR TITLE
cms-admin: Add minHeight option to createTipTapRichTextBlock

### DIFF
--- a/.changeset/tiptap-rich-text-min-height.md
+++ b/.changeset/tiptap-rich-text-min-height.md
@@ -1,0 +1,11 @@
+---
+"@dextinity/cms-admin": minor
+---
+
+Add `minHeight` option to `createTipTapRichTextBlock`
+
+The editor's content area previously had a hardcoded minimum height of 200px with no way to override it. Compact use cases (e.g. a single-line rich text field) now have a supported way to shrink it:
+
+```ts
+createTipTapRichTextBlock({ minHeight: 0 });
+```

--- a/packages/admin/cms-admin/src/blocks/tipTap/TipTapContentTranslationDialog.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/TipTapContentTranslationDialog.tsx
@@ -11,7 +11,15 @@ interface TipTapContentTranslationDialogProps {
     onApplyTranslation: (content: JSONContent) => void;
     editorProps: Pick<
         TipTapEditorProps,
-        "resolvedOptions" | "textBlockStyles" | "inlineStyles" | "placeholders" | "linkBlock" | "childBlocks" | "maxTextBlocks" | "listLevelMax"
+        | "resolvedOptions"
+        | "textBlockStyles"
+        | "inlineStyles"
+        | "placeholders"
+        | "linkBlock"
+        | "childBlocks"
+        | "maxTextBlocks"
+        | "listLevelMax"
+        | "minHeight"
     >;
 }
 

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -179,7 +179,7 @@ export interface TipTapChildBlock {
     display: "block" | "inline";
 }
 
-interface TipTapRichTextBlockFactoryOptions {
+export interface TipTapRichTextBlockFactoryOptions {
     /**
      * Shows the undo/redo buttons in the toolbar. The keyboard shortcuts work regardless. Defaults to `true`.
      */
@@ -261,6 +261,10 @@ interface TipTapRichTextBlockFactoryOptions {
      * A value of 1 means only a flat list (no nesting), 2 allows one level of sub-lists, etc.
      */
     listLevelMax?: number;
+    /**
+     * Minimum height (in px) of the editor's content area. Defaults to `200`.
+     */
+    minHeight?: number;
 }
 
 function getPlainTextFromContent(content: JSONContent): string {
@@ -501,6 +505,7 @@ export interface TipTapEditorProps {
     childBlocks: Record<string, TipTapChildBlock>;
     maxTextBlocks?: number;
     listLevelMax?: number;
+    minHeight?: number;
     readOnly?: boolean;
 }
 
@@ -515,6 +520,7 @@ export const TipTapEditor = ({
     childBlocks,
     maxTextBlocks,
     listLevelMax,
+    minHeight = 200,
     readOnly,
 }: TipTapEditorProps) => {
     const childBlocksByKey: Record<string, BlockInterface> = Object.fromEntries(Object.entries(childBlocks).map(([key, { block }]) => [key, block]));
@@ -633,7 +639,7 @@ export const TipTapEditor = ({
                                 canTranslate={canTranslate}
                                 onTranslateClick={handleTranslateClick}
                             />
-                            <Box sx={{ "& .tiptap": { minHeight: 200, p: "20px", outline: "none" } }}>{editorNode}</Box>
+                            <Box sx={{ "& .tiptap": { minHeight, p: "20px", outline: "none" } }}>{editorNode}</Box>
                         </Box>
                     )}
                     {translationDialogState && (
@@ -681,6 +687,7 @@ export const createTipTapRichTextBlock = (options: TipTapRichTextBlockFactoryOpt
     const hasChildBlocks = Object.keys(childBlocks).length > 0;
     const maxTextBlocks = options.maxTextBlocks;
     const listLevelMax = options.listLevelMax;
+    const minHeight = options.minHeight;
 
     const sharedEditorProps = {
         resolvedOptions,
@@ -691,6 +698,7 @@ export const createTipTapRichTextBlock = (options: TipTapRichTextBlockFactoryOpt
         childBlocks,
         maxTextBlocks,
         listLevelMax,
+        minHeight,
     };
 
     const tipTapExtensions = buildTipTapExtensions({

--- a/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
+++ b/packages/admin/cms-admin/src/blocks/tipTap/createTipTapRichTextBlock.tsx
@@ -179,7 +179,7 @@ export interface TipTapChildBlock {
     display: "block" | "inline";
 }
 
-export interface TipTapRichTextBlockFactoryOptions {
+interface TipTapRichTextBlockFactoryOptions {
     /**
      * Shows the undo/redo buttons in the toolbar. The keyboard shortcuts work regardless. Defaults to `true`.
      */
@@ -661,6 +661,7 @@ export const TipTapEditor = ({
                                 childBlocks,
                                 maxTextBlocks,
                                 listLevelMax,
+                                minHeight,
                             }}
                         />
                     )}

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -85,6 +85,7 @@ export type {
     TipTapInlineStyle,
     TipTapPlaceholder,
     TipTapRichTextBlockContent,
+    TipTapRichTextBlockFactoryOptions,
     TipTapTextBlockStyle,
     TipTapTextBlockType,
 } from "./blocks/tipTap/createTipTapRichTextBlock";

--- a/packages/admin/cms-admin/src/index.ts
+++ b/packages/admin/cms-admin/src/index.ts
@@ -85,7 +85,6 @@ export type {
     TipTapInlineStyle,
     TipTapPlaceholder,
     TipTapRichTextBlockContent,
-    TipTapRichTextBlockFactoryOptions,
     TipTapTextBlockStyle,
     TipTapTextBlockType,
 } from "./blocks/tipTap/createTipTapRichTextBlock";


### PR DESCRIPTION
## Summary
- The TipTap editor's content area had a hardcoded 200px minimum height with no override, unlike the old Draft.js-based `Rte` component, which exposed `minHeight` as a themeable prop
- This blocked compact use cases (e.g. a single-line rich text field) from shrinking the editor during a migration from `createRichTextBlock` to `createTipTapRichTextBlock`
- Adds a `minHeight?: number` factory option to `createTipTapRichTextBlock`, defaulting to `200` to preserve current behavior

## Test plan
- [x] `pnpm run lint:fix` passes
- [x] `tsc --noEmit` passes
- [x] Existing unit tests for `createTipTapRichTextBlock` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)