### PR TITLE
site-react: Add rel="noopener" to DamFileDownloadLinkBlock links opening in a new tab

### DIFF
--- a/.changeset/dam-download-link-rel-noopener.md
+++ b/.changeset/dam-download-link-rel-noopener.md
@@ -1,0 +1,7 @@
+---
+"@dextinity/site-react": patch
+---
+
+Add `rel="noopener"` to `DamFileDownloadLinkBlock` links that open in a new tab
+
+Links with `target="_blank"` gave the opened page access to `window.opener`, allowing it to redirect the original tab (reverse tabnabbing). `rel="noopener"` is now set whenever the link opens in a new tab, whether via `openFileType: "NewTab"` or an explicitly passed `target="_blank"`.

--- a/packages/site/site-react/src/blocks/DamFileDownloadLinkBlock.tsx
+++ b/packages/site/site-react/src/blocks/DamFileDownloadLinkBlock.tsx
@@ -23,17 +23,19 @@ export const DamFileDownloadLinkBlock = withPreview(
 
         const href = file.fileUrl;
         const target = openFileType === "NewTab" ? "_blank" : anchorProps.target;
+        const rel = target === "_blank" ? [anchorProps.rel, "noopener"].filter(Boolean).join(" ") : anchorProps.rel;
 
         if (legacyBehavior) {
             return cloneElement(children as ReactElement<AnchorHTMLAttributes<HTMLAnchorElement>>, {
                 ...anchorProps,
                 href,
                 target,
+                rel,
             });
         }
 
         return (
-            <a {...anchorProps} href={href} target={target}>
+            <a {...anchorProps} href={href} target={target} rel={rel}>
                 {children}
             </a>
         );


### PR DESCRIPTION
## Summary

- `DamFileDownloadLinkBlock` sets `target="_blank"` when `openFileType` is `"NewTab"` (or when a caller passes `target="_blank"` directly), but never set `rel="noopener"` alongside it.
- A `target="_blank"` link without `rel="noopener"` gives the opened page access to `window.opener`, which lets it navigate the original tab to an arbitrary URL (reverse tabnabbing).
- `rel="noopener"` is now added whenever the resolved `target` is `"_blank"`, in both the `legacyBehavior` (`cloneElement`) and default (`<a>`) rendering paths. Any `rel` value already passed by the caller is preserved and `noopener` is appended to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)