### PR TITLE
Keep manually assigned content scopes that are also granted by a rule

### DIFF
--- a/.changeset/user-permissions-admin-content-scopes.md
+++ b/.changeset/user-permissions-admin-content-scopes.md
@@ -1,0 +1,13 @@
+---
+"@dextinity/cms-api": minor
+"@dextinity/cms-admin": minor
+---
+
+Rework the content scopes management in the user permissions panel
+
+The user permissions panel now renders a consistent set of content scope columns for every user based on the content scope dimensions declared in the API (`userPermissionsAvailableContentScopeDimensions`). A dimension whose value is the `"*"` wildcard is shown as "All".
+
+- Content scopes are assigned through an "Add scope" dialog that builds a scope from one dropdown per enumerable dimension, cascading so that only existing combinations can be selected. Each dropdown also offers an "All" option to grant every value of that dimension (`*` wildcard). Dimensions that are not part of `availableContentScopes` are entered as a free text value (`*` grants all values).
+- The assigned content scopes and the permission-specific content scopes (override dialog) use the same paginated grid and add dialog, and show manually assigned scopes first.
+- Removing a content scope asks for confirmation, consistent with removing a permission.
+- The assignment type is shown in a consistent way across the permissions and content scopes grids.

--- a/.changeset/user-permissions-manual-content-scopes.md
+++ b/.changeset/user-permissions-manual-content-scopes.md
@@ -1,0 +1,10 @@
+---
+"@dextinity/cms-api": minor
+"@dextinity/cms-admin": minor
+---
+
+Keep manually assigned content scopes that are also granted by a rule
+
+A content scope that was both manually assigned and granted by a rule could not be removed in the assigned-scopes grid and was silently dropped when another scope was added or removed. The admin derived the manual scopes by subtracting the rule-based scopes from the union, which loses a scope that is present in both.
+
+The API now exposes the persisted manual scopes directly via `userPermissionsManualContentScopes(userId)`, and the assigned-scopes grid uses it as the source of truth for the manual assignments instead of deriving them. Such a scope is now shown as "Manual", stays removable, and is preserved when editing other scopes.

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -313,6 +313,11 @@ type BuildTemplate {
   name: String!
 }
 
+type ContentScopeDimension {
+  label: String!
+  name: String!
+}
+
 type ContentScopeWithLabel {
   label: JSONObject!
   scope: JSONObject!
@@ -2036,6 +2041,7 @@ type Query {
   redirects(active: Boolean, query: String, scope: RedirectScopeInput!, sortColumnName: String, sortDirection: SortDirection! = ASC, type: RedirectGenerationType): [Redirect!]! @deprecated(reason: "Use paginatedRedirects instead. Will be removed in the next version.")
   sitePreviewJwt(includeInvisible: Boolean!, path: String!, scope: JSONObject!): String!
   topMenu(scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
+  userPermissionsAvailableContentScopeDimensions: [ContentScopeDimension!]!
   userPermissionsAvailableContentScopes: [ContentScopeWithLabel!]!
   userPermissionsAvailablePermissions: [String!]!
   userPermissionsContentScopes(skipManual: Boolean, userId: String!): [JSONObject!]!

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -2045,6 +2045,7 @@ type Query {
   userPermissionsAvailableContentScopes: [ContentScopeWithLabel!]!
   userPermissionsAvailablePermissions: [String!]!
   userPermissionsContentScopes(skipManual: Boolean, userId: String!): [JSONObject!]!
+  userPermissionsManualContentScopes(userId: String!): [JSONObject!]!
   userPermissionsPermission(id: ID!, userId: String): UserPermission!
   userPermissionsPermissionList(userId: String!): [UserPermission!]!
   userPermissionsUserById(id: String!): UserPermissionsUser!

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/AddContentScopeDialog.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/AddContentScopeDialog.tsx
@@ -1,0 +1,43 @@
+import { CancelButton, messages, SaveBoundary, SaveBoundarySaveButton } from "@dextinity/admin";
+import { Add } from "@dextinity/admin-icons";
+import {
+    // eslint-disable-next-line no-restricted-imports
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+} from "@mui/material";
+import { FormattedMessage } from "react-intl";
+
+import type { ContentScope } from "./ContentScopeDataGrid";
+import { SelectScopesDialogContent } from "./selectScopesDialogContent/SelectScopesDialogContent";
+
+interface AddContentScopeDialogProps {
+    open: boolean;
+    onClose: () => void;
+    /** Called with the scope selected in the dialog. The dialog closes after this resolves. */
+    onAdd: (scope: ContentScope) => Promise<void> | void;
+}
+
+export function AddContentScopeDialog({ open, onClose, onAdd }: AddContentScopeDialogProps) {
+    return (
+        <SaveBoundary onAfterSave={onClose}>
+            <Dialog open={open} maxWidth="sm" fullWidth>
+                <DialogTitle>
+                    <FormattedMessage id="dextinity.userPermissions.addScope" defaultMessage="Add scope" />
+                </DialogTitle>
+                <DialogContent>
+                    <SelectScopesDialogContent onSubmit={onAdd} />
+                </DialogContent>
+                <DialogActions>
+                    <CancelButton onClick={onClose}>
+                        <FormattedMessage {...messages.close} />
+                    </CancelButton>
+                    <SaveBoundarySaveButton startIcon={<Add />}>
+                        <FormattedMessage id="dextinity.userPermissions.addScope" defaultMessage="Add scope" />
+                    </SaveBoundarySaveButton>
+                </DialogActions>
+            </Dialog>
+        </SaveBoundary>
+    );
+}

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/ContentScopeDataGrid.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/ContentScopeDataGrid.tsx
@@ -1,0 +1,158 @@
+import { DataGridToolbar, FillSpace, type GridColDef, GridToolbarQuickFilter } from "@dextinity/admin";
+import { Typography } from "@mui/material";
+import type { GridRowSelectionModel, GridToolbarProps } from "@mui/x-data-grid";
+import type { ReactNode } from "react";
+import { useIntl } from "react-intl";
+
+import { DataGrid } from "../../../dataGrid/DataGrid";
+import { contentScopeAllValues, type ContentScope } from "./contentScope";
+import type { GQLAvailableContentScopesQuery } from "./selectScopesDialogContent/SelectScopesDialogContent.generated";
+
+export type { ContentScope };
+
+interface ToolbarProps extends GridToolbarProps {
+    toolbarAction?: ReactNode;
+}
+
+function ContentScopeDataGridToolbar({ toolbarAction }: ToolbarProps) {
+    return (
+        <DataGridToolbar>
+            <GridToolbarQuickFilter />
+            <FillSpace />
+            {toolbarAction}
+        </DataGridToolbar>
+    );
+}
+
+interface ContentScopeDataGridSelection {
+    selectedRowIds: string[];
+    onSelectedRowIdsChange: (selectedRowIds: string[]) => void;
+    disabled?: boolean;
+}
+
+interface ContentScopeDataGridProps {
+    rows: ContentScope[];
+    availableContentScopes: GQLAvailableContentScopesQuery["availableContentScopes"];
+    availableContentScopeDimensions?: Array<{ name: string; label: string }>;
+    hasAllContentScopes?: boolean;
+    /** Additional columns appended after the content scope dimension columns (e.g. assignment type or actions). */
+    additionalColumns?: GridColDef<ContentScope>[];
+    /** Rendered on the right of the toolbar (e.g. an "Add scope" button). */
+    toolbarAction?: ReactNode;
+    /** When set, the grid shows a checkbox for each row and reports the selected rows by their id. */
+    selection?: ContentScopeDataGridSelection;
+}
+
+/**
+ * Renders content scopes in a consistent grid: one column per content scope dimension, pagination and an optional
+ * checkbox selection. Shared by the assigned scopes grid and the permission-specific content scopes dialog.
+ */
+export function ContentScopeDataGrid({
+    rows,
+    availableContentScopes,
+    availableContentScopeDimensions,
+    hasAllContentScopes,
+    additionalColumns = [],
+    toolbarAction,
+    selection,
+}: ContentScopeDataGridProps) {
+    const intl = useIntl();
+    const allValuesLabel = intl.formatMessage({ id: "dextinity.userPermissions.allContentScopeValues", defaultMessage: "All" });
+    const columns: GridColDef<ContentScope>[] = [
+        ...generateGridColumnsFromContentScopeProperties(availableContentScopes, {
+            dimensions: availableContentScopeDimensions,
+            hasAllContentScopes,
+            allValuesLabel,
+        }),
+        ...additionalColumns,
+    ];
+
+    return (
+        <DataGrid<ContentScope>
+            rows={rows}
+            columns={columns}
+            loading={false}
+            getRowId={(row) => JSON.stringify(row)}
+            pagination
+            pageSizeOptions={[10, 25, 50]}
+            initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+            slots={{ toolbar: ContentScopeDataGridToolbar }}
+            slotProps={{ toolbar: { toolbarAction } as ToolbarProps }}
+            showToolbar
+            checkboxSelection={selection ? !selection.disabled : undefined}
+            rowSelectionModel={selection ? { type: "include", ids: new Set<string>(selection.selectedRowIds) } : undefined}
+            onRowSelectionModelChange={
+                selection
+                    ? (selectionModel: GridRowSelectionModel) =>
+                          selection.onSelectedRowIdsChange(Array.from(selectionModel.ids).map((id) => String(id)))
+                    : undefined
+            }
+            disableRowSelectionExcludeModel={selection !== undefined}
+        />
+    );
+}
+
+// Resolves the display value of a content scope dimension: the "all values" label for a wildcard, the dimension's label
+// from the available content scopes, or the raw value for a free value that is not part of the available content scopes.
+// Returns an empty string when the dimension is not set, so the grid can render a placeholder.
+function resolveContentScopeDimensionValue({
+    row,
+    propertyName,
+    availableContentScopes,
+    hasAllContentScopes,
+    allValuesLabel,
+}: {
+    row: ContentScope;
+    propertyName: string;
+    availableContentScopes: GQLAvailableContentScopesQuery["availableContentScopes"];
+    hasAllContentScopes: boolean;
+    allValuesLabel: string;
+}): string {
+    const value = row[propertyName];
+    // A user with all content scopes also has all values for dimensions that are not part of the available content scopes
+    // (e.g. an optional dimension), which are therefore not set on the scope.
+    if (value === contentScopeAllValues || (value === undefined && hasAllContentScopes)) {
+        return allValuesLabel;
+    }
+    // A wildcard dimension prevents the whole scope from matching an available scope, so labels are resolved per dimension.
+    // Available scope values are raw JSON (e.g. numbers), while row values are strings, so compare as strings.
+    const label = availableContentScopes.find((availableContentScope) => String(availableContentScope.scope[propertyName]) === String(value))
+        ?.label?.[propertyName];
+    if (label) {
+        return label;
+    }
+    // A value without a label is a free value of a dimension that is not part of the available content scopes.
+    return value !== undefined ? String(value) : "";
+}
+
+function generateGridColumnsFromContentScopeProperties(
+    availableContentScopes: GQLAvailableContentScopesQuery["availableContentScopes"],
+    {
+        dimensions = [],
+        hasAllContentScopes = false,
+        allValuesLabel,
+    }: {
+        dimensions?: Array<{ name: string; label: string }>;
+        hasAllContentScopes?: boolean;
+        allValuesLabel: string;
+    },
+): GridColDef<ContentScope>[] {
+    // The declared content scope dimensions are the sole source of columns, so every user shows a consistent set of columns
+    // regardless of which values happen to be present in the scopes.
+    return dimensions.map((dimension): GridColDef<ContentScope> => {
+        const propertyName = dimension.name;
+        return {
+            field: propertyName,
+            flex: 1,
+            pinnable: false,
+            sortable: false,
+            filterable: true,
+            headerName: dimension.label,
+            // Resolve the label via valueGetter (not only renderCell) so filtering and quick filtering match the displayed
+            // label instead of the raw scope value.
+            valueGetter: (value, row) =>
+                resolveContentScopeDimensionValue({ row, propertyName, availableContentScopes, hasAllContentScopes, allValuesLabel }),
+            renderCell: ({ value }) => (value ? <Typography variant="body2">{value}</Typography> : "-"),
+        };
+    });
+}

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/ContentScopeGrid.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/ContentScopeGrid.tsx
@@ -34,6 +34,7 @@ export const ContentScopeGrid = ({ userId }: { userId: string }) => {
             query ContentScopes($userId: String!) {
                 userContentScopes: userPermissionsContentScopes(userId: $userId)
                 userContentScopesSkipManual: userPermissionsContentScopes(userId: $userId, skipManual: true)
+                userContentScopesManual: userPermissionsManualContentScopes(userId: $userId)
                 availableContentScopes: userPermissionsAvailableContentScopes {
                     scope
                     label
@@ -68,14 +69,14 @@ export const ContentScopeGrid = ({ userId }: { userId: string }) => {
             data.userContentScopesSkipManual.some((scope) => isEqual(scope, availableContentScope.scope)),
         );
 
-    // A scope is rule-based (as opposed to manually assigned) when it is part of the scopes granted by rule. Only manually
-    // assigned scopes can be deleted here.
-    const isRuleBasedScope = (scope: ContentScope) => data.userContentScopesSkipManual.some((ruleBasedScope) => isEqual(ruleBasedScope, scope));
+    // The manually assigned scopes as persisted, taken directly from the API (not derived by subtracting the rule-based
+    // scopes), so a scope that is both manually assigned and rule-based is preserved and not silently dropped on the next edit.
+    // Only manually assigned scopes can be deleted here.
+    const manualContentScopes = deduplicateContentScopes(data.userContentScopesManual);
+    const isManualScope = (scope: ContentScope) => manualContentScopes.some((manualScope) => isEqual(manualScope, scope));
 
-    // Show manually assigned scopes before rule-based ones (sort is stable, so the order within each group is preserved).
-    const sortedContentScopes = [...userContentScopes].sort((a, b) => Number(isRuleBasedScope(a)) - Number(isRuleBasedScope(b)));
-
-    const manualContentScopes = userContentScopes.filter((contentScope) => !isRuleBasedScope(contentScope));
+    // Show manually assigned scopes before purely rule-based ones (sort is stable, so the order within each group is preserved).
+    const sortedContentScopes = [...userContentScopes].sort((a, b) => Number(isManualScope(b)) - Number(isManualScope(a)));
 
     const setManualContentScopes = async (contentScopes: ContentScope[]) => {
         await updateContentScopes({
@@ -104,10 +105,10 @@ export const ContentScopeGrid = ({ userId }: { userId: string }) => {
             filterable: false,
             headerName: intl.formatMessage({ id: "dextinity.userPermissions.source", defaultMessage: "Assignment type" }),
             renderCell: ({ row }) =>
-                isRuleBasedScope(row) ? (
-                    <FormattedMessage id="dextinity.userPermissions.assignmentType.byRule" defaultMessage="By rule" />
-                ) : (
+                isManualScope(row) ? (
                     <FormattedMessage id="dextinity.userPermissions.assignmentType.manual" defaultMessage="Manual" />
+                ) : (
+                    <FormattedMessage id="dextinity.userPermissions.assignmentType.byRule" defaultMessage="By rule" />
                 ),
         },
         {
@@ -119,11 +120,11 @@ export const ContentScopeGrid = ({ userId }: { userId: string }) => {
             sortable: false,
             filterable: false,
             renderCell: ({ row }) =>
-                isRuleBasedScope(row) ? null : (
+                isManualScope(row) ? (
                     <IconButton onClick={() => setScopeToDelete(row)} disabled={updateInProgress}>
                         <Delete />
                     </IconButton>
-                ),
+                ) : null,
         },
     ];
 

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/ContentScopeGrid.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/ContentScopeGrid.tsx
@@ -1,56 +1,33 @@
-import { gql, useQuery } from "@apollo/client";
-import {
-    Button,
-    CancelButton,
-    DataGridToolbar,
-    FieldSet,
-    FillSpace,
-    type GridColDef,
-    Loading,
-    messages,
-    SaveBoundary,
-    SaveBoundarySaveButton,
-} from "@dextinity/admin";
-import { Select } from "@dextinity/admin-icons";
-import {
-    // eslint-disable-next-line no-restricted-imports
-    Dialog,
-    DialogActions,
-    DialogTitle,
-    Typography,
-} from "@mui/material";
-import type { GridToolbarProps } from "@mui/x-data-grid";
+import { gql, useMutation, useQuery } from "@apollo/client";
+import { Button, DeleteDialog, FieldSet, type GridColDef, Loading } from "@dextinity/admin";
+import { Add, Delete } from "@dextinity/admin-icons";
+import { IconButton } from "@mui/material";
 import isEqual from "lodash.isequal";
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { DataGrid } from "../../../dataGrid/DataGrid";
-import { camelCaseToHumanReadable } from "../../utils/camelCaseToHumanReadable";
 import { deduplicateContentScopes } from "../../utils/deduplicateContentScopes";
-import type { GQLContentScopesQuery, GQLContentScopesQueryVariables } from "./ContentScopeGrid.generated";
-import { SelectScopesDialogContent } from "./selectScopesDialogContent/SelectScopesDialogContent";
-import type { GQLAvailableContentScopesQuery } from "./selectScopesDialogContent/SelectScopesDialogContent.generated";
-
-type ContentScope = {
-    [key: string]: string;
-};
-
-interface ToolbarProps extends GridToolbarProps {
-    toolbarAction?: ReactNode;
-}
-
-function ContentScopeGridToolbar({ toolbarAction }: ToolbarProps) {
-    return (
-        <DataGridToolbar>
-            <FillSpace />
-            {toolbarAction}
-        </DataGridToolbar>
-    );
-}
+import { AddContentScopeDialog } from "./AddContentScopeDialog";
+import { type ContentScope, ContentScopeDataGrid } from "./ContentScopeDataGrid";
+import type {
+    GQLContentScopesQuery,
+    GQLContentScopesQueryVariables,
+    GQLUpdateContentScopesMutation,
+    GQLUpdateContentScopesMutationVariables,
+} from "./ContentScopeGrid.generated";
 
 export const ContentScopeGrid = ({ userId }: { userId: string }) => {
     const intl = useIntl();
     const [open, setOpen] = useState(false);
+    const [scopeToDelete, setScopeToDelete] = useState<ContentScope | null>(null);
+
+    const [updateContentScopes, { loading: updateInProgress }] = useMutation<GQLUpdateContentScopesMutation, GQLUpdateContentScopesMutationVariables>(
+        gql`
+            mutation UpdateContentScopes($userId: String!, $input: UserContentScopesInput!) {
+                userPermissionsUpdateContentScopes(userId: $userId, input: $input)
+            }
+        `,
+    );
 
     const { data, error } = useQuery<GQLContentScopesQuery, GQLContentScopesQueryVariables>(
         gql`
@@ -59,6 +36,10 @@ export const ContentScopeGrid = ({ userId }: { userId: string }) => {
                 userContentScopesSkipManual: userPermissionsContentScopes(userId: $userId, skipManual: true)
                 availableContentScopes: userPermissionsAvailableContentScopes {
                     scope
+                    label
+                }
+                availableContentScopeDimensions: userPermissionsAvailableContentScopeDimensions {
+                    name
                     label
                 }
             }
@@ -76,79 +57,105 @@ export const ContentScopeGrid = ({ userId }: { userId: string }) => {
         return <Loading />;
     }
 
+    // The user's content scopes are a union of rule-based and manually assigned scopes and can therefore contain duplicates.
     const userContentScopes = deduplicateContentScopes(data.userContentScopes);
-    const columns: GridColDef<ContentScope>[] = generateGridColumnsFromContentScopeProperties(data.availableContentScopes);
 
-    const toolbarSlotProps: ToolbarProps = {
-        toolbarAction: (
-            <Button startIcon={<Select />} onClick={() => setOpen(true)} variant="primary">
-                <FormattedMessage id="dextinity.userPermissions.selectScopes" defaultMessage="Assign scopes" />
-            </Button>
-        ),
+    // A user has all content scopes (e.g. an admin) when the rule-based scopes cover every available content scope. Such a
+    // user also has all values for dimensions that are not part of the available content scopes (e.g. an optional dimension).
+    const hasAllContentScopes =
+        data.availableContentScopes.length > 0 &&
+        data.availableContentScopes.every((availableContentScope) =>
+            data.userContentScopesSkipManual.some((scope) => isEqual(scope, availableContentScope.scope)),
+        );
+
+    // A scope is rule-based (as opposed to manually assigned) when it is part of the scopes granted by rule. Only manually
+    // assigned scopes can be deleted here.
+    const isRuleBasedScope = (scope: ContentScope) => data.userContentScopesSkipManual.some((ruleBasedScope) => isEqual(ruleBasedScope, scope));
+
+    // Show manually assigned scopes before rule-based ones (sort is stable, so the order within each group is preserved).
+    const sortedContentScopes = [...userContentScopes].sort((a, b) => Number(isRuleBasedScope(a)) - Number(isRuleBasedScope(b)));
+
+    const manualContentScopes = userContentScopes.filter((contentScope) => !isRuleBasedScope(contentScope));
+
+    const setManualContentScopes = async (contentScopes: ContentScope[]) => {
+        await updateContentScopes({
+            variables: { userId, input: { contentScopes } },
+            refetchQueries: ["ContentScopes"],
+            awaitRefetchQueries: true,
+        });
     };
+
+    const handleAddScope = async (scope: ContentScope) => {
+        if (!manualContentScopes.some((contentScope) => isEqual(contentScope, scope))) {
+            await setManualContentScopes([...manualContentScopes, scope]);
+        }
+    };
+
+    const handleDeleteScope = async (scope: ContentScope) => {
+        await setManualContentScopes(manualContentScopes.filter((contentScope) => !isEqual(contentScope, scope)));
+    };
+
+    const additionalColumns: GridColDef<ContentScope>[] = [
+        {
+            field: "source",
+            width: 200,
+            pinnable: false,
+            sortable: false,
+            filterable: false,
+            headerName: intl.formatMessage({ id: "dextinity.userPermissions.source", defaultMessage: "Assignment type" }),
+            renderCell: ({ row }) =>
+                isRuleBasedScope(row) ? (
+                    <FormattedMessage id="dextinity.userPermissions.assignmentType.byRule" defaultMessage="By rule" />
+                ) : (
+                    <FormattedMessage id="dextinity.userPermissions.assignmentType.manual" defaultMessage="Manual" />
+                ),
+        },
+        {
+            field: "actions",
+            headerName: "",
+            width: 52,
+            align: "right",
+            pinnable: false,
+            sortable: false,
+            filterable: false,
+            renderCell: ({ row }) =>
+                isRuleBasedScope(row) ? null : (
+                    <IconButton onClick={() => setScopeToDelete(row)} disabled={updateInProgress}>
+                        <Delete />
+                    </IconButton>
+                ),
+        },
+    ];
 
     return (
         <FieldSet title={intl.formatMessage({ id: "dextinity.userPermissions.assignedScopes", defaultMessage: "Assigned Scopes" })} disablePadding>
-            <DataGrid
-                rows={userContentScopes}
-                columns={columns}
-                rowCount={userContentScopes.length}
-                loading={false}
-                getRowId={(row) => JSON.stringify(row)}
-                slots={{
-                    toolbar: ContentScopeGridToolbar,
-                }}
-                slotProps={{
-                    toolbar: toolbarSlotProps,
-                }}
-                showToolbar
+            <ContentScopeDataGrid
+                rows={sortedContentScopes}
+                availableContentScopes={data.availableContentScopes}
+                availableContentScopeDimensions={data.availableContentScopeDimensions}
+                hasAllContentScopes={hasAllContentScopes}
+                additionalColumns={additionalColumns}
+                toolbarAction={
+                    <Button startIcon={<Add />} onClick={() => setOpen(true)} variant="primary" disabled={updateInProgress}>
+                        <FormattedMessage id="dextinity.userPermissions.addScope" defaultMessage="Add scope" />
+                    </Button>
+                }
             />
-            <SaveBoundary
-                onAfterSave={() => {
-                    setOpen(false);
+            <AddContentScopeDialog open={open} onClose={() => setOpen(false)} onAdd={handleAddScope} />
+            <DeleteDialog
+                dialogOpen={scopeToDelete !== null}
+                deleteType="remove"
+                onCancel={() => setScopeToDelete(null)}
+                onDelete={async () => {
+                    try {
+                        if (scopeToDelete !== null) {
+                            await handleDeleteScope(scopeToDelete);
+                        }
+                    } finally {
+                        setScopeToDelete(null);
+                    }
                 }}
-            >
-                <Dialog open={open} maxWidth="lg">
-                    <DialogTitle>
-                        <FormattedMessage id="dextinity.userScopes.dialog.title" defaultMessage="Select scopes" />
-                    </DialogTitle>
-                    <SelectScopesDialogContent
-                        userId={userId}
-                        userContentScopes={userContentScopes}
-                        userContentScopesSkipManual={data.userContentScopesSkipManual}
-                    />
-                    <DialogActions>
-                        <CancelButton onClick={() => setOpen(false)}>
-                            <FormattedMessage {...messages.close} />
-                        </CancelButton>
-                        <SaveBoundarySaveButton />
-                    </DialogActions>
-                </Dialog>
-            </SaveBoundary>
+            />
         </FieldSet>
     );
 };
-
-export function generateGridColumnsFromContentScopeProperties(
-    availableContentScopes: GQLAvailableContentScopesQuery["availableContentScopes"],
-): GridColDef[] {
-    const uniquePropertyNames = Array.from(new Set(availableContentScopes.flatMap((item) => Object.keys(item.scope))));
-    return uniquePropertyNames.map((propertyName, index) => {
-        return {
-            field: propertyName,
-            flex: 1,
-            pinnable: false,
-            sortable: false,
-            filterable: true,
-            headerName: camelCaseToHumanReadable(propertyName),
-            renderCell: ({ row }: { row: ContentScope }) => {
-                const contentScopeWithLabel = availableContentScopes.find((availableContentScope) => isEqual(availableContentScope.scope, row));
-                if (contentScopeWithLabel) {
-                    return <Typography variant={index === 0 ? "subtitle2" : "body2"}>{contentScopeWithLabel.label[propertyName]}</Typography>;
-                } else {
-                    return "-";
-                }
-            },
-        };
-    });
-}

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/OverrideContentScopesDialog.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/OverrideContentScopesDialog.tsx
@@ -1,15 +1,6 @@
-import { gql, useApolloClient, useQuery } from "@apollo/client";
-import {
-    CancelButton,
-    DataGridToolbar,
-    Field,
-    FillSpace,
-    FinalForm,
-    FinalFormSwitch,
-    type GridColDef,
-    GridToolbarQuickFilter,
-    SaveButton,
-} from "@dextinity/admin";
+import { gql, useMutation, useQuery } from "@apollo/client";
+import { Button, CancelButton, DeleteDialog, type GridColDef } from "@dextinity/admin";
+import { Add, Delete } from "@dextinity/admin-icons";
 import {
     CircularProgress,
     // eslint-disable-next-line no-restricted-imports
@@ -17,12 +8,16 @@ import {
     DialogActions,
     DialogContent,
     DialogTitle,
+    FormControlLabel,
+    IconButton,
+    Switch,
 } from "@mui/material";
+import isEqual from "lodash.isequal";
+import { useState } from "react";
 import { FormattedMessage } from "react-intl";
 
-import type { ContentScope } from "../../../contentScope/Provider";
-import { DataGrid } from "../../../dataGrid/DataGrid";
-import { generateGridColumnsFromContentScopeProperties } from "./ContentScopeGrid";
+import { AddContentScopeDialog } from "./AddContentScopeDialog";
+import { type ContentScope, ContentScopeDataGrid } from "./ContentScopeDataGrid";
 import {
     type GQLOverrideContentScopesMutation,
     type GQLOverrideContentScopesMutationVariables,
@@ -31,54 +26,39 @@ import {
     namedOperations,
 } from "./OverrideContentScopesDialog.generated";
 
-interface FormSubmitData {
-    overrideContentScopes: boolean;
-    contentScopes: string[];
-}
 interface FormProps {
     permissionId: string;
     userId: string;
     handleDialogClose: () => void;
 }
 
-function OverrideContentScopesDialogGridToolbar() {
-    return (
-        <DataGridToolbar>
-            <GridToolbarQuickFilter />
-            <FillSpace />
-        </DataGridToolbar>
-    );
-}
-
 export const OverrideContentScopesDialog = ({ permissionId, userId, handleDialogClose }: FormProps) => {
-    const client = useApolloClient();
+    const [addScopeOpen, setAddScopeOpen] = useState(false);
+    const [scopeToDelete, setScopeToDelete] = useState<ContentScope | null>(null);
+    // Optimistic override toggle: reflects the click immediately while the mutation persists in the background. `null` means
+    // "not changed locally, use the persisted value".
+    const [overrideContentScopesToggle, setOverrideContentScopesToggle] = useState<boolean | null>(null);
 
-    const submit = async (data: FormSubmitData) => {
-        await client.mutate<GQLOverrideContentScopesMutation, GQLOverrideContentScopesMutationVariables>({
-            mutation: gql`
-                mutation OverrideContentScopes($input: UserPermissionOverrideContentScopesInput!) {
-                    userPermissionsUpdateOverrideContentScopes(input: $input) {
-                        id
-                    }
-                }
-            `,
-            variables: {
-                input: {
-                    permissionId,
-                    overrideContentScopes: data.overrideContentScopes,
-                    contentScopes: data.contentScopes.map((contentScope) => JSON.parse(contentScope)),
-                },
-            },
-            refetchQueries: [namedOperations.Query.PermissionContentScopes, "Permissions"],
-        });
-        handleDialogClose();
-    };
+    const [updateOverrideContentScopes, { loading: updateInProgress }] = useMutation<
+        GQLOverrideContentScopesMutation,
+        GQLOverrideContentScopesMutationVariables
+    >(gql`
+        mutation OverrideContentScopes($input: UserPermissionOverrideContentScopesInput!) {
+            userPermissionsUpdateOverrideContentScopes(input: $input) {
+                id
+            }
+        }
+    `);
 
     const { data, error } = useQuery<GQLPermissionContentScopesQuery, GQLPermissionContentScopesQueryVariables>(
         gql`
             query PermissionContentScopes($permissionId: ID!, $userId: String!) {
                 availableContentScopes: userPermissionsAvailableContentScopes {
                     scope
+                    label
+                }
+                availableContentScopeDimensions: userPermissionsAvailableContentScopeDimensions {
+                    name
                     label
                 }
                 permission: userPermissionsPermission(id: $permissionId, userId: $userId) {
@@ -101,80 +81,125 @@ export const OverrideContentScopesDialog = ({ permissionId, userId, handleDialog
         return <CircularProgress />;
     }
 
-    const initialValues: FormSubmitData = {
-        overrideContentScopes: data.permission.overrideContentScopes,
-        contentScopes: data.permission.contentScopes.map((v) => JSON.stringify(v)),
-    };
-    const disabled = data && data.permission.source === "BY_RULE";
+    const disabled = data.permission.source === "BY_RULE";
+    const contentScopes = data.permission.contentScopes as ContentScope[];
+    const overrideContentScopesEnabled = overrideContentScopesToggle ?? data.permission.overrideContentScopes;
 
-    const columns: GridColDef<ContentScope>[] = generateGridColumnsFromContentScopeProperties(data.availableContentScopes);
+    // The toggle and the scopes are both persisted immediately (like the assigned scopes grid), so the dialog needs no save
+    // button. The toggle value is persisted along with the scopes so added scopes aren't hidden again on reopen.
+    const persist = async ({
+        overrideContentScopes,
+        contentScopes: newContentScopes,
+    }: {
+        overrideContentScopes: boolean;
+        contentScopes: ContentScope[];
+    }) => {
+        await updateOverrideContentScopes({
+            variables: {
+                input: { permissionId, overrideContentScopes, contentScopes: newContentScopes },
+            },
+            refetchQueries: [namedOperations.Query.PermissionContentScopes, "Permissions"],
+            awaitRefetchQueries: true,
+        });
+    };
+
+    const handleToggleChange = async (checked: boolean) => {
+        const previous = overrideContentScopesEnabled;
+        setOverrideContentScopesToggle(checked);
+        try {
+            await persist({ overrideContentScopes: checked, contentScopes });
+        } catch {
+            setOverrideContentScopesToggle(previous);
+        }
+    };
+
+    const handleAddScope = async (scope: ContentScope) => {
+        if (!contentScopes.some((contentScope) => isEqual(contentScope, scope))) {
+            await persist({ overrideContentScopes: overrideContentScopesEnabled, contentScopes: [...contentScopes, scope] });
+        }
+    };
+
+    const handleDeleteScope = async (scope: ContentScope) => {
+        await persist({
+            overrideContentScopes: overrideContentScopesEnabled,
+            contentScopes: contentScopes.filter((contentScope) => !isEqual(contentScope, scope)),
+        });
+    };
+
+    const additionalColumns: GridColDef<ContentScope>[] = disabled
+        ? []
+        : [
+              {
+                  field: "actions",
+                  headerName: "",
+                  width: 52,
+                  align: "right",
+                  pinnable: false,
+                  sortable: false,
+                  filterable: false,
+                  renderCell: ({ row }) => (
+                      <IconButton onClick={() => setScopeToDelete(row)} disabled={updateInProgress}>
+                          <Delete />
+                      </IconButton>
+                  ),
+              },
+          ];
 
     return (
         <Dialog maxWidth="lg" open={true}>
-            <FinalForm<FormSubmitData>
-                mode="edit"
-                onSubmit={submit}
-                initialValues={initialValues}
-                render={({ values }) => (
+            <DialogTitle>
+                <FormattedMessage id="dextinity.userPermissions.scopes" defaultMessage="Scopes" />
+            </DialogTitle>
+            <DialogContent>
+                <FormControlLabel
+                    labelPlacement="start"
+                    control={
+                        <Switch
+                            checked={overrideContentScopesEnabled}
+                            onChange={(event) => handleToggleChange(event.target.checked)}
+                            disabled={disabled || updateInProgress}
+                        />
+                    }
+                    label={<FormattedMessage id="dextinity.userPermissions.overrideScopes" defaultMessage="Permission-specific Content-Scopes" />}
+                />
+                {overrideContentScopesEnabled && (
                     <>
-                        <DialogTitle>
-                            <FormattedMessage id="dextinity.userPermissions.scopes" defaultMessage="Scopes" />
-                        </DialogTitle>
-                        <DialogContent>
-                            <Field
-                                name="overrideContentScopes"
-                                label={
-                                    <FormattedMessage
-                                        id="dextinity.userPermissions.overrideScopes"
-                                        defaultMessage="Permission-specific Content-Scopes"
-                                    />
+                        <ContentScopeDataGrid
+                            rows={contentScopes}
+                            availableContentScopes={data.availableContentScopes}
+                            availableContentScopeDimensions={data.availableContentScopeDimensions}
+                            additionalColumns={additionalColumns}
+                            toolbarAction={
+                                disabled ? undefined : (
+                                    <Button startIcon={<Add />} onClick={() => setAddScopeOpen(true)} variant="primary" disabled={updateInProgress}>
+                                        <FormattedMessage id="dextinity.userPermissions.addScope" defaultMessage="Add scope" />
+                                    </Button>
+                                )
+                            }
+                        />
+                        <AddContentScopeDialog open={addScopeOpen} onClose={() => setAddScopeOpen(false)} onAdd={handleAddScope} />
+                        <DeleteDialog
+                            dialogOpen={scopeToDelete !== null}
+                            deleteType="remove"
+                            onCancel={() => setScopeToDelete(null)}
+                            onDelete={async () => {
+                                try {
+                                    if (scopeToDelete !== null) {
+                                        await handleDeleteScope(scopeToDelete);
+                                    }
+                                } finally {
+                                    setScopeToDelete(null);
                                 }
-                                component={FinalFormSwitch}
-                                type="checkbox"
-                                disabled={disabled}
-                            />
-                            {values.overrideContentScopes && (
-                                <Field<string[]> name="contentScopes" fullWidth>
-                                    {(props) => {
-                                        return (
-                                            <DataGrid
-                                                autoHeight={true}
-                                                rows={(
-                                                    data.availableContentScopes.filter(
-                                                        (obj) => !Object.values(obj).every((value) => value === undefined),
-                                                    ) ?? []
-                                                ).map((obj) => obj.scope)}
-                                                columns={columns}
-                                                rowCount={data.availableContentScopes.length}
-                                                loading={false}
-                                                getRowHeight={() => "auto"}
-                                                getRowId={(row) => JSON.stringify(row)}
-                                                checkboxSelection={!disabled}
-                                                rowSelectionModel={{ type: "include", ids: new Set(props.input.value) }}
-                                                onRowSelectionModelChange={(selectionModel) => {
-                                                    props.input.onChange(Array.from(selectionModel.ids).map((id) => String(id)));
-                                                }}
-                                                disableRowSelectionExcludeModel
-                                                slots={{
-                                                    toolbar: OverrideContentScopesDialogGridToolbar,
-                                                }}
-                                                initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
-                                                showToolbar
-                                            />
-                                        );
-                                    }}
-                                </Field>
-                            )}
-                        </DialogContent>
-                        <DialogActions>
-                            <CancelButton onClick={() => handleDialogClose()}>
-                                <FormattedMessage id="dextinity.userPermissions.close" defaultMessage="Close" />
-                            </CancelButton>
-                            {!disabled && <SaveButton type="submit" />}
-                        </DialogActions>
+                            }}
+                        />
                     </>
                 )}
-            />
+            </DialogContent>
+            <DialogActions>
+                <CancelButton onClick={() => handleDialogClose()}>
+                    <FormattedMessage id="dextinity.userPermissions.close" defaultMessage="Close" />
+                </CancelButton>
+            </DialogActions>
         </Dialog>
     );
 };

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/PermissionGrid.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/PermissionGrid.tsx
@@ -1,5 +1,5 @@
-import { gql, useQuery } from "@apollo/client";
-import { Button, DataGridToolbar, FieldSet, FillSpace, GridCellContent, type GridColDef, TableDeleteButton } from "@dextinity/admin";
+import { gql, useMutation, useQuery } from "@apollo/client";
+import { Button, DataGridToolbar, DeleteDialog, FieldSet, FillSpace, GridCellContent, type GridColDef } from "@dextinity/admin";
 import { Add, Delete, Edit, StateFilled } from "@dextinity/admin-icons";
 import { IconButton, Typography } from "@mui/material";
 import type { GridToolbarProps } from "@mui/x-data-grid";
@@ -12,6 +12,8 @@ import { camelCaseToHumanReadable } from "../../utils/camelCaseToHumanReadable";
 import { OverrideContentScopesDialog } from "./OverrideContentScopesDialog";
 import { PermissionDialog } from "./PermissionDialog";
 import {
+    type GQLDeletePermissionMutation,
+    type GQLDeletePermissionMutationVariables,
     type GQLPermissionForGridFragment,
     type GQLPermissionsQuery,
     type GQLPermissionsQueryVariables,
@@ -35,6 +37,13 @@ export const PermissionGrid = ({ userId }: { userId: string }) => {
     const intl = useIntl();
     const [permissionId, setPermissionId] = useState<string | "add" | null>(null);
     const [overrideContentScopesId, setOverrideContentScopesId] = useState<string | null>(null);
+    const [permissionToDelete, setPermissionToDelete] = useState<string | null>(null);
+
+    const [deletePermission] = useMutation<GQLDeletePermissionMutation, GQLDeletePermissionMutationVariables>(gql`
+        mutation DeletePermission($id: ID!) {
+            userPermissionsDeletePermission(id: $id)
+        }
+    `);
 
     const { data, loading, error } = useQuery<GQLPermissionsQuery, GQLPermissionsQueryVariables>(
         gql`
@@ -101,12 +110,6 @@ export const PermissionGrid = ({ userId }: { userId: string }) => {
             ),
         },
         {
-            field: "source",
-            width: 200,
-            pinnable: false,
-            headerName: intl.formatMessage({ id: "dextinity.userPermissions.source", defaultMessage: "Assignment type" }),
-        },
-        {
             field: "validityPeriod",
             width: 200,
             pinnable: false,
@@ -131,6 +134,18 @@ export const PermissionGrid = ({ userId }: { userId: string }) => {
                 ),
         },
         {
+            field: "source",
+            width: 200,
+            pinnable: false,
+            headerName: intl.formatMessage({ id: "dextinity.userPermissions.source", defaultMessage: "Assignment type" }),
+            renderCell: ({ row }) =>
+                row.source === "BY_RULE" ? (
+                    <FormattedMessage id="dextinity.userPermissions.assignmentType.byRule" defaultMessage="By rule" />
+                ) : (
+                    <FormattedMessage id="dextinity.userPermissions.assignmentType.manual" defaultMessage="Manual" />
+                ),
+        },
+        {
             field: "actions",
             type: "actions",
             headerName: "",
@@ -152,17 +167,9 @@ export const PermissionGrid = ({ userId }: { userId: string }) => {
                         </IconButton>
 
                         {row.source !== "BY_RULE" && (
-                            <TableDeleteButton
-                                icon={<Delete />}
-                                mutation={gql`
-                                    mutation DeletePermission($id: ID!) {
-                                        userPermissionsDeletePermission(id: $id)
-                                    }
-                                `}
-                                selectedId={`${row.id}`}
-                                text=""
-                                refetchQueries={[namedOperations.Query.Permissions]}
-                            />
+                            <IconButton onClick={() => setPermissionToDelete(row.id)}>
+                                <Delete />
+                            </IconButton>
                         )}
                     </>
                 );
@@ -213,6 +220,21 @@ export const PermissionGrid = ({ userId }: { userId: string }) => {
                 />
             )}
             {permissionId && <PermissionDialog userId={userId} permissionId={permissionId} handleDialogClose={() => setPermissionId(null)} />}
+            <DeleteDialog
+                dialogOpen={permissionToDelete !== null}
+                deleteType="remove"
+                onCancel={() => setPermissionToDelete(null)}
+                onDelete={async () => {
+                    if (permissionToDelete !== null) {
+                        await deletePermission({
+                            variables: { id: permissionToDelete },
+                            refetchQueries: [namedOperations.Query.Permissions],
+                            awaitRefetchQueries: true,
+                        });
+                    }
+                    setPermissionToDelete(null);
+                }}
+            />
         </FieldSet>
     );
 };

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/contentScope.ts
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/contentScope.ts
@@ -1,0 +1,9 @@
+export type ContentScope = {
+    [key: string]: string;
+};
+
+/**
+ * Wildcard value a content scope dimension can have when `getContentScopesForUser` grants access to any value for it.
+ * Must match the wildcard value used by `getContentScopesForUser` in `@dextinity/cms-api`.
+ */
+export const contentScopeAllValues = "*";

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/selectScopesDialogContent/SelectScopesDialogContent.tsx
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/selectScopesDialogContent/SelectScopesDialogContent.tsx
@@ -1,47 +1,33 @@
-import { gql, useApolloClient, useQuery } from "@apollo/client";
-import { DataGridToolbar, Field, FillSpace, FinalForm, type GridColDef, GridToolbarQuickFilter, Loading, useFormApiRef } from "@dextinity/admin";
-import isEqual from "lodash.isequal";
-import type { FunctionComponent, PropsWithChildren } from "react";
+import { gql, useQuery } from "@apollo/client";
+import { Field, FinalForm, FinalFormInput, FinalFormSelect, Loading } from "@dextinity/admin";
+import type { FormApi } from "final-form";
+import { type FunctionComponent, useMemo } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 
-import { DataGrid } from "../../../../dataGrid/DataGrid";
-import { generateGridColumnsFromContentScopeProperties } from "../ContentScopeGrid";
-import type { GQLContentScopesQuery } from "../ContentScopeGrid.generated";
-import type {
-    GQLAvailableContentScopesQuery,
-    GQLUpdateContentScopesMutation,
-    GQLUpdateContentScopesMutationVariables,
-} from "./SelectScopesDialogContent.generated";
+import type { ContentScope } from "../ContentScopeDataGrid";
+import {
+    enumerableScopeCombinationExists,
+    getDimensionOptions,
+    getEnumerableDimensionNames,
+    getEnumerableSelectionAfterChange,
+    getRequiredEnumerableDimensions,
+} from "./contentScopeSelection";
+import type { GQLAvailableContentScopesQuery } from "./SelectScopesDialogContent.generated";
 
 interface SelectScopesDialogContentProps {
-    userId: string;
-    userContentScopes: GQLContentScopesQuery["userContentScopes"];
-    userContentScopesSkipManual: GQLContentScopesQuery["userContentScopesSkipManual"];
+    /** Called with the built scope when the form is submitted. The caller is responsible for persisting it. */
+    onSubmit: (scope: ContentScope) => Promise<void> | void;
 }
 
 type FormValues = {
-    contentScopes: string[];
+    scope: ContentScope;
 };
 
-type ContentScope = {
-    [key: string]: string;
-};
+export const SelectScopesDialogContent: FunctionComponent<SelectScopesDialogContentProps> = ({ onSubmit }) => {
+    const intl = useIntl();
 
-function SelectScopesDialogContentGridToolbar() {
-    return (
-        <DataGridToolbar>
-            <GridToolbarQuickFilter />
-            <FillSpace />
-        </DataGridToolbar>
-    );
-}
-
-export const SelectScopesDialogContent: FunctionComponent<PropsWithChildren<SelectScopesDialogContentProps>> = ({
-    userId,
-    userContentScopes,
-    userContentScopesSkipManual,
-}) => {
-    const client = useApolloClient();
-    const formApiRef = useFormApiRef<FormValues>();
+    // Memoized so that re-renders don't reinitialize the form and discard the selection.
+    const initialValues = useMemo<FormValues>(() => ({ scope: {} }), []);
 
     const { data, error } = useQuery<GQLAvailableContentScopesQuery>(gql`
         query AvailableContentScopes {
@@ -49,24 +35,20 @@ export const SelectScopesDialogContent: FunctionComponent<PropsWithChildren<Sele
                 scope
                 label
             }
+            availableContentScopeDimensions: userPermissionsAvailableContentScopeDimensions {
+                name
+                label
+            }
         }
     `);
 
     const submit = async (values: FormValues) => {
-        await client.mutate<GQLUpdateContentScopesMutation, GQLUpdateContentScopesMutationVariables>({
-            mutation: gql`
-                mutation UpdateContentScopes($userId: String!, $input: UserContentScopesInput!) {
-                    userPermissionsUpdateContentScopes(userId: $userId, input: $input)
-                }
-            `,
-            variables: {
-                userId,
-                input: {
-                    contentScopes: values.contentScopes.map((contentScope) => JSON.parse(contentScope)),
-                },
-            },
-            refetchQueries: ["ContentScopes"],
-        });
+        const scope: ContentScope = Object.fromEntries(
+            Object.entries(values.scope)
+                .filter(([, value]) => value != null && String(value).trim() !== "")
+                .map(([dimension, value]) => [dimension, String(value).trim()]),
+        );
+        await onSubmit(scope);
     };
 
     if (error) {
@@ -77,50 +59,123 @@ export const SelectScopesDialogContent: FunctionComponent<PropsWithChildren<Sele
         return <Loading />;
     }
 
-    const columns: GridColDef<ContentScope>[] = generateGridColumnsFromContentScopeProperties(data.availableContentScopes);
+    // A dimension is enumerable when it appears in the available content scopes; its values then come from there. The remaining
+    // declared dimensions (e.g. one with too many values to enumerate) are entered as free text.
+    const enumerableDimensionNames = getEnumerableDimensionNames(data.availableContentScopes);
+    const isEnumerableDimension = (dimension: string) => enumerableDimensionNames.includes(dimension);
+    const requiredEnumerableDimensions = getRequiredEnumerableDimensions(data.availableContentScopes);
+
+    const allValuesLabel = intl.formatMessage({ id: "dextinity.userPermissions.allContentScopeValues", defaultMessage: "All" });
+
+    // Changing a dimension keeps the other enumerable selections only while they still form a valid combination; the free-text
+    // selections are preserved.
+    const changeEnumerableValue = (form: FormApi<FormValues>, scope: ContentScope, dimension: string, value: string) => {
+        const enumerableSelection = getEnumerableSelectionAfterChange({
+            availableContentScopes: data.availableContentScopes,
+            scope,
+            dimension,
+            value,
+        });
+        const freeSelection = Object.fromEntries(
+            data.availableContentScopeDimensions
+                .filter((declaredDimension) => !isEnumerableDimension(declaredDimension.name) && scope[declaredDimension.name])
+                .map((declaredDimension) => [declaredDimension.name, scope[declaredDimension.name]]),
+        );
+        form.change("scope", { ...freeSelection, ...enumerableSelection });
+    };
+
+    const validate = ({ scope = {} }: FormValues) => {
+        const scopeErrors: Record<string, string> = {};
+        for (const dimension of requiredEnumerableDimensions) {
+            if (!scope[dimension]) {
+                scopeErrors[dimension] = intl.formatMessage({ id: "dextinity.userPermissions.selectValue", defaultMessage: "Select a value." });
+            }
+        }
+        // Free-text dimensions must not be left empty: an empty value would drop the dimension from the scope, which grants
+        // access only to scopes without that dimension rather than to all values. Require an explicit value (`*` for all).
+        for (const dimension of data.availableContentScopeDimensions) {
+            if (!isEnumerableDimension(dimension.name) && String(scope[dimension.name] ?? "").trim() === "") {
+                scopeErrors[dimension.name] = intl.formatMessage({
+                    id: "dextinity.userPermissions.enterValue",
+                    defaultMessage: "Enter a value (* for all).",
+                });
+            }
+        }
+        // Only a combination of enumerable values that exists in the available content scopes can be assigned. Skip this
+        // when there are no enumerable dimensions (all dimensions are free text), as there is no combination to match.
+        if (Object.keys(scopeErrors).length === 0 && enumerableDimensionNames.length > 0) {
+            if (!enumerableScopeCombinationExists({ scope, availableContentScopes: data.availableContentScopes })) {
+                const message = intl.formatMessage({
+                    id: "dextinity.userPermissions.contentScopeDoesNotExist",
+                    defaultMessage: "This combination of scopes does not exist.",
+                });
+                for (const dimension of enumerableDimensionNames) {
+                    scopeErrors[dimension] = message;
+                }
+            }
+        }
+        return Object.keys(scopeErrors).length > 0 ? { scope: scopeErrors } : {};
+    };
 
     return (
         <FinalForm<FormValues>
-            apiRef={formApiRef}
             subscription={{ values: true }}
             mode="edit"
             onSubmit={submit}
             onAfterSubmit={() => null}
-            initialValues={{
-                contentScopes: userContentScopes.map((cs) => JSON.stringify(cs)),
-            }}
+            initialValues={initialValues}
+            validate={validate}
         >
-            <Field<string[]> name="contentScopes" fullWidth>
-                {(props) => {
-                    return (
-                        <DataGrid
-                            autoHeight={true}
-                            rows={data.availableContentScopes
-                                .filter((obj) => !Object.values(obj).every((value) => value === undefined))
-                                .map((obj) => obj.scope)}
-                            columns={columns}
-                            rowCount={data.availableContentScopes.length}
-                            loading={false}
-                            getRowHeight={() => "auto"}
-                            getRowId={(row) => JSON.stringify(row)}
-                            isRowSelectable={(params) => {
-                                return !userContentScopesSkipManual.some((cs: ContentScope) => isEqual(cs, params.row));
-                            }}
-                            checkboxSelection
-                            rowSelectionModel={{ type: "include", ids: new Set(props.input.value) }}
-                            onRowSelectionModelChange={(selectionModel) => {
-                                props.input.onChange(Array.from(selectionModel.ids).map((id) => String(id)));
-                            }}
-                            disableRowSelectionExcludeModel
-                            slots={{
-                                toolbar: SelectScopesDialogContentGridToolbar,
-                            }}
-                            initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
-                            showToolbar
-                        />
-                    );
-                }}
-            </Field>
+            {({ values, form }: { values: FormValues; form: FormApi<FormValues> }) => {
+                const scope = values.scope ?? {};
+                return (
+                    <>
+                        {data.availableContentScopeDimensions.map((dimension) => {
+                            if (isEnumerableDimension(dimension.name)) {
+                                const options = getDimensionOptions({
+                                    dimension: dimension.name,
+                                    scope,
+                                    availableContentScopes: data.availableContentScopes,
+                                    allValuesLabel,
+                                });
+                                return (
+                                    <Field<string>
+                                        key={dimension.name}
+                                        name={`scope.${dimension.name}`}
+                                        label={dimension.label}
+                                        fullWidth
+                                        required={requiredEnumerableDimensions.includes(dimension.name)}
+                                    >
+                                        {({ input, meta }) => (
+                                            <FinalFormSelect
+                                                input={{
+                                                    ...input,
+                                                    onChange: (value: string) => changeEnumerableValue(form, scope, dimension.name, value),
+                                                }}
+                                                meta={meta}
+                                                fullWidth
+                                                options={options.map((option) => option.value)}
+                                                getOptionLabel={(value: string) => options.find((option) => option.value === value)?.label ?? value}
+                                            />
+                                        )}
+                                    </Field>
+                                );
+                            }
+                            return (
+                                <Field
+                                    key={dimension.name}
+                                    name={`scope.${dimension.name}`}
+                                    label={dimension.label}
+                                    helperText={<FormattedMessage id="dextinity.userPermissions.allValuesHint" defaultMessage="* for All" />}
+                                    fullWidth
+                                    required
+                                    component={FinalFormInput}
+                                />
+                            );
+                        })}
+                    </>
+                );
+            }}
         </FinalForm>
     );
 };

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/selectScopesDialogContent/contentScopeSelection.test.ts
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/selectScopesDialogContent/contentScopeSelection.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    type AvailableContentScope,
+    availableContentScopeMatchesSelection,
+    enumerableScopeCombinationExists,
+    getDimensionOptions,
+    getEnumerableDimensionNames,
+    getEnumerableSelectionAfterChange,
+    getRequiredEnumerableDimensions,
+} from "./contentScopeSelection";
+
+const ALL = "*";
+
+// Every scope has both dimensions (main: en/de, secondary: en only).
+const domainLanguageScopes: AvailableContentScope[] = [
+    { scope: { domain: "main", language: "en" }, label: { domain: "Main", language: "English" } },
+    { scope: { domain: "main", language: "de" }, label: { domain: "Main", language: "German" } },
+    { scope: { domain: "secondary", language: "en" }, label: { domain: "Secondary", language: "English" } },
+];
+
+// Heterogeneous: "shop" has no language dimension.
+const heterogeneousScopes: AvailableContentScope[] = [{ scope: { domain: "main", language: "en" } }, { scope: { domain: "shop" } }];
+
+// Raw JSON values (numbers) as returned by the API.
+const numericScopes: AvailableContentScope[] = [
+    { scope: { tenant: 1 }, label: { tenant: "Tenant One" } },
+    { scope: { tenant: 2 }, label: { tenant: "Tenant Two" } },
+];
+
+describe("getEnumerableDimensionNames", () => {
+    it("returns the union of dimension keys", () => {
+        expect(getEnumerableDimensionNames(domainLanguageScopes)).toEqual(["domain", "language"]);
+        expect(getEnumerableDimensionNames(heterogeneousScopes)).toEqual(["domain", "language"]);
+    });
+});
+
+describe("getRequiredEnumerableDimensions", () => {
+    it("requires only dimensions present in every available scope", () => {
+        expect(getRequiredEnumerableDimensions(domainLanguageScopes)).toEqual(["domain", "language"]);
+        // language is missing from the "shop" scope, so it must stay optional.
+        expect(getRequiredEnumerableDimensions(heterogeneousScopes)).toEqual(["domain"]);
+    });
+});
+
+describe("availableContentScopeMatchesSelection", () => {
+    it("matches on a partial selection", () => {
+        expect(availableContentScopeMatchesSelection({ domain: "main", language: "en" }, { domain: "main" })).toBe(true);
+        expect(availableContentScopeMatchesSelection({ domain: "main", language: "en" }, { domain: "secondary" })).toBe(false);
+    });
+
+    it("compares raw JSON values as strings", () => {
+        expect(availableContentScopeMatchesSelection({ tenant: 1 }, { tenant: "1" })).toBe(true);
+        expect(availableContentScopeMatchesSelection({ tenant: 2 }, { tenant: "1" })).toBe(false);
+    });
+
+    it("treats a wildcard as matching any present value, but not an absent dimension", () => {
+        expect(availableContentScopeMatchesSelection({ domain: "main", language: "en" }, { domain: ALL })).toBe(true);
+        expect(availableContentScopeMatchesSelection({ domain: "shop" }, { language: ALL })).toBe(false);
+    });
+
+    it("matches on an empty selection", () => {
+        expect(availableContentScopeMatchesSelection({ domain: "main" }, {})).toBe(true);
+    });
+});
+
+describe("getDimensionOptions", () => {
+    it("lists the dimension's values with an 'All' option first", () => {
+        expect(getDimensionOptions({ dimension: "domain", scope: {}, availableContentScopes: domainLanguageScopes, allValuesLabel: "All" })).toEqual([
+            { value: ALL, label: "All" },
+            { value: "main", label: "Main" },
+            { value: "secondary", label: "Secondary" },
+        ]);
+    });
+
+    it("cascades: only values valid for the other selection are offered", () => {
+        expect(
+            getDimensionOptions({
+                dimension: "language",
+                scope: { domain: "secondary" },
+                availableContentScopes: domainLanguageScopes,
+                allValuesLabel: "All",
+            }),
+        ).toEqual([
+            { value: ALL, label: "All" },
+            { value: "en", label: "English" },
+        ]);
+    });
+
+    it("does not let a wildcard sibling over-constrain the options", () => {
+        expect(
+            getDimensionOptions({
+                dimension: "language",
+                scope: { domain: ALL },
+                availableContentScopes: domainLanguageScopes,
+                allValuesLabel: "All",
+            }),
+        ).toEqual([
+            { value: ALL, label: "All" },
+            { value: "en", label: "English" },
+            { value: "de", label: "German" },
+        ]);
+    });
+
+    it("offers no options (and no 'All') when the selection has no valid combination", () => {
+        expect(
+            getDimensionOptions({
+                dimension: "language",
+                scope: { domain: "does-not-exist" },
+                availableContentScopes: domainLanguageScopes,
+                allValuesLabel: "All",
+            }),
+        ).toEqual([]);
+    });
+
+    it("stringifies raw JSON values and falls back to the value when no label exists", () => {
+        expect(getDimensionOptions({ dimension: "tenant", scope: {}, availableContentScopes: numericScopes, allValuesLabel: "All" })).toEqual([
+            { value: ALL, label: "All" },
+            { value: "1", label: "Tenant One" },
+            { value: "2", label: "Tenant Two" },
+        ]);
+    });
+});
+
+describe("getEnumerableSelectionAfterChange", () => {
+    it("keeps a sibling selection when the new combination still exists", () => {
+        expect(
+            getEnumerableSelectionAfterChange({
+                availableContentScopes: domainLanguageScopes,
+                scope: { domain: "main", language: "en" },
+                dimension: "domain",
+                value: "secondary",
+            }),
+        ).toEqual({ domain: "secondary", language: "en" });
+    });
+
+    it("drops a sibling selection when the new combination no longer exists", () => {
+        // secondary has no German scope, so language is cleared.
+        expect(
+            getEnumerableSelectionAfterChange({
+                availableContentScopes: domainLanguageScopes,
+                scope: { domain: "main", language: "de" },
+                dimension: "domain",
+                value: "secondary",
+            }),
+        ).toEqual({ domain: "secondary" });
+    });
+
+    it("keeps a sibling selection when switching a dimension to the wildcard", () => {
+        expect(
+            getEnumerableSelectionAfterChange({
+                availableContentScopes: domainLanguageScopes,
+                scope: { domain: "main", language: "en" },
+                dimension: "domain",
+                value: ALL,
+            }),
+        ).toEqual({ domain: ALL, language: "en" });
+    });
+});
+
+describe("enumerableScopeCombinationExists", () => {
+    it("accepts an existing concrete combination and rejects a non-existing one", () => {
+        expect(enumerableScopeCombinationExists({ scope: { domain: "main", language: "en" }, availableContentScopes: domainLanguageScopes })).toBe(
+            true,
+        );
+        expect(
+            enumerableScopeCombinationExists({ scope: { domain: "secondary", language: "de" }, availableContentScopes: domainLanguageScopes }),
+        ).toBe(false);
+    });
+
+    it("accepts a wildcard when at least one matching value exists", () => {
+        expect(enumerableScopeCombinationExists({ scope: { domain: ALL, language: "en" }, availableContentScopes: domainLanguageScopes })).toBe(true);
+        expect(enumerableScopeCombinationExists({ scope: { domain: ALL, language: "de" }, availableContentScopes: domainLanguageScopes })).toBe(true);
+    });
+
+    it("normalizes raw JSON values", () => {
+        expect(enumerableScopeCombinationExists({ scope: { tenant: "1" }, availableContentScopes: numericScopes })).toBe(true);
+        expect(enumerableScopeCombinationExists({ scope: { tenant: "3" }, availableContentScopes: numericScopes })).toBe(false);
+    });
+
+    it("treats an omitted optional dimension as selecting the scopes that also lack it", () => {
+        expect(enumerableScopeCombinationExists({ scope: { domain: "shop" }, availableContentScopes: heterogeneousScopes })).toBe(true);
+        // "shop" has no language, so a concrete or wildcard language cannot match it.
+        expect(enumerableScopeCombinationExists({ scope: { domain: "shop", language: "en" }, availableContentScopes: heterogeneousScopes })).toBe(
+            false,
+        );
+        expect(enumerableScopeCombinationExists({ scope: { domain: "shop", language: ALL }, availableContentScopes: heterogeneousScopes })).toBe(
+            false,
+        );
+    });
+});

--- a/packages/admin/cms-admin/src/userPermissions/user/permissions/selectScopesDialogContent/contentScopeSelection.ts
+++ b/packages/admin/cms-admin/src/userPermissions/user/permissions/selectScopesDialogContent/contentScopeSelection.ts
@@ -1,0 +1,113 @@
+import { contentScopeAllValues, type ContentScope } from "../contentScope";
+
+export interface AvailableContentScope {
+    // Values are raw JSON (e.g. numbers or booleans), unlike a selection whose values are always strings.
+    scope: Record<string, unknown>;
+    label?: Record<string, string> | null;
+}
+
+export interface ContentScopeOption {
+    value: string;
+    label: string;
+}
+
+// A dimension is enumerable when it appears in the available content scopes; its values then come from there.
+export function getEnumerableDimensionNames(availableContentScopes: AvailableContentScope[]): string[] {
+    return Array.from(new Set(availableContentScopes.flatMap((availableContentScope) => Object.keys(availableContentScope.scope))));
+}
+
+// Only dimensions present in every available content scope are mandatory. When the available content scopes are heterogeneous
+// (a dimension exists in some but not others), leaving that dimension empty selects the scopes without it, so it stays optional.
+export function getRequiredEnumerableDimensions(availableContentScopes: AvailableContentScope[]): string[] {
+    return getEnumerableDimensionNames(availableContentScopes).filter((dimension) =>
+        availableContentScopes.every((availableContentScope) => availableContentScope.scope[dimension] != null),
+    );
+}
+
+// Available scope values are raw JSON (e.g. numbers), while selections are strings, so compare per dimension as strings.
+// A wildcard selection (`*`) matches any value the dimension has in the available content scope.
+export function availableContentScopeMatchesSelection(availableContentScope: Record<string, unknown>, selection: ContentScope): boolean {
+    return Object.entries(selection).every(([dimension, value]) =>
+        value === contentScopeAllValues ? availableContentScope[dimension] != null : String(availableContentScope[dimension]) === String(value),
+    );
+}
+
+// The selectable values of a dimension depend on the values already selected for the other enumerable dimensions, so that only
+// combinations that exist in the available content scopes can be built. A wildcard ("All") option is offered whenever the
+// dimension has selectable values for the current selection, so a scope can grant every value of the dimension.
+export function getDimensionOptions({
+    dimension,
+    scope,
+    availableContentScopes,
+    allValuesLabel,
+}: {
+    dimension: string;
+    scope: ContentScope;
+    availableContentScopes: AvailableContentScope[];
+    allValuesLabel: string;
+}): ContentScopeOption[] {
+    const otherSelection: ContentScope = Object.fromEntries(
+        getEnumerableDimensionNames(availableContentScopes)
+            .filter((otherDimension) => otherDimension !== dimension && scope[otherDimension])
+            .map((otherDimension) => [otherDimension, scope[otherDimension]]),
+    );
+    const options: ContentScopeOption[] = [];
+    for (const availableContentScope of availableContentScopes) {
+        if (!availableContentScopeMatchesSelection(availableContentScope.scope, otherSelection)) {
+            continue;
+        }
+        const value = availableContentScope.scope[dimension];
+        if (value != null && !options.some((option) => option.value === String(value))) {
+            options.push({ value: String(value), label: availableContentScope.label?.[dimension] ?? String(value) });
+        }
+    }
+    if (options.length > 0) {
+        options.unshift({ value: contentScopeAllValues, label: allValuesLabel });
+    }
+    return options;
+}
+
+// Changing a dimension keeps the other enumerable selections only while they still form a valid combination with the newly
+// chosen value; the rest is dropped.
+export function getEnumerableSelectionAfterChange({
+    availableContentScopes,
+    scope,
+    dimension,
+    value,
+}: {
+    availableContentScopes: AvailableContentScope[];
+    scope: ContentScope;
+    dimension: string;
+    value: string;
+}): ContentScope {
+    const enumerableSelection: ContentScope = { [dimension]: value };
+    for (const otherDimension of getEnumerableDimensionNames(availableContentScopes)) {
+        if (otherDimension === dimension || !scope[otherDimension]) {
+            continue;
+        }
+        const candidate = { ...enumerableSelection, [otherDimension]: scope[otherDimension] };
+        if (availableContentScopes.some((availableContentScope) => availableContentScopeMatchesSelection(availableContentScope.scope, candidate))) {
+            enumerableSelection[otherDimension] = scope[otherDimension];
+        }
+    }
+    return enumerableSelection;
+}
+
+// Whether the selected combination of enumerable values exists in the available content scopes. A wildcard (`*`) matches any
+// value of its dimension; an omitted dimension matches only the scopes that also lack it.
+export function enumerableScopeCombinationExists({
+    scope,
+    availableContentScopes,
+}: {
+    scope: ContentScope;
+    availableContentScopes: AvailableContentScope[];
+}): boolean {
+    const enumerableDimensionNames = getEnumerableDimensionNames(availableContentScopes);
+    return availableContentScopes.some((availableContentScope) =>
+        enumerableDimensionNames.every((dimension) =>
+            scope[dimension] === contentScopeAllValues
+                ? availableContentScope.scope[dimension] != null
+                : String(availableContentScope.scope[dimension]) === String(scope[dimension]),
+        ),
+    );
+}

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -48,6 +48,11 @@ type ContentScopeWithLabel {
   label: JSONObject!
 }
 
+type ContentScopeDimension {
+  name: String!
+  label: String!
+}
+
 type UserPermissionsUser {
   id: String!
   name: String!
@@ -567,6 +572,7 @@ type Query {
   userPermissionsAvailablePermissions: [String!]!
   userPermissionsContentScopes(userId: String!, skipManual: Boolean): [JSONObject!]!
   userPermissionsAvailableContentScopes: [ContentScopeWithLabel!]!
+  userPermissionsAvailableContentScopeDimensions: [ContentScopeDimension!]!
   fileUploadForTypesGenerationDoNotUse: FileUpload!
   azureAiTranslate(input: AzureAiTranslationInput!): String!
   azureAiTranslateBatch(input: AzureAiTranslationBatchInput!): [String!]!

--- a/packages/api/cms-api/schema.gql
+++ b/packages/api/cms-api/schema.gql
@@ -571,6 +571,7 @@ type Query {
   userPermissionsPermission(id: ID!, userId: String): UserPermission!
   userPermissionsAvailablePermissions: [String!]!
   userPermissionsContentScopes(userId: String!, skipManual: Boolean): [JSONObject!]!
+  userPermissionsManualContentScopes(userId: String!): [JSONObject!]!
   userPermissionsAvailableContentScopes: [ContentScopeWithLabel!]!
   userPermissionsAvailableContentScopeDimensions: [ContentScopeDimension!]!
   fileUploadForTypesGenerationDoNotUse: FileUpload!

--- a/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.spec.ts
@@ -1,0 +1,51 @@
+import { createMock } from "@golevelup/ts-vitest";
+import type { EntityManager, EntityRepository } from "@mikro-orm/postgresql";
+import { describe, expect, it } from "vitest";
+
+import type { UserContentScopes } from "./entities/user-content-scopes.entity";
+import type { ContentScope } from "./interfaces/content-scope.interface";
+import type { User } from "./interfaces/user";
+import { UserContentScopesResolver } from "./user-content-scopes.resolver";
+import type { UserPermissionsService } from "./user-permissions.service";
+
+describe("UserContentScopesResolver", () => {
+    describe("userPermissionsContentScopes", () => {
+        it("returns the content scopes of the user", async () => {
+            const contentScopes: ContentScope[] = [
+                { domain: "main", language: "en" },
+                { domain: "main", language: "*", product: "*" },
+            ];
+            const userService = createMock<UserPermissionsService>({
+                findUserOrThrow: async () => ({ id: "1", name: "User", email: "user@example.com" }) satisfies User,
+                filterContentScopesForUser: async () => contentScopes,
+            });
+            const resolver = new UserContentScopesResolver(
+                createMock<EntityRepository<UserContentScopes>>(),
+                userService,
+                createMock<EntityManager>(),
+            );
+
+            expect(await resolver.userPermissionsContentScopes("1")).toEqual(contentScopes);
+        });
+    });
+
+    describe("userPermissionsAvailableContentScopeDimensions", () => {
+        it("returns the dimensions from the service", async () => {
+            const dimensions = [
+                { name: "domain", label: "Domain" },
+                { name: "language", label: "Language" },
+                { name: "product", label: "Product" },
+            ];
+            const userService = createMock<UserPermissionsService>({
+                getAvailableContentScopeDimensions: async () => dimensions,
+            });
+            const resolver = new UserContentScopesResolver(
+                createMock<EntityRepository<UserContentScopes>>(),
+                userService,
+                createMock<EntityManager>(),
+            );
+
+            expect(await resolver.userPermissionsAvailableContentScopeDimensions()).toEqual(dimensions);
+        });
+    });
+});

--- a/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
@@ -5,7 +5,7 @@ import { GraphQLJSONObject } from "graphql-scalars";
 
 import { SkipBuild } from "../builds/skip-build.decorator";
 import { RequiredPermission } from "./decorators/required-permission.decorator";
-import { ContentScopeWithLabel } from "./dto/content-scope";
+import { ContentScopeDimension, ContentScopeWithLabel } from "./dto/content-scope";
 import { UserContentScopesInput } from "./dto/user-content-scopes.input";
 import { UserContentScopes } from "./entities/user-content-scopes.entity";
 import { ContentScope } from "./interfaces/content-scope.interface";
@@ -50,5 +50,10 @@ export class UserContentScopesResolver {
     @Query(() => [ContentScopeWithLabel])
     async userPermissionsAvailableContentScopes(): Promise<ContentScopeWithLabel[]> {
         return this.userService.getAvailableContentScopes();
+    }
+
+    @Query(() => [ContentScopeDimension])
+    async userPermissionsAvailableContentScopeDimensions(): Promise<ContentScopeDimension[]> {
+        return this.userService.getAvailableContentScopeDimensions();
     }
 }

--- a/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
+++ b/packages/api/cms-api/src/user-permissions/user-content-scopes.resolver.ts
@@ -47,6 +47,11 @@ export class UserContentScopesResolver {
         });
     }
 
+    @Query(() => [GraphQLJSONObject])
+    async userPermissionsManualContentScopes(@Args("userId", { type: () => String }) userId: string): Promise<ContentScope[]> {
+        return this.userService.getManualContentScopesForUser(await this.userService.findUserOrThrow(userId));
+    }
+
     @Query(() => [ContentScopeWithLabel])
     async userPermissionsAvailableContentScopes(): Promise<ContentScopeWithLabel[]> {
         return this.userService.getAvailableContentScopes();

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.spec.ts
@@ -33,7 +33,7 @@ function createService(
 
 describe("UserPermissionsService", () => {
     describe("getAvailableContentScopeDimensions", () => {
-        it("returns the configured dimensions and falls back to the name for missing labels", async () => {
+        it("returns the configured dimensions and humanizes missing labels", async () => {
             const service = createService({
                 availableContentScopeDimensions: [{ name: "domain", label: "Domain" }, { name: "language" }, { name: "product" }],
             });
@@ -42,8 +42,8 @@ describe("UserPermissionsService", () => {
 
             expect(dimensions).toEqual([
                 { name: "domain", label: "Domain" },
-                { name: "language", label: "language" },
-                { name: "product", label: "product" },
+                { name: "language", label: "Language" },
+                { name: "product", label: "Product" },
             ]);
         });
 
@@ -54,7 +54,7 @@ describe("UserPermissionsService", () => {
 
             const dimensions = await service.getAvailableContentScopeDimensions();
 
-            expect(dimensions).toEqual([{ name: "domain", label: "domain" }]);
+            expect(dimensions).toEqual([{ name: "domain", label: "Domain" }]);
         });
 
         it("derives the dimensions from the available content scopes when not configured", async () => {
@@ -68,8 +68,8 @@ describe("UserPermissionsService", () => {
             const dimensions = await service.getAvailableContentScopeDimensions();
 
             expect(dimensions).toEqual([
-                { name: "domain", label: "domain" },
-                { name: "language", label: "language" },
+                { name: "domain", label: "Domain" },
+                { name: "language", label: "Language" },
             ]);
         });
 

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.spec.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.spec.ts
@@ -115,4 +115,31 @@ describe("UserPermissionsService", () => {
             ]);
         });
     });
+
+    describe("getManualContentScopesForUser", () => {
+        it("returns the persisted manual content scopes", async () => {
+            const service = createService({}, { manualContentScopes: [{ domain: "main", language: "en" }] });
+
+            expect(await service.getManualContentScopesForUser(user)).toEqual([{ domain: "main", language: "en" }]);
+        });
+
+        it("returns a manual content scope even when the same scope is also granted by a rule", async () => {
+            const service = createService(
+                {},
+                {
+                    getContentScopesForUser: () => [{ domain: "main", language: "en" }],
+                    manualContentScopes: [{ domain: "main", language: "en" }],
+                },
+            );
+
+            // The scope is both rule-based and manually assigned; it must still be reported as manual so it stays removable.
+            expect(await service.getManualContentScopesForUser(user)).toEqual([{ domain: "main", language: "en" }]);
+        });
+
+        it("returns an empty array when the user has no manual content scopes", async () => {
+            const service = createService({});
+
+            expect(await service.getManualContentScopesForUser(user)).toEqual([]);
+        });
+    });
 });

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -25,6 +25,11 @@ import {
     UserPermissionsUserServiceInterface,
 } from "./user-permissions.types";
 
+function camelCaseToHumanReadable(s: string | number) {
+    const words = s.toString().match(/[A-Za-z0-9][a-z0-9]*/g) || [];
+    return words.map((word) => word.charAt(0).toUpperCase() + word.substring(1)).join(" ");
+}
+
 @Injectable()
 export class UserPermissionsService {
     constructor(
@@ -47,11 +52,6 @@ export class UserPermissionsService {
             } else {
                 contentScopes = this.options.availableContentScopes;
             }
-        }
-
-        function camelCaseToHumanReadable(s: string | number) {
-            const words = s.toString().match(/[A-Za-z0-9][a-z0-9]*/g) || [];
-            return words.map((word) => word.charAt(0).toUpperCase() + word.substring(1)).join(" ");
         }
 
         const contentScopesWithLabel = contentScopes
@@ -84,13 +84,13 @@ export class UserPermissionsService {
                     : this.options.availableContentScopeDimensions;
             return dimensions.map((dimension) => ({
                 name: dimension.name,
-                label: dimension.label ?? dimension.name,
+                label: dimension.label ?? camelCaseToHumanReadable(dimension.name),
             }));
         }
 
         // Derive the dimensions from the keys of the available content scopes when not explicitly configured
         const dimensionNames = new Set((await this.getAvailableContentScopes()).flatMap((contentScope) => Object.keys(contentScope.scope)));
-        return [...dimensionNames].map((name) => ({ name, label: name }));
+        return [...dimensionNames].map((name) => ({ name, label: camelCaseToHumanReadable(name) }));
     }
 
     async getAvailablePermissions(): Promise<Permission[]> {

--- a/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
+++ b/packages/api/cms-api/src/user-permissions/user-permissions.service.ts
@@ -235,13 +235,17 @@ export class UserPermissionsService {
         }
 
         if (includeContentScopesManual) {
-            const entity = await this.contentScopeRepository.findOne({ userId: user.id });
-            if (entity) {
-                contentScopes.push(...entity.contentScopes);
-            }
+            contentScopes.push(...(await this.getManualContentScopesForUser(user)));
         }
 
         return contentScopes;
+    }
+
+    // The manually assigned content scopes as persisted, independent of the rule-based ones. Needed to distinguish a scope
+    // that is both manually assigned and granted by a rule (which cannot be derived from the union and the rule-based scopes).
+    async getManualContentScopesForUser(user: User): Promise<ContentScope[]> {
+        const entity = await this.contentScopeRepository.findOne({ userId: user.id });
+        return entity?.contentScopes ?? [];
     }
 
     async getImpersonatedUser(authenticatedUser: User, request: Request): Promise<User | undefined> {


### PR DESCRIPTION
Follow-up to #6116 (stacked on top of it).

## Problem

In the assigned-scopes grid, a content scope that is **both** manually assigned **and** granted by a rule could not be removed, and was silently dropped when any other scope was added or removed.

The admin derived the manual scopes by subtraction: `manualContentScopes = union(rule ∪ manual) \ rule`. That loses the intersection — a scope present in both sets. Since add/remove persist the derived manual list, the overlapping manual grant was omitted and lost; and because such a row was classified purely as "By rule", it had no delete affordance. If the matching rule was later removed, the explicit manual grant was already gone.

This was flagged independently by macroscope, CodeRabbit and greptile on #6116 and deferred to this follow-up because it needs an API change.

## Solution

Expose the persisted manual scopes directly instead of deriving them:

- **API** — new query `userPermissionsManualContentScopes(userId): [JSONObject!]!`, backed by `UserPermissionsService.getManualContentScopesForUser(user)`, which returns the persisted manual scopes (`UserContentScopes.contentScopes`) as-is.
- **Admin** — the assigned-scopes grid uses that field as the source of truth for the manual assignments (`isManualScope`), rather than `union \ rule`. A scope that is both manually assigned and rule-granted is now shown as "Manual", stays removable, and is preserved when editing other scopes.

The override dialog was already unaffected (it reads the permission's own persisted `contentScopes` directly, not by subtraction).

## Example

Persisted manual `[{domain: "main"}]`, rule-based `[{domain: "main"}, {domain: "news"}]`. Adding `{domain: "shop"}`:

- Before: the derived manual list was `[]` (main filtered out as rule-based), so the mutation persisted `[{domain: "shop"}]` — the manual `{domain: "main"}` grant was lost.
- After: the manual list is the persisted `[{domain: "main"}]`, so the mutation persists `[{domain: "main"}, {domain: "shop"}]`; `{domain: "main"}` shows as "Manual" and keeps its delete action.

Unit tests: `getManualContentScopesForUser` returns the persisted manual scopes, including one that is also granted by a rule (`packages/api/cms-api/src/user-permissions/user-permissions.service.spec.ts`).

## Changeset

`@dextinity/cms-api` minor, `@dextinity/cms-admin` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVwZJtKmfrQq2VZmPAB76j

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVwZJtKmfrQq2VZmPAB76j)_